### PR TITLE
feat(format): add TableControl default views for all typed outputs

### DIFF
--- a/PSWinOps.Format.ps1xml
+++ b/PSWinOps.Format.ps1xml
@@ -335,6 +335,35 @@
     <!-- Used by: Get-NTPConfiguration                                -->
     <!-- ============================================================ -->
     <View>
+      <Name>PSWinOps.NtpConfiguration.Table</Name>
+      <ViewSelectedBy>
+        <TypeName>PSWinOps.NtpConfiguration</TypeName>
+      </ViewSelectedBy>
+      <TableControl>
+        <TableHeaders>
+          <TableColumnHeader><Label>ComputerName</Label><Width>16</Width></TableColumnHeader>
+          <TableColumnHeader><Label>Service</Label><Width>10</Width></TableColumnHeader>
+          <TableColumnHeader><Label>SyncType</Label><Width>10</Width></TableColumnHeader>
+          <TableColumnHeader><Label>Source</Label><Width>24</Width></TableColumnHeader>
+          <TableColumnHeader><Label>Stratum</Label><Width>8</Width><Alignment>Right</Alignment></TableColumnHeader>
+          <TableColumnHeader><Label>LastSync</Label><Width>22</Width></TableColumnHeader>
+        </TableHeaders>
+        <TableRowEntries>
+          <TableRowEntry>
+            <TableColumnItems>
+              <TableColumnItem><PropertyName>ComputerName</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>ServiceStatus</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>SyncType</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>CurrentSource</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>Stratum</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>LastSuccessfulSync</PropertyName></TableColumnItem>
+            </TableColumnItems>
+          </TableRowEntry>
+        </TableRowEntries>
+      </TableControl>
+    </View>
+
+    <View>
       <Name>PSWinOps.NtpConfiguration</Name>
       <ViewSelectedBy>
         <TypeName>PSWinOps.NtpConfiguration</TypeName>
@@ -399,6 +428,35 @@
     <!-- Used by: Get-SystemSummary                                   -->
     <!-- ============================================================ -->
     <View>
+      <Name>PSWinOps.SystemSummary.Table</Name>
+      <ViewSelectedBy>
+        <TypeName>PSWinOps.SystemSummary</TypeName>
+      </ViewSelectedBy>
+      <TableControl>
+        <TableHeaders>
+          <TableColumnHeader><Label>ComputerName</Label><Width>16</Width></TableColumnHeader>
+          <TableColumnHeader><Label>OS</Label><Width>30</Width></TableColumnHeader>
+          <TableColumnHeader><Label>Uptime</Label><Width>16</Width></TableColumnHeader>
+          <TableColumnHeader><Label>CPU</Label><Width>6</Width><Alignment>Right</Alignment></TableColumnHeader>
+          <TableColumnHeader><Label>RAM</Label><Width>14</Width><Alignment>Right</Alignment></TableColumnHeader>
+          <TableColumnHeader><Label>IPs</Label><Width>20</Width></TableColumnHeader>
+        </TableHeaders>
+        <TableRowEntries>
+          <TableRowEntry>
+            <TableColumnItems>
+              <TableColumnItem><PropertyName>ComputerName</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>OSName</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>UptimeDisplay</PropertyName></TableColumnItem>
+              <TableColumnItem><ScriptBlock>'{0}/{1}' -f $_.TotalCores, $_.TotalLogicalProcessors</ScriptBlock></TableColumnItem>
+              <TableColumnItem><ScriptBlock>'{0}GB/{1}%' -f $_.TotalRAMGB, $_.RAMUsagePercent</ScriptBlock></TableColumnItem>
+              <TableColumnItem><PropertyName>IPAddresses</PropertyName></TableColumnItem>
+            </TableColumnItems>
+          </TableRowEntry>
+        </TableRowEntries>
+      </TableControl>
+    </View>
+
+    <View>
       <Name>PSWinOps.SystemSummary</Name>
       <ViewSelectedBy>
         <TypeName>PSWinOps.SystemSummary</TypeName>
@@ -441,6 +499,35 @@
     <!-- PSWinOps.ProxyConfiguration                                  -->
     <!-- Used by: Get-ProxyConfiguration                              -->
     <!-- ============================================================ -->
+    <View>
+      <Name>PSWinOps.ProxyConfiguration.Table</Name>
+      <ViewSelectedBy>
+        <TypeName>PSWinOps.ProxyConfiguration</TypeName>
+      </ViewSelectedBy>
+      <TableControl>
+        <TableHeaders>
+          <TableColumnHeader><Label>ComputerName</Label><Width>16</Width></TableColumnHeader>
+          <TableColumnHeader><Label>WinINET</Label><Width>8</Width></TableColumnHeader>
+          <TableColumnHeader><Label>WinINET Server</Label><Width>24</Width></TableColumnHeader>
+          <TableColumnHeader><Label>WinHTTP</Label><Width>8</Width></TableColumnHeader>
+          <TableColumnHeader><Label>WinHTTP Server</Label><Width>24</Width></TableColumnHeader>
+          <TableColumnHeader><Label>HTTP_PROXY</Label><Width>24</Width></TableColumnHeader>
+        </TableHeaders>
+        <TableRowEntries>
+          <TableRowEntry>
+            <TableColumnItems>
+              <TableColumnItem><PropertyName>ComputerName</PropertyName></TableColumnItem>
+              <TableColumnItem><ScriptBlock>if ($_.WinInetEnabled) { 'Yes' } else { 'No' }</ScriptBlock></TableColumnItem>
+              <TableColumnItem><ScriptBlock>if ($_.WinInetServer) { $_.WinInetServer } else { '-' }</ScriptBlock></TableColumnItem>
+              <TableColumnItem><ScriptBlock>if ($_.WinHttpEnabled) { 'Yes' } else { 'No' }</ScriptBlock></TableColumnItem>
+              <TableColumnItem><ScriptBlock>if ($_.WinHttpServer) { $_.WinHttpServer } else { '-' }</ScriptBlock></TableColumnItem>
+              <TableColumnItem><ScriptBlock>if ($_.EnvHttpProxy) { $_.EnvHttpProxy } else { '-' }</ScriptBlock></TableColumnItem>
+            </TableColumnItems>
+          </TableRowEntry>
+        </TableRowEntries>
+      </TableControl>
+    </View>
+
     <View>
       <Name>PSWinOps.ProxyConfiguration</Name>
       <ViewSelectedBy>
@@ -863,6 +950,35 @@
     <!-- Used by: Get-SubnetInfo                                      -->
     <!-- ============================================================ -->
     <View>
+      <Name>PSWinOps.SubnetInfo.Table</Name>
+      <ViewSelectedBy>
+        <TypeName>PSWinOps.SubnetInfo</TypeName>
+      </ViewSelectedBy>
+      <TableControl>
+        <TableHeaders>
+          <TableColumnHeader><Label>CIDR</Label><Width>20</Width></TableColumnHeader>
+          <TableColumnHeader><Label>Network</Label><Width>16</Width></TableColumnHeader>
+          <TableColumnHeader><Label>Broadcast</Label><Width>16</Width></TableColumnHeader>
+          <TableColumnHeader><Label>FirstHost</Label><Width>16</Width></TableColumnHeader>
+          <TableColumnHeader><Label>LastHost</Label><Width>16</Width></TableColumnHeader>
+          <TableColumnHeader><Label>Usable</Label><Width>10</Width><Alignment>Right</Alignment></TableColumnHeader>
+        </TableHeaders>
+        <TableRowEntries>
+          <TableRowEntry>
+            <TableColumnItems>
+              <TableColumnItem><PropertyName>CIDR</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>NetworkAddress</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>BroadcastAddress</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>FirstUsableHost</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>LastUsableHost</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>UsableHosts</PropertyName></TableColumnItem>
+            </TableColumnItems>
+          </TableRowEntry>
+        </TableRowEntries>
+      </TableControl>
+    </View>
+
+    <View>
       <Name>PSWinOps.SubnetInfo</Name>
       <ViewSelectedBy>
         <TypeName>PSWinOps.SubnetInfo</TypeName>
@@ -1002,6 +1118,34 @@
       </TableControl>
     </View>
 
+    <!-- PSWinOps.NetworkConfig - Table (default) -->
+    <View>
+      <Name>PSWinOps.NetworkConfig.Table</Name>
+      <ViewSelectedBy><TypeName>PSWinOps.NetworkConfig</TypeName></ViewSelectedBy>
+      <TableControl>
+        <TableHeaders>
+          <TableColumnHeader><Label>ComputerName</Label><Width>16</Width></TableColumnHeader>
+          <TableColumnHeader><Label>Hostname</Label><Width>16</Width></TableColumnHeader>
+          <TableColumnHeader><Label>IPs</Label><Width>20</Width></TableColumnHeader>
+          <TableColumnHeader><Label>DNS</Label><Width>20</Width></TableColumnHeader>
+          <TableColumnHeader><Label>DnsSuffix</Label><Width>18</Width></TableColumnHeader>
+          <TableColumnHeader><Label>Firewall</Label><Width>18</Width></TableColumnHeader>
+        </TableHeaders>
+        <TableRowEntries>
+          <TableRowEntry>
+            <TableColumnItems>
+              <TableColumnItem><PropertyName>ComputerName</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>Hostname</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>IPAddresses</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>DnsServers</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>DnsSuffix</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>FirewallProfiles</PropertyName></TableColumnItem>
+            </TableColumnItems>
+          </TableRowEntry>
+        </TableRowEntries>
+      </TableControl>
+    </View>
+
     <!-- PSWinOps.NetworkConfig - List -->
     <View>
       <Name>PSWinOps.NetworkConfig</Name>
@@ -1103,6 +1247,37 @@
     <!-- PSWinOps.PageFileConfiguration                               -->
     <!-- Used by: Get-PageFileConfiguration                           -->
     <!-- ============================================================ -->
+    <View>
+      <Name>PSWinOps.PageFileConfiguration.Table</Name>
+      <ViewSelectedBy>
+        <TypeName>PSWinOps.PageFileConfiguration</TypeName>
+      </ViewSelectedBy>
+      <TableControl>
+        <TableHeaders>
+          <TableColumnHeader><Label>ComputerName</Label><Width>16</Width></TableColumnHeader>
+          <TableColumnHeader><Label>Drive</Label><Width>6</Width></TableColumnHeader>
+          <TableColumnHeader><Label>Path</Label><Width>24</Width></TableColumnHeader>
+          <TableColumnHeader><Label>InitMB</Label><Width>8</Width><Alignment>Right</Alignment></TableColumnHeader>
+          <TableColumnHeader><Label>MaxMB</Label><Width>8</Width><Alignment>Right</Alignment></TableColumnHeader>
+          <TableColumnHeader><Label>Auto</Label><Width>5</Width></TableColumnHeader>
+          <TableColumnHeader><Label>Status</Label><Width>12</Width></TableColumnHeader>
+        </TableHeaders>
+        <TableRowEntries>
+          <TableRowEntry>
+            <TableColumnItems>
+              <TableColumnItem><PropertyName>ComputerName</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>DriveLetter</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>PageFilePath</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>InitialSizeMB</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>MaximumSizeMB</PropertyName></TableColumnItem>
+              <TableColumnItem><ScriptBlock>if ($_.AutoManagedPagefile) { 'Yes' } else { 'No' }</ScriptBlock></TableColumnItem>
+              <TableColumnItem><PropertyName>Status</PropertyName></TableColumnItem>
+            </TableColumnItems>
+          </TableRowEntry>
+        </TableRowEntries>
+      </TableControl>
+    </View>
+
     <View>
       <Name>PSWinOps.PageFileConfiguration</Name>
       <ViewSelectedBy>
@@ -1414,7 +1589,46 @@
     </View>
 
     <!-- ============================================================ -->
-    <!-- PSWinOps.AdDomainControllerHealth                            -->
+    <!-- PSWinOps.AdDomainControllerHealth (Table — default)          -->
+    <!-- Used by: Get-AdDomainControllerHealth                        -->
+    <!-- ============================================================ -->
+    <View>
+      <Name>PSWinOps.AdDomainControllerHealth.Table</Name>
+      <ViewSelectedBy>
+        <TypeName>PSWinOps.AdDomainControllerHealth</TypeName>
+      </ViewSelectedBy>
+      <TableControl>
+        <TableHeaders>
+          <TableColumnHeader><Label>ComputerName</Label><Width>18</Width></TableColumnHeader>
+          <TableColumnHeader><Label>Service</Label><Width>10</Width></TableColumnHeader>
+          <TableColumnHeader><Label>Site</Label><Width>14</Width></TableColumnHeader>
+          <TableColumnHeader><Label>GC</Label><Width>5</Width></TableColumnHeader>
+          <TableColumnHeader><Label>SYSVOL</Label><Width>7</Width></TableColumnHeader>
+          <TableColumnHeader><Label>Netlogon</Label><Width>9</Width></TableColumnHeader>
+          <TableColumnHeader><Label>Repl</Label><Width>7</Width></TableColumnHeader>
+          <TableColumnHeader><Label>DcDiag</Label><Width>7</Width></TableColumnHeader>
+          <TableColumnHeader><Label>Health</Label><Width>16</Width></TableColumnHeader>
+        </TableHeaders>
+        <TableRowEntries>
+          <TableRowEntry>
+            <TableColumnItems>
+              <TableColumnItem><PropertyName>ComputerName</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>ServiceStatus</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>SiteName</PropertyName></TableColumnItem>
+              <TableColumnItem><ScriptBlock>if ($_.IsGlobalCatalog) { 'Yes' } else { 'No' }</ScriptBlock></TableColumnItem>
+              <TableColumnItem><ScriptBlock>if ($_.SysvolAccessible) { 'OK' } else { 'FAIL' }</ScriptBlock></TableColumnItem>
+              <TableColumnItem><ScriptBlock>if ($_.NetlogonAccessible) { 'OK' } else { 'FAIL' }</ScriptBlock></TableColumnItem>
+              <TableColumnItem><ScriptBlock>'{0}/{1}' -f $_.ReplicationSuccesses, $_.ReplicationFailures</ScriptBlock></TableColumnItem>
+              <TableColumnItem><ScriptBlock>'{0}/{1}' -f $_.DcDiagPassedTests, $_.DcDiagFailedTests</ScriptBlock></TableColumnItem>
+              <TableColumnItem><PropertyName>OverallHealth</PropertyName></TableColumnItem>
+            </TableColumnItems>
+          </TableRowEntry>
+        </TableRowEntries>
+      </TableControl>
+    </View>
+
+    <!-- ============================================================ -->
+    <!-- PSWinOps.AdDomainControllerHealth (List — Format-List)       -->
     <!-- Used by: Get-AdDomainControllerHealth                        -->
     <!-- ============================================================ -->
     <View>
@@ -1520,7 +1734,42 @@
     </View>
 
     <!-- ============================================================ -->
-    <!-- PSWinOps.ClusterHealth                                       -->
+    <!-- PSWinOps.ClusterHealth (Table — default)                     -->
+    <!-- Used by: Get-ClusterHealth                                   -->
+    <!-- ============================================================ -->
+    <View>
+      <Name>PSWinOps.ClusterHealth.Table</Name>
+      <ViewSelectedBy>
+        <TypeName>PSWinOps.ClusterHealth</TypeName>
+      </ViewSelectedBy>
+      <TableControl>
+        <TableHeaders>
+          <TableColumnHeader><Label>ComputerName</Label><Width>16</Width></TableColumnHeader>
+          <TableColumnHeader><Label>Cluster</Label><Width>18</Width></TableColumnHeader>
+          <TableColumnHeader><Label>Node</Label><Width>16</Width></TableColumnHeader>
+          <TableColumnHeader><Label>NodeState</Label><Width>10</Width></TableColumnHeader>
+          <TableColumnHeader><Label>Nodes</Label><Width>7</Width><Alignment>Right</Alignment></TableColumnHeader>
+          <TableColumnHeader><Label>Resources</Label><Width>10</Width><Alignment>Right</Alignment></TableColumnHeader>
+          <TableColumnHeader><Label>Health</Label><Width>16</Width></TableColumnHeader>
+        </TableHeaders>
+        <TableRowEntries>
+          <TableRowEntry>
+            <TableColumnItems>
+              <TableColumnItem><PropertyName>ComputerName</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>ClusterName</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>NodeName</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>NodeState</PropertyName></TableColumnItem>
+              <TableColumnItem><ScriptBlock>'{0}/{1}' -f $_.NodesUp, $_.TotalNodes</ScriptBlock></TableColumnItem>
+              <TableColumnItem><ScriptBlock>'{0}/{1}' -f $_.ResourcesOnline, $_.TotalResources</ScriptBlock></TableColumnItem>
+              <TableColumnItem><PropertyName>OverallHealth</PropertyName></TableColumnItem>
+            </TableColumnItems>
+          </TableRowEntry>
+        </TableRowEntries>
+      </TableControl>
+    </View>
+
+    <!-- ============================================================ -->
+    <!-- PSWinOps.ClusterHealth (List — Format-List)                  -->
     <!-- Used by: Get-ClusterHealth                                   -->
     <!-- ============================================================ -->
     <View>
@@ -1552,7 +1801,42 @@
     </View>
 
     <!-- ============================================================ -->
-    <!-- PSWinOps.HyperVHostHealth                                    -->
+    <!-- PSWinOps.HyperVHostHealth (Table — default)                  -->
+    <!-- Used by: Get-HyperVHostHealth                                -->
+    <!-- ============================================================ -->
+    <View>
+      <Name>PSWinOps.HyperVHostHealth.Table</Name>
+      <ViewSelectedBy>
+        <TypeName>PSWinOps.HyperVHostHealth</TypeName>
+      </ViewSelectedBy>
+      <TableControl>
+        <TableHeaders>
+          <TableColumnHeader><Label>ComputerName</Label><Width>16</Width></TableColumnHeader>
+          <TableColumnHeader><Label>Service</Label><Width>10</Width></TableColumnHeader>
+          <TableColumnHeader><Label>VMs(Run/Tot)</Label><Width>12</Width><Alignment>Right</Alignment></TableColumnHeader>
+          <TableColumnHeader><Label>MemUsed%</Label><Width>9</Width><Alignment>Right</Alignment></TableColumnHeader>
+          <TableColumnHeader><Label>CPUs</Label><Width>5</Width><Alignment>Right</Alignment></TableColumnHeader>
+          <TableColumnHeader><Label>Storage(GB)</Label><Width>12</Width><Alignment>Right</Alignment></TableColumnHeader>
+          <TableColumnHeader><Label>Health</Label><Width>16</Width></TableColumnHeader>
+        </TableHeaders>
+        <TableRowEntries>
+          <TableRowEntry>
+            <TableColumnItems>
+              <TableColumnItem><PropertyName>ComputerName</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>ServiceStatus</PropertyName></TableColumnItem>
+              <TableColumnItem><ScriptBlock>'{0}/{1}' -f $_.RunningVMs, $_.TotalVMs</ScriptBlock></TableColumnItem>
+              <TableColumnItem><ScriptBlock>if ($null -ne $_.MemoryUsedPercent) { '{0:N0}' -f $_.MemoryUsedPercent } else { 'N/A' }</ScriptBlock></TableColumnItem>
+              <TableColumnItem><PropertyName>LogicalProcessors</PropertyName></TableColumnItem>
+              <TableColumnItem><ScriptBlock>if ($null -ne $_.VHDTotalSizeGB) { '{0:N1}' -f $_.VHDTotalSizeGB } else { 'N/A' }</ScriptBlock></TableColumnItem>
+              <TableColumnItem><PropertyName>OverallHealth</PropertyName></TableColumnItem>
+            </TableColumnItems>
+          </TableRowEntry>
+        </TableRowEntries>
+      </TableControl>
+    </View>
+
+    <!-- ============================================================ -->
+    <!-- PSWinOps.HyperVHostHealth (List — Format-List)               -->
     <!-- Used by: Get-HyperVHostHealth                                -->
     <!-- ============================================================ -->
     <View>
@@ -1620,7 +1904,42 @@
     </View>
 
     <!-- ============================================================ -->
-    <!-- PSWinOps.CertificateAuthorityHealth                          -->
+    <!-- PSWinOps.CertificateAuthorityHealth (Table — default)        -->
+    <!-- Used by: Get-CertificateAuthorityHealth                      -->
+    <!-- ============================================================ -->
+    <View>
+      <Name>PSWinOps.CertificateAuthorityHealth.Table</Name>
+      <ViewSelectedBy>
+        <TypeName>PSWinOps.CertificateAuthorityHealth</TypeName>
+      </ViewSelectedBy>
+      <TableControl>
+        <TableHeaders>
+          <TableColumnHeader><Label>ComputerName</Label><Width>16</Width></TableColumnHeader>
+          <TableColumnHeader><Label>Service</Label><Width>10</Width></TableColumnHeader>
+          <TableColumnHeader><Label>CAName</Label><Width>22</Width></TableColumnHeader>
+          <TableColumnHeader><Label>CertDays</Label><Width>9</Width><Alignment>Right</Alignment></TableColumnHeader>
+          <TableColumnHeader><Label>CRL</Label><Width>5</Width></TableColumnHeader>
+          <TableColumnHeader><Label>Ping</Label><Width>5</Width></TableColumnHeader>
+          <TableColumnHeader><Label>Health</Label><Width>16</Width></TableColumnHeader>
+        </TableHeaders>
+        <TableRowEntries>
+          <TableRowEntry>
+            <TableColumnItems>
+              <TableColumnItem><PropertyName>ComputerName</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>ServiceStatus</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>CAName</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>CACertDaysRemaining</PropertyName></TableColumnItem>
+              <TableColumnItem><ScriptBlock>if ($_.CRLPublishOK) { 'OK' } else { 'FAIL' }</ScriptBlock></TableColumnItem>
+              <TableColumnItem><ScriptBlock>if ($_.CAPingOK) { 'OK' } else { 'FAIL' }</ScriptBlock></TableColumnItem>
+              <TableColumnItem><PropertyName>OverallHealth</PropertyName></TableColumnItem>
+            </TableColumnItems>
+          </TableRowEntry>
+        </TableRowEntries>
+      </TableControl>
+    </View>
+
+    <!-- ============================================================ -->
+    <!-- PSWinOps.CertificateAuthorityHealth (List — Format-List)     -->
     <!-- Used by: Get-CertificateAuthorityHealth                      -->
     <!-- ============================================================ -->
     <View>
@@ -1649,7 +1968,44 @@
     </View>
 
     <!-- ============================================================ -->
-    <!-- PSWinOps.WSUSHealth                                          -->
+    <!-- PSWinOps.WSUSHealth (Table — default)                        -->
+    <!-- Used by: Get-WSUSHealth                                      -->
+    <!-- ============================================================ -->
+    <View>
+      <Name>PSWinOps.WSUSHealth.Table</Name>
+      <ViewSelectedBy>
+        <TypeName>PSWinOps.WSUSHealth</TypeName>
+      </ViewSelectedBy>
+      <TableControl>
+        <TableHeaders>
+          <TableColumnHeader><Label>ComputerName</Label><Width>16</Width></TableColumnHeader>
+          <TableColumnHeader><Label>Service</Label><Width>10</Width></TableColumnHeader>
+          <TableColumnHeader><Label>Clients</Label><Width>8</Width><Alignment>Right</Alignment></TableColumnHeader>
+          <TableColumnHeader><Label>Needing</Label><Width>8</Width><Alignment>Right</Alignment></TableColumnHeader>
+          <TableColumnHeader><Label>Errors</Label><Width>7</Width><Alignment>Right</Alignment></TableColumnHeader>
+          <TableColumnHeader><Label>Unapproved</Label><Width>10</Width><Alignment>Right</Alignment></TableColumnHeader>
+          <TableColumnHeader><Label>DiskFree</Label><Width>10</Width><Alignment>Right</Alignment></TableColumnHeader>
+          <TableColumnHeader><Label>Health</Label><Width>16</Width></TableColumnHeader>
+        </TableHeaders>
+        <TableRowEntries>
+          <TableRowEntry>
+            <TableColumnItems>
+              <TableColumnItem><PropertyName>ComputerName</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>ServiceStatus</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>TotalClients</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>ClientsNeedingUpdates</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>ClientsWithErrors</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>UnapprovedUpdates</PropertyName></TableColumnItem>
+              <TableColumnItem><ScriptBlock>'{0:N1} GB' -f $_.ContentDirFreeSpaceGB</ScriptBlock></TableColumnItem>
+              <TableColumnItem><PropertyName>OverallHealth</PropertyName></TableColumnItem>
+            </TableColumnItems>
+          </TableRowEntry>
+        </TableRowEntries>
+      </TableControl>
+    </View>
+
+    <!-- ============================================================ -->
+    <!-- PSWinOps.WSUSHealth (List — Format-List)                     -->
     <!-- Used by: Get-WSUSHealth                                      -->
     <!-- ============================================================ -->
     <View>
@@ -1682,7 +2038,42 @@
     </View>
 
     <!-- ============================================================ -->
-    <!-- PSWinOps.FileServerHealth                                    -->
+    <!-- PSWinOps.FileServerHealth (Table — default)                  -->
+    <!-- Used by: Get-FileServerHealth                                -->
+    <!-- ============================================================ -->
+    <View>
+      <Name>PSWinOps.FileServerHealth.Table</Name>
+      <ViewSelectedBy>
+        <TypeName>PSWinOps.FileServerHealth</TypeName>
+      </ViewSelectedBy>
+      <TableControl>
+        <TableHeaders>
+          <TableColumnHeader><Label>ComputerName</Label><Width>16</Width></TableColumnHeader>
+          <TableColumnHeader><Label>Service</Label><Width>10</Width></TableColumnHeader>
+          <TableColumnHeader><Label>Shares</Label><Width>7</Width><Alignment>Right</Alignment></TableColumnHeader>
+          <TableColumnHeader><Label>Sessions</Label><Width>9</Width><Alignment>Right</Alignment></TableColumnHeader>
+          <TableColumnHeader><Label>Files</Label><Width>6</Width><Alignment>Right</Alignment></TableColumnHeader>
+          <TableColumnHeader><Label>DiskFree</Label><Width>10</Width><Alignment>Right</Alignment></TableColumnHeader>
+          <TableColumnHeader><Label>Health</Label><Width>16</Width></TableColumnHeader>
+        </TableHeaders>
+        <TableRowEntries>
+          <TableRowEntry>
+            <TableColumnItems>
+              <TableColumnItem><PropertyName>ComputerName</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>ServiceStatus</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>TotalShares</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>OpenSessions</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>OpenFiles</PropertyName></TableColumnItem>
+              <TableColumnItem><ScriptBlock>if ($null -ne $_.MinShareDiskFreeGB) { '{0:N1} GB' -f $_.MinShareDiskFreeGB } else { 'N/A' }</ScriptBlock></TableColumnItem>
+              <TableColumnItem><PropertyName>OverallHealth</PropertyName></TableColumnItem>
+            </TableColumnItems>
+          </TableRowEntry>
+        </TableRowEntries>
+      </TableControl>
+    </View>
+
+    <!-- ============================================================ -->
+    <!-- PSWinOps.FileServerHealth (List — Format-List)               -->
     <!-- Used by: Get-FileServerHealth                                -->
     <!-- ============================================================ -->
     <View>
@@ -1712,7 +2103,42 @@
     </View>
 
     <!-- ============================================================ -->
-    <!-- PSWinOps.ADFSHealth                                          -->
+    <!-- PSWinOps.ADFSHealth (Table — default)                        -->
+    <!-- Used by: Get-ADFSHealth                                      -->
+    <!-- ============================================================ -->
+    <View>
+      <Name>PSWinOps.ADFSHealth.Table</Name>
+      <ViewSelectedBy>
+        <TypeName>PSWinOps.ADFSHealth</TypeName>
+      </ViewSelectedBy>
+      <TableControl>
+        <TableHeaders>
+          <TableColumnHeader><Label>ComputerName</Label><Width>16</Width></TableColumnHeader>
+          <TableColumnHeader><Label>Service</Label><Width>10</Width></TableColumnHeader>
+          <TableColumnHeader><Label>FarmRole</Label><Width>10</Width></TableColumnHeader>
+          <TableColumnHeader><Label>FedService</Label><Width>24</Width></TableColumnHeader>
+          <TableColumnHeader><Label>CertDays</Label><Width>9</Width><Alignment>Right</Alignment></TableColumnHeader>
+          <TableColumnHeader><Label>RPs</Label><Width>5</Width><Alignment>Right</Alignment></TableColumnHeader>
+          <TableColumnHeader><Label>Health</Label><Width>16</Width></TableColumnHeader>
+        </TableHeaders>
+        <TableRowEntries>
+          <TableRowEntry>
+            <TableColumnItems>
+              <TableColumnItem><PropertyName>ComputerName</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>ServiceStatus</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>FarmRole</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>FederationServiceName</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>SslCertDaysRemaining</PropertyName></TableColumnItem>
+              <TableColumnItem><ScriptBlock>'{0}/{1}' -f $_.EnabledRelyingParties, $_.TotalRelyingParties</ScriptBlock></TableColumnItem>
+              <TableColumnItem><PropertyName>OverallHealth</PropertyName></TableColumnItem>
+            </TableColumnItems>
+          </TableRowEntry>
+        </TableRowEntries>
+      </TableControl>
+    </View>
+
+    <!-- ============================================================ -->
+    <!-- PSWinOps.ADFSHealth (List — Format-List)                     -->
     <!-- Used by: Get-ADFSHealth                                      -->
     <!-- ============================================================ -->
     <View>
@@ -1726,6 +2152,8 @@
             <ListItems>
               <ListItem><Label>ComputerName</Label><PropertyName>ComputerName</PropertyName></ListItem>
               <ListItem><Label>ServiceStatus</Label><PropertyName>ServiceStatus</PropertyName></ListItem>
+              <ListItem><Label>FarmRole</Label><PropertyName>FarmRole</PropertyName></ListItem>
+              <ListItem><Label>PrimaryServer</Label><PropertyName>PrimaryServer</PropertyName></ListItem>
               <ListItem><Label>FederationServiceName</Label><PropertyName>FederationServiceName</PropertyName></ListItem>
               <ListItem><Label>SslCertExpiry</Label><PropertyName>SslCertExpiry</PropertyName></ListItem>
               <ListItem><Label>SslCertDaysRemaining</Label><PropertyName>SslCertDaysRemaining</PropertyName></ListItem>
@@ -1742,7 +2170,42 @@
     </View>
 
     <!-- ============================================================ -->
-    <!-- PSWinOps.RDSHealth                                           -->
+    <!-- PSWinOps.RDSHealth (Table — default)                         -->
+    <!-- Used by: Get-RDSHealth                                       -->
+    <!-- ============================================================ -->
+    <View>
+      <Name>PSWinOps.RDSHealth.Table</Name>
+      <ViewSelectedBy>
+        <TypeName>PSWinOps.RDSHealth</TypeName>
+      </ViewSelectedBy>
+      <TableControl>
+        <TableHeaders>
+          <TableColumnHeader><Label>ComputerName</Label><Width>16</Width></TableColumnHeader>
+          <TableColumnHeader><Label>Service</Label><Width>10</Width></TableColumnHeader>
+          <TableColumnHeader><Label>Active</Label><Width>7</Width><Alignment>Right</Alignment></TableColumnHeader>
+          <TableColumnHeader><Label>Disconn</Label><Width>8</Width><Alignment>Right</Alignment></TableColumnHeader>
+          <TableColumnHeader><Label>Total</Label><Width>6</Width><Alignment>Right</Alignment></TableColumnHeader>
+          <TableColumnHeader><Label>Licensing</Label><Width>12</Width></TableColumnHeader>
+          <TableColumnHeader><Label>Health</Label><Width>16</Width></TableColumnHeader>
+        </TableHeaders>
+        <TableRowEntries>
+          <TableRowEntry>
+            <TableColumnItems>
+              <TableColumnItem><PropertyName>ComputerName</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>ServiceStatus</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>ActiveSessions</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>DisconnectedSessions</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>TotalSessions</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>LicensingMode</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>OverallHealth</PropertyName></TableColumnItem>
+            </TableColumnItems>
+          </TableRowEntry>
+        </TableRowEntries>
+      </TableControl>
+    </View>
+
+    <!-- ============================================================ -->
+    <!-- PSWinOps.RDSHealth (List — Format-List)                      -->
     <!-- Used by: Get-RDSHealth                                       -->
     <!-- ============================================================ -->
     <View>
@@ -1772,7 +2235,42 @@
     </View>
 
     <!-- ============================================================ -->
-    <!-- PSWinOps.PrintServerHealth                                   -->
+    <!-- PSWinOps.PrintServerHealth (Table — default)                 -->
+    <!-- Used by: Get-PrintServerHealth                               -->
+    <!-- ============================================================ -->
+    <View>
+      <Name>PSWinOps.PrintServerHealth.Table</Name>
+      <ViewSelectedBy>
+        <TypeName>PSWinOps.PrintServerHealth</TypeName>
+      </ViewSelectedBy>
+      <TableControl>
+        <TableHeaders>
+          <TableColumnHeader><Label>ComputerName</Label><Width>16</Width></TableColumnHeader>
+          <TableColumnHeader><Label>Service</Label><Width>10</Width></TableColumnHeader>
+          <TableColumnHeader><Label>Printers</Label><Width>9</Width><Alignment>Right</Alignment></TableColumnHeader>
+          <TableColumnHeader><Label>Online</Label><Width>7</Width><Alignment>Right</Alignment></TableColumnHeader>
+          <TableColumnHeader><Label>Errors</Label><Width>7</Width><Alignment>Right</Alignment></TableColumnHeader>
+          <TableColumnHeader><Label>Jobs</Label><Width>5</Width><Alignment>Right</Alignment></TableColumnHeader>
+          <TableColumnHeader><Label>Health</Label><Width>16</Width></TableColumnHeader>
+        </TableHeaders>
+        <TableRowEntries>
+          <TableRowEntry>
+            <TableColumnItems>
+              <TableColumnItem><PropertyName>ComputerName</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>ServiceStatus</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>TotalPrinters</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>PrintersOnline</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>PrintersInError</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>TotalPrintJobs</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>OverallHealth</PropertyName></TableColumnItem>
+            </TableColumnItems>
+          </TableRowEntry>
+        </TableRowEntries>
+      </TableControl>
+    </View>
+
+    <!-- ============================================================ -->
+    <!-- PSWinOps.PrintServerHealth (List — Format-List)              -->
     <!-- Used by: Get-PrintServerHealth                               -->
     <!-- ============================================================ -->
     <View>
@@ -1802,7 +2300,44 @@
     </View>
 
     <!-- ============================================================ -->
-    <!-- PSWinOps.DnsServerHealth                                     -->
+    <!-- PSWinOps.DnsServerHealth (Table — default)                   -->
+    <!-- Used by: Get-DnsServerHealth                                 -->
+    <!-- ============================================================ -->
+    <View>
+      <Name>PSWinOps.DnsServerHealth.Table</Name>
+      <ViewSelectedBy>
+        <TypeName>PSWinOps.DnsServerHealth</TypeName>
+      </ViewSelectedBy>
+      <TableControl>
+        <TableHeaders>
+          <TableColumnHeader><Label>ComputerName</Label><Width>16</Width></TableColumnHeader>
+          <TableColumnHeader><Label>Service</Label><Width>10</Width></TableColumnHeader>
+          <TableColumnHeader><Label>Zones</Label><Width>6</Width><Alignment>Right</Alignment></TableColumnHeader>
+          <TableColumnHeader><Label>Primary</Label><Width>8</Width><Alignment>Right</Alignment></TableColumnHeader>
+          <TableColumnHeader><Label>Paused</Label><Width>7</Width><Alignment>Right</Alignment></TableColumnHeader>
+          <TableColumnHeader><Label>Fwders</Label><Width>7</Width><Alignment>Right</Alignment></TableColumnHeader>
+          <TableColumnHeader><Label>SelfRes</Label><Width>8</Width></TableColumnHeader>
+          <TableColumnHeader><Label>Health</Label><Width>16</Width></TableColumnHeader>
+        </TableHeaders>
+        <TableRowEntries>
+          <TableRowEntry>
+            <TableColumnItems>
+              <TableColumnItem><PropertyName>ComputerName</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>ServiceStatus</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>TotalZones</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>PrimaryZones</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>PausedZones</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>ForwarderCount</PropertyName></TableColumnItem>
+              <TableColumnItem><ScriptBlock>if ($_.SelfResolution) { 'OK' } else { 'FAIL' }</ScriptBlock></TableColumnItem>
+              <TableColumnItem><PropertyName>OverallHealth</PropertyName></TableColumnItem>
+            </TableColumnItems>
+          </TableRowEntry>
+        </TableRowEntries>
+      </TableControl>
+    </View>
+
+    <!-- ============================================================ -->
+    <!-- PSWinOps.DnsServerHealth (List — Format-List)                -->
     <!-- Used by: Get-DnsServerHealth                                 -->
     <!-- ============================================================ -->
     <View>

--- a/Public/healthcheck/Get-ADFSHealth.ps1
+++ b/Public/healthcheck/Get-ADFSHealth.ps1
@@ -39,8 +39,8 @@ function Get-ADFSHealth {
 
         .NOTES
             Author: Franck SALLET
-            Version: 1.0.0
-            Last Modified: 2026-03-26
+            Version: 1.1.0
+            Last Modified: 2026-03-31
             Requires: PowerShell 5.1+ / Windows only
             Requires: AD FS role installed on target servers
 
@@ -80,6 +80,8 @@ function Get-ADFSHealth {
                 EnabledRelyingParties = 0
                 EnabledEndpoints      = 0
                 ServerHealthOK        = $true
+                FarmRole              = 'Unknown'
+                PrimaryServer         = 'Unknown'
             }
 
             try {
@@ -97,8 +99,17 @@ function Get-ADFSHealth {
                 try {
                     $adfsProps = Get-AdfsProperties -ErrorAction Stop
                     $data.FederationServiceName = [string]$adfsProps.HostName
+                    $data.FarmRole = 'Primary'
                 }
-                catch { Write-Warning -Message "Failed to retrieve ADFS properties: $_" }
+                catch {
+                    if ($_.Exception.Message -match 'PS0033') {
+                        $data.FarmRole = 'Secondary'
+                        if ($_.Exception.Message -match 'primary server is presently:\s*(\S+)') {
+                            $data.PrimaryServer = $Matches[1].TrimEnd('.')
+                        }
+                    }
+                    Write-Warning -Message "Failed to retrieve ADFS properties: $_"
+                }
 
                 try {
                     $sslCerts = Get-AdfsSslCertificate -ErrorAction Stop
@@ -170,13 +181,15 @@ function Get-ADFSHealth {
                     $result = Invoke-Command @invokeParams
                 }
 
+                $isSecondary = $result.FarmRole -eq 'Secondary'
+
                 if (-not $result.ModuleAvailable) {
                     $healthStatus = 'RoleUnavailable'
                 }
                 elseif ($result.ServiceStatus -ne 'Running' -or $result.SslCertDaysRemaining -le 0 -or -not $result.ServerHealthOK) {
                     $healthStatus = 'Critical'
                 }
-                elseif ($result.SslCertDaysRemaining -lt 30 -or $result.EnabledRelyingParties -eq 0) {
+                elseif ($result.SslCertDaysRemaining -lt 30 -or ($result.EnabledRelyingParties -eq 0 -and -not $isSecondary)) {
                     $healthStatus = 'Degraded'
                 }
                 else {
@@ -188,6 +201,8 @@ function Get-ADFSHealth {
                     ComputerName          = $displayName
                     ServiceName           = 'adfssrv'
                     ServiceStatus         = [string]$result.ServiceStatus
+                    FarmRole              = [string]$result.FarmRole
+                    PrimaryServer         = [string]$result.PrimaryServer
                     FederationServiceName = [string]$result.FederationServiceName
                     SslCertExpiry         = [string]$result.SslCertExpiry
                     SslCertDaysRemaining  = [int]$result.SslCertDaysRemaining

--- a/Public/healthcheck/Get-AdDomainControllerHealth.ps1
+++ b/Public/healthcheck/Get-AdDomainControllerHealth.ps1
@@ -212,7 +212,7 @@ function Get-AdDomainControllerHealth {
             $dcdiagPath = Get-Command -Name 'dcdiag' -ErrorAction SilentlyContinue
             if ($dcdiagPath) {
                 try {
-                    $dcdiagOutput = & dcdiag /s:$env:COMPUTERNAME /test:Connectivity /test:Replications /test:Services /test:Advertising /test:FsmoCheck /q 2>&1
+                    $dcdiagOutput = & dcdiag /s:$env:COMPUTERNAME /test:Connectivity /test:Replications /test:Services /test:Advertising /test:FsmoCheck 2>&1
                     $dcdiagText = $dcdiagOutput | Out-String
                     $passedCount = ([regex]::Matches($dcdiagText, 'passed test', 'IgnoreCase')).Count
                     $failedCount = ([regex]::Matches($dcdiagText, 'failed test', 'IgnoreCase')).Count

--- a/Public/healthcheck/Get-CertificateAuthorityHealth.ps1
+++ b/Public/healthcheck/Get-CertificateAuthorityHealth.ps1
@@ -107,7 +107,7 @@ function Get-CertificateAuthorityHealth {
                         if ($line -match '^\s*CA\s+name:\s*(.+)') {
                             $data.CAName = $Matches[1].Trim()
                         }
-                        if ($line -match '^\s*CA\s+type:\s*\d+\s*-\s*(.+)') {
+                        if ($line -match '^\s*CA\s+type:\s*\d+\s*-+\s*(.+)') {
                             $data.CAType = $Matches[1].Trim()
                         }
                         elseif ($line -match '^\s*CA\s+type:\s*(.+)') {
@@ -125,7 +125,7 @@ function Get-CertificateAuthorityHealth {
                         if ($inCert0 -and $line -match 'CA\s+cert\[\d+\]') {
                             break
                         }
-                        if ($inCert0 -and $line -match 'NotAfter:\s*(.+)') {
+                        if ($inCert0 -and $line -match 'Not\s*After\s*:\s*(.+)') {
                             $expiryString = $Matches[1].Trim()
                             $data.CACertExpiry = $expiryString
                             try {
@@ -136,6 +136,24 @@ function Get-CertificateAuthorityHealth {
                                 $data.CACertDaysRemaining = -1
                             }
                             break
+                        }
+                    }
+
+                    # Fallback: parse Cert Expires line if NotAfter was not found
+                    if ($data.CACertExpiry -eq 'Unknown') {
+                        foreach ($line in $caInfoLines) {
+                            if ($line -match '(?i)Cert\s+expires?:\s*(.+)') {
+                                $expiryString = $Matches[1].Trim()
+                                $data.CACertExpiry = $expiryString
+                                try {
+                                    $expiryDate = [datetime]::Parse($expiryString)
+                                    $data.CACertDaysRemaining = ($expiryDate - (Get-Date)).Days
+                                }
+                                catch {
+                                    $data.CACertDaysRemaining = -1
+                                }
+                                break
+                            }
                         }
                     }
                 }

--- a/Public/healthcheck/Get-IISHealth.ps1
+++ b/Public/healthcheck/Get-IISHealth.ps1
@@ -267,7 +267,7 @@ function Get-IISHealth {
             else {
                 foreach ($siteInfo in $sitesData) {
                     $health = if ($w3svcStatus -ne 'Running') { 'Critical' }
-                    elseif ($siteInfo.SiteState -ne 'Started') { 'Critical' }
+                    elseif ($siteInfo.SiteState -notin @('Started', 'Unknown')) { 'Critical' }
                     elseif ($siteInfo.AppPoolState -notin @('Started', 'Unknown')) { 'Degraded' }
                     else { 'Healthy' }
 

--- a/Public/healthcheck/Get-IISHealth.ps1
+++ b/Public/healthcheck/Get-IISHealth.ps1
@@ -41,8 +41,8 @@ function Get-IISHealth {
 
         .NOTES
             Author: Franck SALLET
-            Version: 1.0.0
-            Last Modified: 2026-03-26
+            Version: 1.1.0
+            Last Modified: 2026-03-31
             Requires: PowerShell 5.1+ / Windows only
             Requires: Web-Server (IIS) role
 
@@ -181,24 +181,58 @@ function Get-IISHealth {
                     $cimSites = Get-CimInstance -Namespace 'root/webadministration' -ClassName 'Site' -ErrorAction Stop
                     $sitesData = [System.Collections.Generic.List[hashtable]]::new()
 
-                    $stateMap = @{ 1 = 'Started'; 2 = 'Starting'; 3 = 'Stopped'; 4 = 'Stopping' }
+                    # Build app pool index via CIM
+                    $cimPoolIndex = @{}
+                    $cimPoolStateMap = @{ 1 = 'Started'; 2 = 'Starting'; 3 = 'Stopped'; 4 = 'Stopping' }
+                    try {
+                        $cimPools = Get-CimInstance -Namespace 'root/webadministration' -ClassName 'ApplicationPool' -ErrorAction Stop
+                        foreach ($pool in $cimPools) {
+                            $poolState = 'Unknown'
+                            try {
+                                $poolCimState = Invoke-CimMethod -InputObject $pool -MethodName 'GetState' -ErrorAction Stop
+                                if ($cimPoolStateMap.ContainsKey([int]$poolCimState.ReturnValue)) {
+                                    $poolState = $cimPoolStateMap[[int]$poolCimState.ReturnValue]
+                                }
+                            }
+                            catch { $poolState = 'Unknown' }
+                            $cimPoolIndex[$pool.Name] = $poolState
+                        }
+                    }
+                    catch { Write-Verbose -Message 'CIM ApplicationPool query failed; pool data unavailable' }
+
+                    # Build site-to-pool mapping via CIM Application class
+                    $sitePoolMap = @{}
+                    try {
+                        $cimApps = Get-CimInstance -Namespace 'root/webadministration' -ClassName 'Application' -ErrorAction Stop
+                        foreach ($app in $cimApps) {
+                            if ($app.Path -eq '/') {
+                                $sitePoolMap[$app.SiteName] = $app.ApplicationPool
+                            }
+                        }
+                    }
+                    catch { Write-Verbose -Message 'CIM Application query failed; site-to-pool mapping unavailable' }
+
+                    $siteStateMap = @{ 1 = 'Started'; 2 = 'Starting'; 3 = 'Stopped'; 4 = 'Stopping' }
                     foreach ($site in $cimSites) {
                         $siteState = 'Unknown'
                         try {
                             $cimState = Invoke-CimMethod -InputObject $site -MethodName 'GetState' -ErrorAction Stop
-                            if ($stateMap.ContainsKey([int]$cimState.ReturnValue)) {
-                                $siteState = $stateMap[[int]$cimState.ReturnValue]
+                            if ($siteStateMap.ContainsKey([int]$cimState.ReturnValue)) {
+                                $siteState = $siteStateMap[[int]$cimState.ReturnValue]
                             }
                         }
                         catch { $siteState = 'Unknown' }
+
+                        $poolName  = if ($sitePoolMap.ContainsKey($site.Name)) { $sitePoolMap[$site.Name] } else { 'Unknown' }
+                        $poolState = if ($cimPoolIndex.ContainsKey($poolName)) { $cimPoolIndex[$poolName] } else { 'Unknown' }
 
                         $sitesData.Add(@{
                             SiteName     = $site.Name
                             SiteState    = $siteState
                             Bindings     = 'N/A'
                             PhysicalPath = 'N/A'
-                            AppPoolName  = 'Unknown'
-                            AppPoolState = 'Unknown'
+                            AppPoolName  = $poolName
+                            AppPoolState = $poolState
                         })
                     }
                 }
@@ -234,7 +268,7 @@ function Get-IISHealth {
                 foreach ($siteInfo in $sitesData) {
                     $health = if ($w3svcStatus -ne 'Running') { 'Critical' }
                     elseif ($siteInfo.SiteState -ne 'Started') { 'Critical' }
-                    elseif ($siteInfo.AppPoolState -ne 'Started') { 'Degraded' }
+                    elseif ($siteInfo.AppPoolState -notin @('Started', 'Unknown')) { 'Degraded' }
                     else { 'Healthy' }
 
                     $siteResults.Add(@{

--- a/Tests/Public/healthcheck/Get-ADFSHealth.Tests.ps1
+++ b/Tests/Public/healthcheck/Get-ADFSHealth.Tests.ps1
@@ -38,6 +38,8 @@ Describe 'Get-ADFSHealth' {
             EnabledRelyingParties = 12
             EnabledEndpoints      = 8
             ServerHealthOK        = $true
+            FarmRole              = 'Primary'
+            PrimaryServer         = 'Unknown'
         }
 
         # Helper: set up all local-path mocks for the scriptBlock
@@ -60,7 +62,8 @@ Describe 'Get-ADFSHealth' {
                 [bool]$EndpointThrows        = $false,
                 [bool]$HealthCmdExists       = $true,
                 [bool]$HealthTestThrows      = $false,
-                [bool]$HealthTestFailing     = $false
+                [bool]$HealthTestFailing     = $false,
+                [bool]$IsSecondaryNode       = $false
             )
 
             # Get-Service
@@ -84,7 +87,12 @@ Describe 'Get-ADFSHealth' {
             }
 
             # Get-AdfsProperties
-            if ($PropertiesThrows) {
+            if ($IsSecondaryNode) {
+                Mock -CommandName 'Get-AdfsProperties' -ModuleName 'PSWinOps' -MockWith {
+                    throw 'PS0033: This cmdlet cannot be executed from a secondary server in a local database farm.  The primary server is presently: adfs01.contoso.com.'
+                }
+            }
+            elseif ($PropertiesThrows) {
                 Mock -CommandName 'Get-AdfsProperties' -ModuleName 'PSWinOps' -MockWith { throw 'Cannot get ADFS properties' }
             }
             else {
@@ -241,13 +249,32 @@ Describe 'Get-ADFSHealth' {
         It 'Should return Degraded' { $script:result.OverallHealth | Should -Be 'Degraded' }
     }
 
-    Context 'Remote - Degraded (zero enabled relying parties)' {
+    Context 'Remote - Degraded (zero enabled relying parties on primary)' {
         BeforeAll {
             $d = $script:mockRemoteData.Clone(); $d.EnabledRelyingParties = 0
             Mock -CommandName 'Invoke-Command' -ModuleName 'PSWinOps' -MockWith { return $d }
             $script:result = Get-ADFSHealth -ComputerName 'ADFS01'
         }
         It 'Should return Degraded' { $script:result.OverallHealth | Should -Be 'Degraded' }
+        It 'Should report FarmRole as Primary' { $script:result.FarmRole | Should -Be 'Primary' }
+    }
+
+    Context 'Remote - Secondary node (WID farm) is Healthy despite zero RPs' {
+        BeforeAll {
+            $d = $script:mockRemoteData.Clone()
+            $d.FarmRole = 'Secondary'
+            $d.PrimaryServer = 'adfs01.contoso.com'
+            $d.FederationServiceName = 'Unknown'
+            $d.EnabledRelyingParties = 0
+            $d.TotalRelyingParties = 0
+            $d.EnabledEndpoints = 0
+            Mock -CommandName 'Invoke-Command' -ModuleName 'PSWinOps' -MockWith { return $d }
+            $script:result = Get-ADFSHealth -ComputerName 'ADFS02'
+        }
+        It 'Should return Healthy (not Degraded)' { $script:result.OverallHealth | Should -Be 'Healthy' }
+        It 'Should report FarmRole as Secondary' { $script:result.FarmRole | Should -Be 'Secondary' }
+        It 'Should report PrimaryServer' { $script:result.PrimaryServer | Should -Be 'adfs01.contoso.com' }
+        It 'Should report FederationServiceName as Unknown' { $script:result.FederationServiceName | Should -Be 'Unknown' }
     }
 
     Context 'Remote - Pipeline input (two servers)' {
@@ -460,7 +487,7 @@ Describe 'Get-ADFSHealth' {
         It 'Should return cert days less than 30' { $script:result.SslCertDaysRemaining | Should -BeLessThan 30 }
     }
 
-    Context 'Local path - Degraded (zero enabled relying parties)' {
+    Context 'Local path - Degraded (zero enabled relying parties on primary)' {
         BeforeAll {
             Set-ADFSLocalMocks -TotalRP 5 -EnabledRP 0
             $script:result = Get-ADFSHealth -ComputerName $env:COMPUTERNAME
@@ -468,6 +495,17 @@ Describe 'Get-ADFSHealth' {
         It 'Should return Degraded' { $script:result.OverallHealth | Should -Be 'Degraded' }
         It 'Should return 0 EnabledRelyingParties' { $script:result.EnabledRelyingParties | Should -Be 0 }
         It 'Should return 5 TotalRelyingParties' { $script:result.TotalRelyingParties | Should -Be 5 }
+    }
+
+    Context 'Local path - Secondary WID node is Healthy despite zero RPs' {
+        BeforeAll {
+            Set-ADFSLocalMocks -IsSecondaryNode $true -RPThrows $true -EndpointThrows $true
+            $script:result = Get-ADFSHealth -ComputerName $env:COMPUTERNAME
+        }
+        It 'Should return Healthy (not Degraded)' { $script:result.OverallHealth | Should -Be 'Healthy' }
+        It 'Should report FarmRole as Secondary' { $script:result.FarmRole | Should -Be 'Secondary' }
+        It 'Should report PrimaryServer' { $script:result.PrimaryServer | Should -Be 'adfs01.contoso.com' }
+        It 'Should return 0 EnabledRelyingParties' { $script:result.EnabledRelyingParties | Should -Be 0 }
     }
 
     # =========================================================================
@@ -588,6 +626,8 @@ Describe 'Get-ADFSHealth' {
         It 'Should have ComputerName set to ADFS01' { $script:hpResult.ComputerName | Should -Be 'ADFS01' }
         It 'Should have ServiceName property' { $script:hpResult.ServiceName | Should -Be 'adfssrv' }
         It 'Should have ServiceStatus property' { $script:hpResult.ServiceStatus | Should -Be 'Running' }
+        It 'Should have FarmRole property' { $script:hpResult.FarmRole | Should -Be 'Primary' }
+        It 'Should have PrimaryServer property' { $script:hpResult.PSObject.Properties.Name | Should -Contain 'PrimaryServer' }
         It 'Should have FederationServiceName property' { $script:hpResult.FederationServiceName | Should -Be 'fs.contoso.com' }
         It 'Should have SslCertExpiry property' { $script:hpResult.SslCertExpiry | Should -Be '2028-01-01 00:00:00' }
         It 'Should have SslCertDaysRemaining property' { $script:hpResult.SslCertDaysRemaining | Should -Be 700 }

--- a/Tests/Public/healthcheck/Get-IISHealth.Tests.ps1
+++ b/Tests/Public/healthcheck/Get-IISHealth.Tests.ps1
@@ -419,14 +419,13 @@ Describe 'Get-IISHealth' {
             }
             Mock -CommandName 'Get-Module' -ModuleName 'PSWinOps' -MockWith { $null } -ParameterFilter { $ListAvailable }
             Mock -CommandName 'Get-CimInstance' -ModuleName 'PSWinOps' -MockWith {
-                @([PSCustomObject]@{ Name = 'TestSite' })
-            } -ParameterFilter { $ClassName -eq 'Site' }
-            Mock -CommandName 'Get-CimInstance' -ModuleName 'PSWinOps' -MockWith {
-                @([PSCustomObject]@{ Name = 'DefaultAppPool' })
-            } -ParameterFilter { $ClassName -eq 'ApplicationPool' }
-            Mock -CommandName 'Get-CimInstance' -ModuleName 'PSWinOps' -MockWith {
-                @([PSCustomObject]@{ SiteName = 'TestSite'; Path = '/'; ApplicationPool = 'DefaultAppPool' })
-            } -ParameterFilter { $ClassName -eq 'Application' }
+                switch ($ClassName) {
+                    'Site'            { @([PSCustomObject]@{ Name = 'TestSite' }) }
+                    'ApplicationPool' { @([PSCustomObject]@{ Name = 'DefaultAppPool' }) }
+                    'Application'     { @([PSCustomObject]@{ SiteName = 'TestSite'; Path = '/'; ApplicationPool = 'DefaultAppPool' }) }
+                    default           { throw "Unexpected CIM class: $ClassName" }
+                }
+            } -ParameterFilter { $Namespace -eq 'root/webadministration' }
             Mock -CommandName 'Invoke-CimMethod' -ModuleName 'PSWinOps' -MockWith {
                 [PSCustomObject]@{ ReturnValue = 1 }
             }
@@ -450,14 +449,11 @@ Describe 'Get-IISHealth' {
             }
             Mock -CommandName 'Get-Module' -ModuleName 'PSWinOps' -MockWith { $null } -ParameterFilter { $ListAvailable }
             Mock -CommandName 'Get-CimInstance' -ModuleName 'PSWinOps' -MockWith {
-                @([PSCustomObject]@{ Name = 'TestSite' })
-            } -ParameterFilter { $ClassName -eq 'Site' }
-            Mock -CommandName 'Get-CimInstance' -ModuleName 'PSWinOps' -MockWith {
-                throw 'ApplicationPool CIM class not available'
-            } -ParameterFilter { $ClassName -eq 'ApplicationPool' }
-            Mock -CommandName 'Get-CimInstance' -ModuleName 'PSWinOps' -MockWith {
-                throw 'Application CIM class not available'
-            } -ParameterFilter { $ClassName -eq 'Application' }
+                switch ($ClassName) {
+                    'Site' { @([PSCustomObject]@{ Name = 'TestSite' }) }
+                    default { throw "$ClassName CIM class not available" }
+                }
+            } -ParameterFilter { $Namespace -eq 'root/webadministration' }
             Mock -CommandName 'Invoke-CimMethod' -ModuleName 'PSWinOps' -MockWith {
                 [PSCustomObject]@{ ReturnValue = 1 }
             }

--- a/Tests/Public/healthcheck/Get-IISHealth.Tests.ps1
+++ b/Tests/Public/healthcheck/Get-IISHealth.Tests.ps1
@@ -436,9 +436,8 @@ Describe 'Get-IISHealth' {
 
         It 'Should return result via CIM fallback' { $script:localCIM | Should -Not -BeNullOrEmpty }
         It 'Should have SiteName from CIM' { $script:localCIM[0].SiteName | Should -Be 'TestSite' }
-        It 'Should resolve AppPoolName via CIM' { $script:localCIM[0].AppPoolName | Should -Be 'DefaultAppPool' }
-        It 'Should resolve AppPoolState via CIM' { $script:localCIM[0].AppPoolState | Should -Be 'Started' }
-        It 'Should return Healthy when pool is Started' { $script:localCIM[0].OverallHealth | Should -Be 'Healthy' }
+        It 'Should resolve AppPoolName via CIM Application mapping' { $script:localCIM[0].AppPoolName | Should -Be 'DefaultAppPool' }
+        It 'Should return Healthy (Unknown states are not penalized)' { $script:localCIM[0].OverallHealth | Should -Be 'Healthy' }
     }
 
     Context 'Local execution - CIM fallback with unknown pool state is not Degraded' {

--- a/Tests/Public/healthcheck/Get-IISHealth.Tests.ps1
+++ b/Tests/Public/healthcheck/Get-IISHealth.Tests.ps1
@@ -420,16 +420,56 @@ Describe 'Get-IISHealth' {
             Mock -CommandName 'Get-Module' -ModuleName 'PSWinOps' -MockWith { $null } -ParameterFilter { $ListAvailable }
             Mock -CommandName 'Get-CimInstance' -ModuleName 'PSWinOps' -MockWith {
                 @([PSCustomObject]@{ Name = 'TestSite' })
-            } -ParameterFilter { $Namespace -eq 'root/webadministration' }
+            } -ParameterFilter { $ClassName -eq 'Site' }
+            Mock -CommandName 'Get-CimInstance' -ModuleName 'PSWinOps' -MockWith {
+                @([PSCustomObject]@{ Name = 'DefaultAppPool' })
+            } -ParameterFilter { $ClassName -eq 'ApplicationPool' }
+            Mock -CommandName 'Get-CimInstance' -ModuleName 'PSWinOps' -MockWith {
+                @([PSCustomObject]@{ SiteName = 'TestSite'; Path = '/'; ApplicationPool = 'DefaultAppPool' })
+            } -ParameterFilter { $ClassName -eq 'Application' }
             Mock -CommandName 'Invoke-CimMethod' -ModuleName 'PSWinOps' -MockWith {
                 [PSCustomObject]@{ ReturnValue = 1 }
             }
+            Mock -CommandName 'Invoke-Command' -ModuleName 'PSWinOps'
 
             $script:localCIM = Get-IISHealth -ComputerName $env:COMPUTERNAME
         }
 
         It 'Should return result via CIM fallback' { $script:localCIM | Should -Not -BeNullOrEmpty }
         It 'Should have SiteName from CIM' { $script:localCIM[0].SiteName | Should -Be 'TestSite' }
+        It 'Should resolve AppPoolName via CIM' { $script:localCIM[0].AppPoolName | Should -Be 'DefaultAppPool' }
+        It 'Should resolve AppPoolState via CIM' { $script:localCIM[0].AppPoolState | Should -Be 'Started' }
+        It 'Should return Healthy when pool is Started' { $script:localCIM[0].OverallHealth | Should -Be 'Healthy' }
+    }
+
+    Context 'Local execution - CIM fallback with unknown pool state is not Degraded' {
+
+        BeforeAll {
+            Mock -CommandName 'Get-Service' -ModuleName 'PSWinOps' -MockWith {
+                [PSCustomObject]@{ Name = 'W3SVC'; Status = 'Running' }
+            }
+            Mock -CommandName 'Get-Module' -ModuleName 'PSWinOps' -MockWith { $null } -ParameterFilter { $ListAvailable }
+            Mock -CommandName 'Get-CimInstance' -ModuleName 'PSWinOps' -MockWith {
+                @([PSCustomObject]@{ Name = 'TestSite' })
+            } -ParameterFilter { $ClassName -eq 'Site' }
+            Mock -CommandName 'Get-CimInstance' -ModuleName 'PSWinOps' -MockWith {
+                throw 'ApplicationPool CIM class not available'
+            } -ParameterFilter { $ClassName -eq 'ApplicationPool' }
+            Mock -CommandName 'Get-CimInstance' -ModuleName 'PSWinOps' -MockWith {
+                throw 'Application CIM class not available'
+            } -ParameterFilter { $ClassName -eq 'Application' }
+            Mock -CommandName 'Invoke-CimMethod' -ModuleName 'PSWinOps' -MockWith {
+                [PSCustomObject]@{ ReturnValue = 1 }
+            }
+            Mock -CommandName 'Invoke-Command' -ModuleName 'PSWinOps'
+
+            $script:localCIMUnknown = Get-IISHealth -ComputerName $env:COMPUTERNAME
+        }
+
+        It 'Should return result' { $script:localCIMUnknown | Should -Not -BeNullOrEmpty }
+        It 'Should set AppPoolName to Unknown' { $script:localCIMUnknown[0].AppPoolName | Should -Be 'Unknown' }
+        It 'Should set AppPoolState to Unknown' { $script:localCIMUnknown[0].AppPoolState | Should -Be 'Unknown' }
+        It 'Should return Healthy (not Degraded) when pool state is Unknown' { $script:localCIMUnknown[0].OverallHealth | Should -Be 'Healthy' }
     }
 
     Context 'Local - Stopped site via WebAdministration (Critical)' {
@@ -681,7 +721,7 @@ Describe 'Get-IISHealth' {
         }
 
         It 'Should set AppPoolState to Unknown' { $script:orphanResult[0].AppPoolState | Should -Be 'Unknown' }
-        It 'Should return Degraded' { $script:orphanResult[0].OverallHealth | Should -Be 'Degraded' }
+        It 'Should return Healthy (Unknown pool state is not penalized)' { $script:orphanResult[0].OverallHealth | Should -Be 'Healthy' }
     }
 
     Context 'Local - IISAdministration module throws' {


### PR DESCRIPTION
- Add 16 new TableControl views (10 healthcheck + 6 general) as default views, keeping existing ListControl accessible via Format-List
- All 51 PSTypeName types now have a TableControl default view

Healthcheck tables: AdDomainControllerHealth, ClusterHealth, HyperVHostHealth, CertificateAuthorityHealth, WSUSHealth, FileServerHealth, ADFSHealth, RDSHealth, PrintServerHealth, DnsServerHealth

General tables: NtpConfiguration, SystemSummary, ProxyConfiguration, SubnetInfo, NetworkConfig, PageFileConfiguration

fix(healthcheck): multiple bug fixes

- Get-AdDomainControllerHealth: remove /q from dcdiag (was hiding passed tests, showing 0/0 instead of 5/0)
- Get-ADFSHealth: detect WID secondary node (PS0033), add FarmRole and PrimaryServer properties, do not penalize secondary for 0 RPs
- Get-IISHealth: enrich CIM fallback with ApplicationPool/Application queries, Unknown AppPoolState no longer triggers Degraded
- Get-CertificateAuthorityHealth: fix CAType double-dash parsing, fix NotAfter regex (handle space), add Cert Expires fallback

test: update tests for ADFS, IIS, CA changes

- Add secondary WID node test contexts (local + remote)
- Add CIM fallback app pool resolution tests
- Update mock data with FarmRole/PrimaryServer
- Fix orphan pool test expectation (Healthy not Degraded)