### PR TITLE
refactor: move OverallHealth computation to process{} block

### DIFF
--- a/Public/healthcheck/Get-DfsNamespaceHealth.ps1
+++ b/Public/healthcheck/Get-DfsNamespaceHealth.ps1
@@ -71,7 +71,6 @@ function Get-DfsNamespaceHealth {
         Write-Verbose -Message "[$($MyInvocation.MyCommand)] Starting"
 
         $scriptBlock = {
-            $timestamp = Get-Date -Format 'o'
             $resultList = [System.Collections.Generic.List[object]]::new()
 
             # Step 1 - Check DFS service
@@ -90,28 +89,15 @@ function Get-DfsNamespaceHealth {
             }
 
             if (-not $dfsnAvailable) {
-                $health = if ($svcStatus -eq 'Running') {
-                    'RoleUnavailable'
-                }
-                elseif ($svcStatus -eq 'NotFound') {
-                    'RoleUnavailable'
-                }
-                else {
-                    'Critical'
-                }
-
-                $resultList.Add([PSCustomObject]@{
-                    PSTypeName     = 'PSWinOps.DfsNamespaceHealth'
-                    ComputerName   = $env:COMPUTERNAME
-                    ServiceName    = 'Dfs'
+                $resultList.Add(@{
                     ServiceStatus  = $svcStatus
                     RootPath       = 'N/A'
                     RootType       = 'N/A'
                     State          = 'N/A'
                     TargetCount    = 0
                     HealthyTargets = 0
-                    OverallHealth  = $health
-                    Timestamp      = $timestamp
+                    DfsnAvailable  = $false
+                    QueryError     = $false
                 })
                 return $resultList.ToArray()
             }
@@ -122,35 +108,29 @@ function Get-DfsNamespaceHealth {
                 $dfsRoots = @(Get-DfsnRoot -ErrorAction Stop)
             }
             catch {
-                $resultList.Add([PSCustomObject]@{
-                    PSTypeName     = 'PSWinOps.DfsNamespaceHealth'
-                    ComputerName   = $env:COMPUTERNAME
-                    ServiceName    = 'Dfs'
+                $resultList.Add(@{
                     ServiceStatus  = $svcStatus
                     RootPath       = 'N/A'
                     RootType       = 'N/A'
                     State          = 'N/A'
                     TargetCount    = 0
                     HealthyTargets = 0
-                    OverallHealth  = 'Critical'
-                    Timestamp      = $timestamp
+                    DfsnAvailable  = $true
+                    QueryError     = $true
                 })
                 return $resultList.ToArray()
             }
 
             if ($dfsRoots.Count -eq 0) {
-                $resultList.Add([PSCustomObject]@{
-                    PSTypeName     = 'PSWinOps.DfsNamespaceHealth'
-                    ComputerName   = $env:COMPUTERNAME
-                    ServiceName    = 'Dfs'
+                $resultList.Add(@{
                     ServiceStatus  = $svcStatus
                     RootPath       = 'N/A'
                     RootType       = 'N/A'
                     State          = 'N/A'
                     TargetCount    = 0
                     HealthyTargets = 0
-                    OverallHealth  = 'Healthy'
-                    Timestamp      = $timestamp
+                    DfsnAvailable  = $true
+                    QueryError     = $false
                 })
                 return $resultList.ToArray()
             }
@@ -176,31 +156,15 @@ function Get-DfsNamespaceHealth {
                     $targetHealthy = 0
                 }
 
-                $rootHealth = if ($targetTotal -eq 0) {
-                    'Critical'
-                }
-                elseif ($targetHealthy -eq 0) {
-                    'Critical'
-                }
-                elseif ($targetHealthy -lt $targetTotal) {
-                    'Degraded'
-                }
-                else {
-                    'Healthy'
-                }
-
-                $resultList.Add([PSCustomObject]@{
-                    PSTypeName     = 'PSWinOps.DfsNamespaceHealth'
-                    ComputerName   = $env:COMPUTERNAME
-                    ServiceName    = 'Dfs'
+                $resultList.Add(@{
                     ServiceStatus  = $svcStatus
                     RootPath       = $root.Path
                     RootType       = $rootType
                     State          = $rootState
                     TargetCount    = $targetTotal
                     HealthyTargets = $targetHealthy
-                    OverallHealth  = $rootHealth
-                    Timestamp      = $timestamp
+                    DfsnAvailable  = $true
+                    QueryError     = $false
                 })
             }
 
@@ -216,9 +180,45 @@ function Get-DfsNamespaceHealth {
                 $rawResults = Invoke-RemoteOrLocal -ComputerName $machine -ScriptBlock $scriptBlock -Credential $Credential
 
                 foreach ($item in $rawResults) {
-                    $item.PSObject.TypeNames.Insert(0, 'PSWinOps.DfsNamespaceHealth')
-                    $item.ComputerName = $displayName
-                    $item
+                    # Compute OverallHealth outside the scriptblock
+                    $healthStatus = if ($item.ServiceStatus -eq 'NotFound') {
+                        'RoleUnavailable'
+                    }
+                    elseif ($item.ServiceStatus -ne 'Running') {
+                        'Critical'
+                    }
+                    elseif (-not $item.DfsnAvailable) {
+                        'RoleUnavailable'
+                    }
+                    elseif ($item.QueryError) {
+                        'Critical'
+                    }
+                    elseif ($item.RootPath -eq 'N/A') {
+                        'Healthy'
+                    }
+                    elseif ($item.TargetCount -eq 0 -or $item.HealthyTargets -eq 0) {
+                        'Critical'
+                    }
+                    elseif ($item.HealthyTargets -lt $item.TargetCount) {
+                        'Degraded'
+                    }
+                    else {
+                        'Healthy'
+                    }
+
+                    [PSCustomObject]@{
+                        PSTypeName     = 'PSWinOps.DfsNamespaceHealth'
+                        ComputerName   = $displayName
+                        ServiceName    = 'Dfs'
+                        ServiceStatus  = $item.ServiceStatus
+                        RootPath       = $item.RootPath
+                        RootType       = $item.RootType
+                        State          = $item.State
+                        TargetCount    = [int]$item.TargetCount
+                        HealthyTargets = [int]$item.HealthyTargets
+                        OverallHealth  = $healthStatus
+                        Timestamp      = Get-Date -Format 'o'
+                    }
                 }
             }
             catch {

--- a/Public/healthcheck/Get-DfsReplicationHealth.ps1
+++ b/Public/healthcheck/Get-DfsReplicationHealth.ps1
@@ -99,7 +99,6 @@ function Get-DfsReplicationHealth {
                     ReplicatedFolderName = 'N/A'
                     State                = 'N/A'
                     CurrentConflictSize  = [long]0
-                    OverallHealth        = 'RoleUnavailable'
                 })
             }
             else {
@@ -116,15 +115,6 @@ function Get-DfsReplicationHealth {
                         default { "Unknown ($stateValue)" }
                     }
 
-                    $health = if ($serviceStatus -ne 'Running' -or $stateText -eq 'In Error') {
-                        'Critical'
-                    }
-                    elseif ($stateText -ne 'Normal') {
-                        'Degraded'
-                    }
-                    else {
-                        'Healthy'
-                    }
 
                     $conflictSize = if ($null -ne $folder.CurrentConflictSizeInMb) {
                         [long]$folder.CurrentConflictSizeInMb
@@ -139,7 +129,6 @@ function Get-DfsReplicationHealth {
                         ReplicatedFolderName = $folder.ReplicatedFolderName
                         State                = $stateText
                         CurrentConflictSize  = $conflictSize
-                        OverallHealth        = $health
                     })
                 }
             }
@@ -163,6 +152,20 @@ function Get-DfsReplicationHealth {
                 }
 
                 foreach ($entry in $rawResults) {
+                    # Compute OverallHealth outside the scriptblock
+                    $healthStatus = if ($entry.State -eq 'N/A') {
+                        'RoleUnavailable'
+                    }
+                    elseif ($entry.ServiceStatus -ne 'Running' -or $entry.State -eq 'In Error') {
+                        'Critical'
+                    }
+                    elseif ($entry.State -ne 'Normal') {
+                        'Degraded'
+                    }
+                    else {
+                        'Healthy'
+                    }
+
                     [PSCustomObject]@{
                         PSTypeName           = 'PSWinOps.DfsReplicationHealth'
                         ComputerName         = $displayName
@@ -172,7 +175,7 @@ function Get-DfsReplicationHealth {
                         ReplicatedFolderName = $entry.ReplicatedFolderName
                         State                = $entry.State
                         CurrentConflictSize  = $entry.CurrentConflictSize
-                        OverallHealth        = $entry.OverallHealth
+                        OverallHealth        = $healthStatus
                         Timestamp            = Get-Date -Format 'o'
                     }
                 }

--- a/Public/healthcheck/Get-IISHealth.ps1
+++ b/Public/healthcheck/Get-IISHealth.ps1
@@ -88,7 +88,6 @@ function Get-IISHealth {
                     PhysicalPath  = 'N/A'
                     AppPoolName   = 'N/A'
                     AppPoolState  = 'N/A'
-                    OverallHealth = 'RoleUnavailable'
                 })
                 return $siteResults
             }
@@ -244,8 +243,7 @@ function Get-IISHealth {
                         PhysicalPath  = 'N/A'
                         AppPoolName   = 'N/A'
                         AppPoolState  = 'N/A'
-                        OverallHealth = 'RoleUnavailable'
-                    })
+                        })
                     return $siteResults
                 }
             }
@@ -260,15 +258,10 @@ function Get-IISHealth {
                     PhysicalPath  = 'N/A'
                     AppPoolName   = 'N/A'
                     AppPoolState  = 'N/A'
-                    OverallHealth = if ($w3svcStatus -ne 'Running') { 'Critical' } else { 'Healthy' }
                 })
             }
             else {
                 foreach ($siteInfo in $sitesData) {
-                    $health = if ($w3svcStatus -ne 'Running') { 'Critical' }
-                    elseif ($siteInfo.SiteState -notin @('Started', 'Unknown')) { 'Critical' }
-                    elseif ($siteInfo.AppPoolState -notin @('Started', 'Unknown')) { 'Degraded' }
-                    else { 'Healthy' }
 
                     $siteResults.Add(@{
                         ServiceStatus = $w3svcStatus
@@ -278,7 +271,6 @@ function Get-IISHealth {
                         PhysicalPath  = $siteInfo.PhysicalPath
                         AppPoolName   = $siteInfo.AppPoolName
                         AppPoolState  = $siteInfo.AppPoolState
-                        OverallHealth = $health
                     })
                 }
             }
@@ -296,6 +288,29 @@ function Get-IISHealth {
                 $rawResults = Invoke-RemoteOrLocal -ComputerName $machine -ScriptBlock $scriptBlock -Credential $Credential
 
                 foreach ($entry in $rawResults) {
+                    # Compute OverallHealth outside the scriptblock
+                    $healthStatus = if ($entry.ServiceStatus -eq 'NotInstalled') {
+                        'RoleUnavailable'
+                    }
+                    elseif ($entry.SiteName -eq 'N/A') {
+                        'RoleUnavailable'
+                    }
+                    elseif ($entry.SiteName -eq 'NoSitesFound') {
+                        if ($entry.ServiceStatus -ne 'Running') { 'Critical' } else { 'Healthy' }
+                    }
+                    elseif ($entry.ServiceStatus -ne 'Running') {
+                        'Critical'
+                    }
+                    elseif ($entry.SiteState -notin @('Started', 'Unknown')) {
+                        'Critical'
+                    }
+                    elseif ($entry.AppPoolState -notin @('Started', 'Unknown')) {
+                        'Degraded'
+                    }
+                    else {
+                        'Healthy'
+                    }
+
                     [PSCustomObject]@{
                         PSTypeName    = 'PSWinOps.IISHealth'
                         ComputerName  = $displayName
@@ -307,7 +322,7 @@ function Get-IISHealth {
                         PhysicalPath  = $entry.PhysicalPath
                         AppPoolName   = $entry.AppPoolName
                         AppPoolState  = $entry.AppPoolState
-                        OverallHealth = $entry.OverallHealth
+                        OverallHealth = $healthStatus
                         Timestamp     = Get-Date -Format 'o'
                     }
                 }

--- a/Tests/Public/healthcheck/Get-DfsNamespaceHealth.Tests.ps1
+++ b/Tests/Public/healthcheck/Get-DfsNamespaceHealth.Tests.ps1
@@ -52,18 +52,15 @@ Describe 'Get-DfsNamespaceHealth' {
         )
 
         $script:mockRemoteResult = @(
-            [PSCustomObject]@{
-                PSTypeName     = 'PSWinOps.DfsNamespaceHealth'
-                ComputerName   = 'SRV01'
-                ServiceName    = 'Dfs'
+            @{
                 ServiceStatus  = 'Running'
                 RootPath       = '\\contoso.com\Share'
                 RootType       = 'DomainV2'
                 State          = 'Online'
                 TargetCount    = 2
                 HealthyTargets = 2
-                OverallHealth  = 'Healthy'
-                Timestamp      = '2026-03-26T12:00:00.0000000+00:00'
+                DfsnAvailable  = $true
+                QueryError     = $false
             }
         )
     }


### PR DESCRIPTION
DfsNamespaceHealth, DfsReplicationHealth, and IISHealth previously computed OverallHealth inside the remote scriptblock. This caused inconsistent health assessment between local and remote execution.

Now all 15 healthcheck functions follow the same pattern:
- scriptblock returns raw data (hashtables without OverallHealth)
- process{} computes OverallHealth from the raw data

For DfsNamespaceHealth, added DfsnAvailable and QueryError metadata fields to the scriptblock output so process{} can distinguish RoleUnavailable, Critical, and Healthy edge cases.

Updated DfsNamespaceHealth test mock data accordingly.