### PR TITLE
fix: misc cleanup — synopsis, #Requires, module-scoped local names

### DIFF
--- a/PSWinOps.psm1
+++ b/PSWinOps.psm1
@@ -17,6 +17,9 @@ if ($PSEdition -eq 'Core' -and -not $IsWindows) {
 # Get module root path
 $script:ModuleRoot = $PSScriptRoot
 
+# Module-scoped list of names that identify the local machine
+$script:LocalComputerNames = @($env:COMPUTERNAME, 'localhost', '.')
+
 Write-Verbose "[$($MyInvocation.MyCommand)] Loading PSWinOps module from: $script:ModuleRoot"
 
 # Import Private functions

--- a/Private/Invoke-RemoteOrLocal.ps1
+++ b/Private/Invoke-RemoteOrLocal.ps1
@@ -79,9 +79,7 @@ function Invoke-RemoteOrLocal {
         $Credential = [System.Management.Automation.PSCredential]::Empty
     )
 
-    $localNames = @($env:COMPUTERNAME, 'localhost', '.')
-
-    if ($localNames -contains $ComputerName) {
+    if ($script:LocalComputerNames -contains $ComputerName) {
         Write-Verbose -Message "[Invoke-RemoteOrLocal] Executing locally on '$ComputerName'"
         if ($ArgumentList) {
             return & $ScriptBlock @ArgumentList

--- a/Public/network/Get-NetworkConnection.ps1
+++ b/Public/network/Get-NetworkConnection.ps1
@@ -45,27 +45,27 @@ function Get-NetworkConnection {
             Filter by owning process name. Supports wildcards.
 
         .EXAMPLE
-            Get-NetworkStatistic
+            Get-NetworkConnection
 
             Returns all TCP and UDP connections on the local machine.
 
         .EXAMPLE
-            Get-NetworkStatistic -Protocol TCP -State Established
+            Get-NetworkConnection -Protocol TCP -State Established
 
             Returns only established TCP connections on the local machine.
 
         .EXAMPLE
-            Get-NetworkStatistic -ComputerName 'SRV01', 'SRV02' -Protocol TCP -State Listen
+            Get-NetworkConnection -ComputerName 'SRV01', 'SRV02' -Protocol TCP -State Listen
 
             Returns listening TCP connections on two remote servers.
 
         .EXAMPLE
-            Get-NetworkStatistic -ProcessName 'svchost' -LocalPort 443
+            Get-NetworkConnection -ProcessName 'svchost' -LocalPort 443
 
             Returns connections on local port 443 owned by svchost.
 
         .EXAMPLE
-            'SRV01', 'SRV02' | Get-NetworkStatistic -Credential (Get-Credential) -Protocol TCP
+            'SRV01', 'SRV02' | Get-NetworkConnection -Credential (Get-Credential) -Protocol TCP
 
             Queries multiple servers via pipeline with explicit credentials.
 

--- a/Public/network/Get-PublicIPAddress.ps1
+++ b/Public/network/Get-PublicIPAddress.ps1
@@ -1,4 +1,6 @@
-﻿function Get-PublicIPAddress {
+﻿#Requires -Version 5.1
+
+function Get-PublicIPAddress {
     <#
         .SYNOPSIS
             Retrieves the public IP address of the local or remote computer


### PR DESCRIPTION
- Get-NetworkConnection: fix copy-paste in .EXAMPLE blocks (Get-NetworkStatistic → Get-NetworkConnection)
- Get-PublicIPAddress: add missing #Requires -Version 5.1
- PSWinOps.psm1: define $script:LocalComputerNames once
- Invoke-RemoteOrLocal: use $script:LocalComputerNames instead of inline $localNames array