### PR TITLE
feat: add Get-ExchangeServerHealth healthcheck function

### DIFF
--- a/PSWinOps.Format.ps1xml
+++ b/PSWinOps.Format.ps1xml
@@ -2407,5 +2407,92 @@
       </TableControl>
     </View>
 
+    <!-- ============================================================ -->
+    <!-- PSWinOps.ExchangeServerHealth (Table — default)              -->
+    <!-- Used by: Get-ExchangeServerHealth                            -->
+    <!-- ============================================================ -->
+    <View>
+      <Name>PSWinOps.ExchangeServerHealth.Table</Name>
+      <ViewSelectedBy>
+        <TypeName>PSWinOps.ExchangeServerHealth</TypeName>
+      </ViewSelectedBy>
+      <TableControl>
+        <TableHeaders>
+          <TableColumnHeader><Label>ComputerName</Label><Width>16</Width></TableColumnHeader>
+          <TableColumnHeader><Label>Transport</Label><Width>10</Width></TableColumnHeader>
+          <TableColumnHeader><Label>IS</Label><Width>10</Width></TableColumnHeader>
+          <TableColumnHeader><Label>DBs</Label><Width>4</Width><Alignment>Right</Alignment></TableColumnHeader>
+          <TableColumnHeader><Label>Mounted</Label><Width>8</Width><Alignment>Right</Alignment></TableColumnHeader>
+          <TableColumnHeader><Label>Queues</Label><Width>7</Width><Alignment>Right</Alignment></TableColumnHeader>
+          <TableColumnHeader><Label>MaxQ</Label><Width>6</Width><Alignment>Right</Alignment></TableColumnHeader>
+          <TableColumnHeader><Label>DAGOk</Label><Width>6</Width><Alignment>Right</Alignment></TableColumnHeader>
+          <TableColumnHeader><Label>Certs</Label><Width>6</Width><Alignment>Right</Alignment></TableColumnHeader>
+          <TableColumnHeader><Label>Health</Label><Width>16</Width></TableColumnHeader>
+        </TableHeaders>
+        <TableRowEntries>
+          <TableRowEntry>
+            <TableColumnItems>
+              <TableColumnItem><PropertyName>ComputerName</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>TransportStatus</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>InformationStoreStatus</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>TotalDatabases</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>MountedDatabases</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>TotalQueueMessages</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>HighestQueueLength</PropertyName></TableColumnItem>
+              <TableColumnItem>
+                <ScriptBlock>'{0}/{1}' -f $_.DAGCopiesHealthy, $_.DAGCopiesTotal</ScriptBlock>
+              </TableColumnItem>
+              <TableColumnItem>
+                <ScriptBlock>
+                  if ($_.CertificatesExpired -gt 0) { '{0} EXP' -f $_.CertificatesExpired }
+                  elseif ($_.CertificatesExpiringSoon -gt 0) { '{0} WARN' -f $_.CertificatesExpiringSoon }
+                  else { 'OK' }
+                </ScriptBlock>
+              </TableColumnItem>
+              <TableColumnItem><PropertyName>OverallHealth</PropertyName></TableColumnItem>
+            </TableColumnItems>
+          </TableRowEntry>
+        </TableRowEntries>
+      </TableControl>
+    </View>
+
+    <!-- ============================================================ -->
+    <!-- PSWinOps.ExchangeServerHealth (List — Format-List)           -->
+    <!-- Used by: Get-ExchangeServerHealth                            -->
+    <!-- ============================================================ -->
+    <View>
+      <Name>PSWinOps.ExchangeServerHealth</Name>
+      <ViewSelectedBy>
+        <TypeName>PSWinOps.ExchangeServerHealth</TypeName>
+      </ViewSelectedBy>
+      <ListControl>
+        <ListEntries>
+          <ListEntry>
+            <ListItems>
+              <ListItem><Label>ComputerName</Label><PropertyName>ComputerName</PropertyName></ListItem>
+              <ListItem><Label>TransportStatus</Label><PropertyName>TransportStatus</PropertyName></ListItem>
+              <ListItem><Label>InformationStoreStatus</Label><PropertyName>InformationStoreStatus</PropertyName></ListItem>
+              <ListItem><Label>ADTopologyStatus</Label><PropertyName>ADTopologyStatus</PropertyName></ListItem>
+              <ListItem><Label>ServiceHostStatus</Label><PropertyName>ServiceHostStatus</PropertyName></ListItem>
+              <ListItem><Label>TotalDatabases</Label><PropertyName>TotalDatabases</PropertyName></ListItem>
+              <ListItem><Label>MountedDatabases</Label><PropertyName>MountedDatabases</PropertyName></ListItem>
+              <ListItem><Label>DismountedDatabases</Label><PropertyName>DismountedDatabases</PropertyName></ListItem>
+              <ListItem><Label>TotalQueues</Label><PropertyName>TotalQueues</PropertyName></ListItem>
+              <ListItem><Label>TotalQueueMessages</Label><PropertyName>TotalQueueMessages</PropertyName></ListItem>
+              <ListItem><Label>HighestQueueLength</Label><PropertyName>HighestQueueLength</PropertyName></ListItem>
+              <ListItem><Label>DAGCopiesTotal</Label><PropertyName>DAGCopiesTotal</PropertyName></ListItem>
+              <ListItem><Label>DAGCopiesHealthy</Label><PropertyName>DAGCopiesHealthy</PropertyName></ListItem>
+              <ListItem><Label>DAGCopiesUnhealthy</Label><PropertyName>DAGCopiesUnhealthy</PropertyName></ListItem>
+              <ListItem><Label>CertificatesTotal</Label><PropertyName>CertificatesTotal</PropertyName></ListItem>
+              <ListItem><Label>CertificatesExpiringSoon</Label><PropertyName>CertificatesExpiringSoon</PropertyName></ListItem>
+              <ListItem><Label>CertificatesExpired</Label><PropertyName>CertificatesExpired</PropertyName></ListItem>
+              <ListItem><Label>OverallHealth</Label><PropertyName>OverallHealth</PropertyName></ListItem>
+              <ListItem><Label>Timestamp</Label><PropertyName>Timestamp</PropertyName></ListItem>
+            </ListItems>
+          </ListEntry>
+        </ListEntries>
+      </ListControl>
+    </View>
+
   </ViewDefinitions>
 </Configuration>

--- a/PSWinOps.psd1
+++ b/PSWinOps.psd1
@@ -74,7 +74,7 @@
     'Get-ADFSHealth', 'Get-CertificateAuthorityHealth',
     'Get-ClusterHealth', 'Get-DfsNamespaceHealth',
     'Get-DfsReplicationHealth', 'Get-DhcpServerHealth',
-    'Get-DnsServerHealth', 'Get-FileServerHealth', 'Get-HyperVHostHealth',
+    'Get-DnsServerHealth', 'Get-ExchangeServerHealth', 'Get-FileServerHealth', 'Get-HyperVHostHealth',
     'Get-IISHealth', 'Get-PrintServerHealth', 'Get-RDSHealth',
     'Get-ServiceHealth', 'Get-WSUSHealth', 'Connect-RdpSession',
     'Disconnect-RdpSession', 'Get-RdpSession', 'Get-RdpSessionHistory',

--- a/Public/healthcheck/Get-ExchangeServerHealth.ps1
+++ b/Public/healthcheck/Get-ExchangeServerHealth.ps1
@@ -1,0 +1,259 @@
+#Requires -Version 5.1
+function Get-ExchangeServerHealth {
+    <#
+        .SYNOPSIS
+            Checks Exchange Server health on Windows servers
+
+        .DESCRIPTION
+            Retrieves comprehensive Exchange Server health information including service status,
+            mailbox database mount status, mail queue lengths, DAG database copy health,
+            and certificate expiry. Returns a single typed object per server with an overall
+            health assessment suitable for dashboards and alerting pipelines.
+
+        .PARAMETER ComputerName
+            One or more computer names to query. Defaults to the local machine.
+            Accepts pipeline input by value and by property name.
+
+        .PARAMETER Credential
+            Optional PSCredential for authenticating to remote computers.
+            Not used for local queries.
+
+        .PARAMETER QueueWarningThreshold
+            Number of messages in a single queue that triggers a Degraded health status.
+            Defaults to 100.
+
+        .PARAMETER QueueCriticalThreshold
+            Number of messages in a single queue that triggers a Critical health status.
+            Defaults to 500.
+
+        .PARAMETER CertificateWarningDays
+            Number of days before certificate expiry that triggers a Degraded health status.
+            Defaults to 30.
+
+        .EXAMPLE
+            Get-ExchangeServerHealth
+
+            Checks Exchange Server health on the local machine using default thresholds.
+
+        .EXAMPLE
+            Get-ExchangeServerHealth -ComputerName 'EX01' -QueueWarningThreshold 50
+
+            Checks Exchange Server health on a single remote server with a custom queue warning threshold.
+
+        .EXAMPLE
+            'EX01', 'EX02' | Get-ExchangeServerHealth -Credential (Get-Credential)
+
+            Checks Exchange Server health on multiple remote servers via pipeline with alternate credentials.
+
+        .OUTPUTS
+            PSWinOps.ExchangeServerHealth
+            Returns one object per server with Exchange service statuses, database counts,
+            queue metrics, DAG copy health, certificate expiry counts, and overall health.
+
+        .NOTES
+            Author: Franck SALLET
+            Version: 1.0.0
+            Last Modified: 2026-04-01
+            Requires: PowerShell 5.1+ / Windows only
+            Requires: Exchange Server 2016+ Management Tools
+
+        .LINK
+            https://github.com/k9fr4n/PSWinOps
+
+        .LINK
+            https://learn.microsoft.com/en-us/powershell/exchange/exchange-management-shell
+    #>
+    [CmdletBinding()]
+    [OutputType('PSWinOps.ExchangeServerHealth')]
+    param(
+        [Parameter(Mandatory = $false, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [ValidateNotNullOrEmpty()]
+        [Alias('CN', 'Name', 'DNSHostName')]
+        [string[]]$ComputerName = $env:COMPUTERNAME,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateNotNull()]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential = [System.Management.Automation.PSCredential]::Empty,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateRange(1, 10000)]
+        [int]$QueueWarningThreshold = 100,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateRange(1, 100000)]
+        [int]$QueueCriticalThreshold = 500,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateRange(1, 365)]
+        [int]$CertificateWarningDays = 30
+    )
+
+    begin {
+        Write-Verbose -Message "[$($MyInvocation.MyCommand)] Starting"
+
+        $scriptBlock = {
+            param($queueWarn, $queueCrit, $certWarnDays)
+
+            $data = @{
+                TransportStatus          = 'NotFound'
+                InformationStoreStatus   = 'NotFound'
+                ADTopologyStatus         = 'NotFound'
+                ServiceHostStatus        = 'NotFound'
+                SnapinAvailable          = $false
+                TotalDatabases           = 0
+                MountedDatabases         = 0
+                DismountedDatabases      = 0
+                TotalQueues              = 0
+                TotalQueueMessages       = 0
+                HighestQueueLength       = 0
+                DAGCopiesTotal           = 0
+                DAGCopiesHealthy         = 0
+                DAGCopiesUnhealthy       = 0
+                CertificatesTotal        = 0
+                CertificatesExpiringSoon = 0
+                CertificatesExpired      = 0
+            }
+
+            # Check Exchange services
+            $exchangeServices = @{
+                'MSExchangeTransport'   = 'TransportStatus'
+                'MSExchangeIS'          = 'InformationStoreStatus'
+                'MSExchangeADTopology'  = 'ADTopologyStatus'
+                'MSExchangeServiceHost' = 'ServiceHostStatus'
+            }
+            foreach ($svcName in $exchangeServices.Keys) {
+                $svc = Get-Service -Name $svcName -ErrorAction SilentlyContinue
+                if ($svc) {
+                    $data[$exchangeServices[$svcName]] = $svc.Status.ToString()
+                }
+            }
+
+            # Try loading Exchange Management Shell
+            try {
+                Add-PSSnapin -Name 'Microsoft.Exchange.Management.PowerShell.SnapIn' -ErrorAction Stop
+                $data.SnapinAvailable = $true
+            }
+            catch {
+                try {
+                    Import-Module -Name 'ExchangeManagementShell' -ErrorAction Stop
+                    $data.SnapinAvailable = $true
+                }
+                catch {
+                    $data.SnapinAvailable = $false
+                }
+            }
+
+            if ($data.SnapinAvailable) {
+                # Mailbox databases
+                $databases = Get-MailboxDatabase -Status -ErrorAction SilentlyContinue
+                if ($databases) {
+                    $data.TotalDatabases     = @($databases).Count
+                    $data.MountedDatabases   = @($databases | Where-Object { $_.Mounted -eq $true }).Count
+                    $data.DismountedDatabases = $data.TotalDatabases - $data.MountedDatabases
+                }
+
+                # Mail queues
+                $queues = Get-Queue -ErrorAction SilentlyContinue
+                if ($queues) {
+                    $data.TotalQueues        = @($queues).Count
+                    $data.TotalQueueMessages = ($queues | Measure-Object -Property MessageCount -Sum).Sum
+                    $data.HighestQueueLength = ($queues | Measure-Object -Property MessageCount -Maximum).Maximum
+                }
+
+                # DAG database copy status
+                $copies = Get-MailboxDatabaseCopyStatus -ErrorAction SilentlyContinue
+                if ($copies) {
+                    $data.DAGCopiesTotal     = @($copies).Count
+                    $healthyCopyStatuses     = @('Mounted', 'Healthy')
+                    $data.DAGCopiesHealthy   = @($copies | Where-Object { $_.Status -in $healthyCopyStatuses }).Count
+                    $data.DAGCopiesUnhealthy = $data.DAGCopiesTotal - $data.DAGCopiesHealthy
+                }
+
+                # Exchange certificates
+                $certs = Get-ExchangeCertificate -ErrorAction SilentlyContinue
+                if ($certs) {
+                    $now = Get-Date
+                    $data.CertificatesTotal       = @($certs).Count
+                    $data.CertificatesExpired     = @($certs | Where-Object { $_.NotAfter -lt $now }).Count
+                    $data.CertificatesExpiringSoon = @($certs | Where-Object {
+                        $_.NotAfter -ge $now -and $_.NotAfter -lt $now.AddDays($certWarnDays)
+                    }).Count
+                }
+            }
+
+            $data
+        }
+    }
+
+    process {
+        foreach ($machine in $ComputerName) {
+            $displayName = $machine.ToUpper()
+            Write-Verbose -Message "[$($MyInvocation.MyCommand)] Querying '${machine}'"
+
+            try {
+                $result = Invoke-RemoteOrLocal -ComputerName $machine -ScriptBlock $scriptBlock `
+                    -Credential $Credential `
+                    -ArgumentList @($QueueWarningThreshold, $QueueCriticalThreshold, $CertificateWarningDays)
+
+                # Compute OverallHealth outside the scriptblock
+                if (-not $result.SnapinAvailable) {
+                    $healthStatus = 'RoleUnavailable'
+                }
+                elseif (
+                    $result.TransportStatus -ne 'Running' -or
+                    $result.InformationStoreStatus -ne 'Running' -or
+                    $result.DismountedDatabases -gt 0 -or
+                    $result.HighestQueueLength -ge $QueueCriticalThreshold
+                ) {
+                    $healthStatus = 'Critical'
+                }
+                elseif (
+                    $result.HighestQueueLength -ge $QueueWarningThreshold -or
+                    $result.DAGCopiesUnhealthy -gt 0 -or
+                    $result.CertificatesExpiringSoon -gt 0 -or
+                    $result.CertificatesExpired -gt 0 -or
+                    $result.ADTopologyStatus -ne 'Running' -or
+                    $result.ServiceHostStatus -ne 'Running'
+                ) {
+                    $healthStatus = 'Degraded'
+                }
+                else {
+                    $healthStatus = 'Healthy'
+                }
+
+                [PSCustomObject]@{
+                    PSTypeName               = 'PSWinOps.ExchangeServerHealth'
+                    ComputerName             = $displayName
+                    TransportStatus          = $result.TransportStatus
+                    InformationStoreStatus   = $result.InformationStoreStatus
+                    ADTopologyStatus         = $result.ADTopologyStatus
+                    ServiceHostStatus        = $result.ServiceHostStatus
+                    TotalDatabases           = [int]$result.TotalDatabases
+                    MountedDatabases         = [int]$result.MountedDatabases
+                    DismountedDatabases      = [int]$result.DismountedDatabases
+                    TotalQueues              = [int]$result.TotalQueues
+                    TotalQueueMessages       = [int]$result.TotalQueueMessages
+                    HighestQueueLength       = [int]$result.HighestQueueLength
+                    DAGCopiesTotal           = [int]$result.DAGCopiesTotal
+                    DAGCopiesHealthy         = [int]$result.DAGCopiesHealthy
+                    DAGCopiesUnhealthy       = [int]$result.DAGCopiesUnhealthy
+                    CertificatesTotal        = [int]$result.CertificatesTotal
+                    CertificatesExpiringSoon = [int]$result.CertificatesExpiringSoon
+                    CertificatesExpired      = [int]$result.CertificatesExpired
+                    OverallHealth            = $healthStatus
+                    Timestamp                = Get-Date -Format 'o'
+                }
+            }
+            catch {
+                Write-Error -Message "[$($MyInvocation.MyCommand)] Failed on '${machine}': $_"
+                continue
+            }
+        }
+    }
+
+    end {
+        Write-Verbose -Message "[$($MyInvocation.MyCommand)] Completed"
+    }
+}

--- a/Public/healthcheck/Get-ExchangeServerHealth.ps1
+++ b/Public/healthcheck/Get-ExchangeServerHealth.ps1
@@ -94,7 +94,7 @@ function Get-ExchangeServerHealth {
         Write-Verbose -Message "[$($MyInvocation.MyCommand)] Starting"
 
         $scriptBlock = {
-            param($queueWarn, $queueCrit, $certWarnDays)
+            param($certWarnDays)
 
             $data = @{
                 TransportStatus          = 'NotFound'
@@ -195,7 +195,7 @@ function Get-ExchangeServerHealth {
             try {
                 $result = Invoke-RemoteOrLocal -ComputerName $machine -ScriptBlock $scriptBlock `
                     -Credential $Credential `
-                    -ArgumentList @($QueueWarningThreshold, $QueueCriticalThreshold, $CertificateWarningDays)
+                    -ArgumentList @($CertificateWarningDays)
 
                 # Compute OverallHealth outside the scriptblock
                 if (-not $result.SnapinAvailable) {

--- a/Tests/Public/healthcheck/Get-ExchangeServerHealth.Tests.ps1
+++ b/Tests/Public/healthcheck/Get-ExchangeServerHealth.Tests.ps1
@@ -1,0 +1,394 @@
+#Requires -Version 5.1
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+BeforeAll {
+    $script:modulePath = Split-Path -Path (Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent) -Parent
+    Import-Module -Name (Join-Path -Path $script:modulePath -ChildPath 'PSWinOps.psd1') -Force
+
+    # Stub Exchange cmdlets not available on CI runner
+    if (-not (Get-Command -Name 'Add-PSSnapin' -ErrorAction SilentlyContinue)) {
+        function global:Add-PSSnapin { param($Name) }
+    }
+    if (-not (Get-Command -Name 'Get-MailboxDatabase' -ErrorAction SilentlyContinue)) {
+        function global:Get-MailboxDatabase { param([switch]$Status) }
+    }
+    if (-not (Get-Command -Name 'Get-Queue' -ErrorAction SilentlyContinue)) {
+        function global:Get-Queue { }
+    }
+    if (-not (Get-Command -Name 'Get-MailboxDatabaseCopyStatus' -ErrorAction SilentlyContinue)) {
+        function global:Get-MailboxDatabaseCopyStatus { }
+    }
+    if (-not (Get-Command -Name 'Get-ExchangeCertificate' -ErrorAction SilentlyContinue)) {
+        function global:Get-ExchangeCertificate { }
+    }
+}
+
+AfterAll {
+    Remove-Item -Path 'Function:Get-MailboxDatabase' -ErrorAction SilentlyContinue
+    Remove-Item -Path 'Function:Get-Queue' -ErrorAction SilentlyContinue
+    Remove-Item -Path 'Function:Get-MailboxDatabaseCopyStatus' -ErrorAction SilentlyContinue
+    Remove-Item -Path 'Function:Get-ExchangeCertificate' -ErrorAction SilentlyContinue
+}
+
+Describe 'Get-ExchangeServerHealth' {
+
+    BeforeAll {
+        # Standard healthy remote mock data
+        $script:mockHealthyData = @{
+            TransportStatus          = 'Running'
+            InformationStoreStatus   = 'Running'
+            ADTopologyStatus         = 'Running'
+            ServiceHostStatus        = 'Running'
+            SnapinAvailable          = $true
+            TotalDatabases           = 4
+            MountedDatabases         = 4
+            DismountedDatabases      = 0
+            TotalQueues              = 3
+            TotalQueueMessages       = 12
+            HighestQueueLength       = 5
+            DAGCopiesTotal           = 8
+            DAGCopiesHealthy         = 8
+            DAGCopiesUnhealthy       = 0
+            CertificatesTotal        = 3
+            CertificatesExpiringSoon = 0
+            CertificatesExpired      = 0
+        }
+    }
+
+    Context 'RoleUnavailable - Exchange snapin not available' {
+
+        BeforeAll {
+            $script:mockNoSnapin = @{
+                TransportStatus          = 'NotFound'
+                InformationStoreStatus   = 'NotFound'
+                ADTopologyStatus         = 'NotFound'
+                ServiceHostStatus        = 'NotFound'
+                SnapinAvailable          = $false
+                TotalDatabases           = 0
+                MountedDatabases         = 0
+                DismountedDatabases      = 0
+                TotalQueues              = 0
+                TotalQueueMessages       = 0
+                HighestQueueLength       = 0
+                DAGCopiesTotal           = 0
+                DAGCopiesHealthy         = 0
+                DAGCopiesUnhealthy       = 0
+                CertificatesTotal        = 0
+                CertificatesExpiringSoon = 0
+                CertificatesExpired      = 0
+            }
+            Mock -CommandName 'Invoke-Command' -ModuleName 'PSWinOps' -MockWith { return $script:mockNoSnapin }
+            $script:result = Get-ExchangeServerHealth -ComputerName 'EX01'
+        }
+
+        It -Name 'Should return RoleUnavailable health status' -Test {
+            $script:result.OverallHealth | Should -Be 'RoleUnavailable'
+        }
+
+        It -Name 'Should populate the ComputerName property' -Test {
+            $script:result.ComputerName | Should -Be 'EX01'
+        }
+
+        It -Name 'Should report SnapinAvailable as false via zero databases' -Test {
+            $script:result.TotalDatabases | Should -Be 0
+        }
+    }
+
+    Context 'Healthy - All checks pass' {
+
+        BeforeAll {
+            Mock -CommandName 'Invoke-Command' -ModuleName 'PSWinOps' -MockWith { return $script:mockHealthyData }
+            $script:result = Get-ExchangeServerHealth -ComputerName 'EX01'
+        }
+
+        It -Name 'Should return Healthy overall health' -Test {
+            $script:result.OverallHealth | Should -Be 'Healthy'
+        }
+
+        It -Name 'Should report Running transport status' -Test {
+            $script:result.TransportStatus | Should -Be 'Running'
+        }
+
+        It -Name 'Should report Running information store status' -Test {
+            $script:result.InformationStoreStatus | Should -Be 'Running'
+        }
+
+        It -Name 'Should report 4 total databases' -Test {
+            $script:result.TotalDatabases | Should -Be 4
+        }
+
+        It -Name 'Should report 4 mounted databases' -Test {
+            $script:result.MountedDatabases | Should -Be 4
+        }
+
+        It -Name 'Should report 0 dismounted databases' -Test {
+            $script:result.DismountedDatabases | Should -Be 0
+        }
+
+        It -Name 'Should report 8 healthy DAG copies' -Test {
+            $script:result.DAGCopiesHealthy | Should -Be 8
+        }
+
+        It -Name 'Should report 0 unhealthy DAG copies' -Test {
+            $script:result.DAGCopiesUnhealthy | Should -Be 0
+        }
+
+        It -Name 'Should have a Timestamp value' -Test {
+            $script:result.Timestamp | Should -Not -BeNullOrEmpty
+        }
+    }
+
+    Context 'Critical - Transport service stopped' {
+
+        BeforeAll {
+            $script:mockTransportStopped = $script:mockHealthyData.Clone()
+            $script:mockTransportStopped.TransportStatus = 'Stopped'
+            Mock -CommandName 'Invoke-Command' -ModuleName 'PSWinOps' -MockWith { return $script:mockTransportStopped }
+            $script:result = Get-ExchangeServerHealth -ComputerName 'EX01'
+        }
+
+        It -Name 'Should return Critical overall health' -Test {
+            $script:result.OverallHealth | Should -Be 'Critical'
+        }
+
+        It -Name 'Should report Stopped transport status' -Test {
+            $script:result.TransportStatus | Should -Be 'Stopped'
+        }
+    }
+
+    Context 'Critical - Information Store stopped' {
+
+        BeforeAll {
+            $script:mockISStopped = $script:mockHealthyData.Clone()
+            $script:mockISStopped.InformationStoreStatus = 'Stopped'
+            Mock -CommandName 'Invoke-Command' -ModuleName 'PSWinOps' -MockWith { return $script:mockISStopped }
+            $script:result = Get-ExchangeServerHealth -ComputerName 'EX01'
+        }
+
+        It -Name 'Should return Critical overall health' -Test {
+            $script:result.OverallHealth | Should -Be 'Critical'
+        }
+
+        It -Name 'Should report Stopped information store status' -Test {
+            $script:result.InformationStoreStatus | Should -Be 'Stopped'
+        }
+    }
+
+    Context 'Critical - Database dismounted' {
+
+        BeforeAll {
+            $script:mockDBDismounted = $script:mockHealthyData.Clone()
+            $script:mockDBDismounted.MountedDatabases = 3
+            $script:mockDBDismounted.DismountedDatabases = 1
+            Mock -CommandName 'Invoke-Command' -ModuleName 'PSWinOps' -MockWith { return $script:mockDBDismounted }
+            $script:result = Get-ExchangeServerHealth -ComputerName 'EX01'
+        }
+
+        It -Name 'Should return Critical overall health' -Test {
+            $script:result.OverallHealth | Should -Be 'Critical'
+        }
+
+        It -Name 'Should report 1 dismounted database' -Test {
+            $script:result.DismountedDatabases | Should -Be 1
+        }
+    }
+
+    Context 'Critical - Queue exceeds critical threshold' {
+
+        BeforeAll {
+            $script:mockQueueCritical = $script:mockHealthyData.Clone()
+            $script:mockQueueCritical.HighestQueueLength = 600
+            $script:mockQueueCritical.TotalQueueMessages = 850
+            Mock -CommandName 'Invoke-Command' -ModuleName 'PSWinOps' -MockWith { return $script:mockQueueCritical }
+            $script:result = Get-ExchangeServerHealth -ComputerName 'EX01'
+        }
+
+        It -Name 'Should return Critical overall health' -Test {
+            $script:result.OverallHealth | Should -Be 'Critical'
+        }
+
+        It -Name 'Should report highest queue length of 600' -Test {
+            $script:result.HighestQueueLength | Should -Be 600
+        }
+    }
+
+    Context 'Degraded - Queue exceeds warning threshold' {
+
+        BeforeAll {
+            $script:mockQueueWarn = $script:mockHealthyData.Clone()
+            $script:mockQueueWarn.HighestQueueLength = 150
+            $script:mockQueueWarn.TotalQueueMessages = 200
+            Mock -CommandName 'Invoke-Command' -ModuleName 'PSWinOps' -MockWith { return $script:mockQueueWarn }
+            $script:result = Get-ExchangeServerHealth -ComputerName 'EX01'
+        }
+
+        It -Name 'Should return Degraded overall health' -Test {
+            $script:result.OverallHealth | Should -Be 'Degraded'
+        }
+
+        It -Name 'Should report highest queue length of 150' -Test {
+            $script:result.HighestQueueLength | Should -Be 150
+        }
+    }
+
+    Context 'Degraded - Unhealthy DAG copies' {
+
+        BeforeAll {
+            $script:mockDAGUnhealthy = $script:mockHealthyData.Clone()
+            $script:mockDAGUnhealthy.DAGCopiesHealthy = 6
+            $script:mockDAGUnhealthy.DAGCopiesUnhealthy = 2
+            Mock -CommandName 'Invoke-Command' -ModuleName 'PSWinOps' -MockWith { return $script:mockDAGUnhealthy }
+            $script:result = Get-ExchangeServerHealth -ComputerName 'EX01'
+        }
+
+        It -Name 'Should return Degraded overall health' -Test {
+            $script:result.OverallHealth | Should -Be 'Degraded'
+        }
+
+        It -Name 'Should report 2 unhealthy DAG copies' -Test {
+            $script:result.DAGCopiesUnhealthy | Should -Be 2
+        }
+    }
+
+    Context 'Degraded - Certificates expiring soon' {
+
+        BeforeAll {
+            $script:mockCertExpiring = $script:mockHealthyData.Clone()
+            $script:mockCertExpiring.CertificatesExpiringSoon = 1
+            Mock -CommandName 'Invoke-Command' -ModuleName 'PSWinOps' -MockWith { return $script:mockCertExpiring }
+            $script:result = Get-ExchangeServerHealth -ComputerName 'EX01'
+        }
+
+        It -Name 'Should return Degraded overall health' -Test {
+            $script:result.OverallHealth | Should -Be 'Degraded'
+        }
+
+        It -Name 'Should report 1 certificate expiring soon' -Test {
+            $script:result.CertificatesExpiringSoon | Should -Be 1
+        }
+    }
+
+    Context 'Degraded - Expired certificates' {
+
+        BeforeAll {
+            $script:mockCertExpired = $script:mockHealthyData.Clone()
+            $script:mockCertExpired.CertificatesExpired = 1
+            Mock -CommandName 'Invoke-Command' -ModuleName 'PSWinOps' -MockWith { return $script:mockCertExpired }
+            $script:result = Get-ExchangeServerHealth -ComputerName 'EX01'
+        }
+
+        It -Name 'Should return Degraded overall health' -Test {
+            $script:result.OverallHealth | Should -Be 'Degraded'
+        }
+
+        It -Name 'Should report 1 expired certificate' -Test {
+            $script:result.CertificatesExpired | Should -Be 1
+        }
+    }
+
+    Context 'Degraded - ADTopology service stopped' {
+
+        BeforeAll {
+            $script:mockADTopStopped = $script:mockHealthyData.Clone()
+            $script:mockADTopStopped.ADTopologyStatus = 'Stopped'
+            Mock -CommandName 'Invoke-Command' -ModuleName 'PSWinOps' -MockWith { return $script:mockADTopStopped }
+            $script:result = Get-ExchangeServerHealth -ComputerName 'EX01'
+        }
+
+        It -Name 'Should return Degraded overall health' -Test {
+            $script:result.OverallHealth | Should -Be 'Degraded'
+        }
+
+        It -Name 'Should report Stopped ADTopology status' -Test {
+            $script:result.ADTopologyStatus | Should -Be 'Stopped'
+        }
+    }
+
+    Context 'Remote single machine' {
+
+        BeforeAll {
+            Mock -CommandName 'Invoke-Command' -ModuleName 'PSWinOps' -MockWith { return $script:mockHealthyData }
+            $script:result = Get-ExchangeServerHealth -ComputerName 'EX01'
+        }
+
+        It -Name 'Should set ComputerName to EX01' -Test {
+            $script:result.ComputerName | Should -Be 'EX01'
+        }
+
+        It -Name 'Should return a result with Timestamp' -Test {
+            $script:result.Timestamp | Should -Not -BeNullOrEmpty
+        }
+    }
+
+    Context 'Pipeline multiple machines' {
+
+        BeforeAll {
+            Mock -CommandName 'Invoke-Command' -ModuleName 'PSWinOps' -MockWith { return $script:mockHealthyData }
+            $script:results = @('EX01', 'EX02') | Get-ExchangeServerHealth
+        }
+
+        It -Name 'Should return results for each pipeline input' -Test {
+            @($script:results).Count | Should -Be 2
+        }
+
+        It -Name 'Should return distinct ComputerName values' -Test {
+            $names = @($script:results) | Select-Object -ExpandProperty ComputerName -Unique
+            @($names).Count | Should -Be 2
+        }
+    }
+
+    Context 'Per-machine failure' {
+
+        BeforeAll {
+            Mock -CommandName 'Invoke-Command' -ModuleName 'PSWinOps' -MockWith { throw 'Connection failed' }
+        }
+
+        It -Name 'Should write error for unreachable host' -Test {
+            { Get-ExchangeServerHealth -ComputerName 'BADHOST' -ErrorAction Stop } |
+                Should -Throw -ExpectedMessage '*BADHOST*'
+        }
+
+        It -Name 'Should return null when errors are silenced' -Test {
+            $failResult = Get-ExchangeServerHealth -ComputerName 'BADHOST' -ErrorAction SilentlyContinue
+            $failResult | Should -BeNullOrEmpty
+        }
+    }
+
+    Context 'Parameter validation' {
+
+        It -Name 'Should throw when ComputerName is empty' -Test {
+            { Get-ExchangeServerHealth -ComputerName '' } | Should -Throw
+        }
+
+        It -Name 'Should throw when ComputerName is null' -Test {
+            { Get-ExchangeServerHealth -ComputerName $null } | Should -Throw
+        }
+
+        It -Name 'Should throw when QueueWarningThreshold is 0' -Test {
+            { Get-ExchangeServerHealth -ComputerName 'EX01' -QueueWarningThreshold 0 } | Should -Throw
+        }
+
+        It -Name 'Should throw when CertificateWarningDays exceeds 365' -Test {
+            { Get-ExchangeServerHealth -ComputerName 'EX01' -CertificateWarningDays 999 } | Should -Throw
+        }
+    }
+
+    Context 'Custom thresholds' {
+
+        BeforeAll {
+            $script:mockCustomQueue = $script:mockHealthyData.Clone()
+            $script:mockCustomQueue.HighestQueueLength = 60
+            Mock -CommandName 'Invoke-Command' -ModuleName 'PSWinOps' -MockWith { return $script:mockCustomQueue }
+        }
+
+        It -Name 'Should report Degraded with custom warning threshold of 50' -Test {
+            $result = Get-ExchangeServerHealth -ComputerName 'EX01' -QueueWarningThreshold 50
+            $result.OverallHealth | Should -Be 'Degraded'
+        }
+
+        It -Name 'Should report Healthy with default threshold of 100' -Test {
+            $result = Get-ExchangeServerHealth -ComputerName 'EX01'
+            $result.OverallHealth | Should -Be 'Healthy'
+        }
+    }
+}


### PR DESCRIPTION
- Add Exchange Server 2016+ health check (services, databases, queues, DAG, certs)
- Health tiers: RoleUnavailable / Critical / Degraded / Healthy
- Configurable thresholds: QueueWarningThreshold, QueueCriticalThreshold, CertificateWarningDays
- Add PSWinOps.ExchangeServerHealth Table + List format views
- Add Pester v5 tests (15 contexts, 35+ assertions)
- Update FunctionsToExport in manifest