### PR TITLE
fix: replace Clear-Host with Console.SetCursorPosition to eliminate t…

### DIFF
--- a/Public/network/Start-NetworkStatisticMonitor.ps1
+++ b/Public/network/Start-NetworkStatisticMonitor.ps1
@@ -70,8 +70,8 @@ function Start-NetworkStatisticMonitor {
 
         .NOTES
             Author:        Franck SALLET
-            Version:       1.1.0
-            Last Modified: 2026-03-23
+            Version:       1.2.0
+            Last Modified: 2026-04-01
             Requires:      PowerShell 5.1+ / Windows only
             Permissions:   No admin required for basic queries
             Remote:        Requires WinRM / WS-Man enabled on target machines
@@ -178,24 +178,50 @@ function Start-NetworkStatisticMonitor {
         $computerList = $allComputers -join ', '
         Write-Host "Network Statistics Monitor - Refresh every ${RefreshInterval}s - Press Ctrl+C to stop" -ForegroundColor Cyan
 
+        $isFirstRender = $true
+        $previousLineCount = 0
+
         try {
             while ($true) {
                 $allResults = @(Get-NetworkConnection -ComputerName $allComputers.ToArray() @getStatParams -ErrorAction SilentlyContinue)
 
-                Clear-Host
+                # Use cursor repositioning to avoid flicker (Clear-Host on first render only)
+                if ($isFirstRender) {
+                    Clear-Host
+                    $isFirstRender = $false
+                } else {
+                    try {
+                        [Console]::SetCursorPosition(0, 0)
+                    } catch {
+                        Clear-Host
+                    }
+                }
                 $now = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
                 Write-Host "=== Network Statistics on $computerList - $now - ${RefreshInterval}s refresh - Ctrl+C to stop ===" -ForegroundColor Cyan
                 Write-Host "Total connections: $($allResults.Count)" -ForegroundColor DarkGray
                 Write-Host ''
 
                 if ($allResults.Count -gt 0) {
-                    $allResults |
+                    $tableOutput = $allResults |
                         Sort-Object ComputerName, ProcessName, Protocol, RemoteAddress |
                         Format-Table -AutoSize |
-                        Out-Host
+                        Out-String
+                    Write-Host $tableOutput -NoNewline
+                    $currentLineCount = ($tableOutput -split "`n").Count + 3
                 } else {
                     Write-Host '(No matching connections found)' -ForegroundColor Yellow
+                    $currentLineCount = 4
                 }
+
+                # Clear stale lines from previous render when content shrinks
+                if ($currentLineCount -lt $previousLineCount) {
+                    $padWidth = try { [Console]::WindowWidth } catch { 120 }
+                    $blankLine = ' ' * $padWidth
+                    for ($i = $currentLineCount; $i -lt $previousLineCount; $i++) {
+                        Write-Host $blankLine
+                    }
+                }
+                $previousLineCount = $currentLineCount
 
                 Start-Sleep -Seconds $RefreshInterval
             }

--- a/Public/network/Start-PingMonitor.ps1
+++ b/Public/network/Start-PingMonitor.ps1
@@ -40,8 +40,8 @@ function Start-PingMonitor {
 
         .NOTES
             Author:        Franck SALLET
-            Version:       1.0.0
-            Last Modified: 2026-03-21
+            Version:       1.1.0
+            Last Modified: 2026-04-01
             Requires:      PowerShell 5.1+ / Windows only
             Permissions:   No admin required (ICMP may be blocked by firewall)
             Output:        Writes to console only, no pipeline output.
@@ -94,6 +94,7 @@ function Start-PingMonitor {
         $buffer = [byte[]]::new(32)
         $pingOptions = New-Object System.Net.NetworkInformation.PingOptions(128, $true)
         $startTime = Get-Date
+        $isFirstRender = $true
     }
 
     process {
@@ -127,8 +128,17 @@ function Start-PingMonitor {
                     }
                 }
 
-                # Render dashboard
-                Clear-Host
+                # Render dashboard — use cursor repositioning to avoid flicker
+                if ($isFirstRender) {
+                    Clear-Host
+                    $isFirstRender = $false
+                } else {
+                    try {
+                        [Console]::SetCursorPosition(0, 0)
+                    } catch {
+                        Clear-Host
+                    }
+                }
                 $elapsed = (Get-Date) - $startTime
                 $elapsedStr = '{0:hh\:mm\:ss}' -f $elapsed
                 Write-Host "=== Ping Monitor === $($ComputerName.Count) host(s) === Elapsed: $elapsedStr === Refresh: ${RefreshInterval}s === Ctrl+C to stop ===" -ForegroundColor Cyan


### PR DESCRIPTION
…erminal flicker

Start-PingMonitor (v1.1.0) and Start-NetworkStatisticMonitor (v1.2.0):
- Use Clear-Host only on first render, then [Console]::SetCursorPosition(0,0)
- try/catch fallback to Clear-Host for redirected/non-interactive output
- NetworkStatisticMonitor: capture Format-Table via Out-String + stale line clearing when connection count shrinks between refreshes