### PR TITLE
docs: fix documentation audit findings (Axis 1)

### DIFF
--- a/Private/PSWinOpsHealthStatus.ps1
+++ b/Private/PSWinOpsHealthStatus.ps1
@@ -1,10 +1,36 @@
 ﻿#Requires -Version 5.1
 
 <#
-    Health status values returned by the 15 healthcheck functions.
-    Defined as an enum so consumers can reference values as:
-        [PSWinOpsHealthStatus]::Healthy
-        [PSWinOpsHealthStatus]::Critical
+    .SYNOPSIS
+        Enum defining standardised health status values for PSWinOps healthcheck functions.
+
+    .DESCRIPTION
+        PSWinOpsHealthStatus is an enumeration used by the 15 healthcheck functions
+        (Get-AdDomainControllerHealth, Get-ADFSHealth, Get-ClusterHealth, etc.) to
+        express the overall health of a server role in a machine-comparable way.
+
+        Consumers can reference values as typed constants:
+            [PSWinOpsHealthStatus]::Healthy
+            [PSWinOpsHealthStatus]::Critical
+
+        Members:
+            Healthy               — All checks passed; the role is fully operational.
+            Degraded              — One or more non-critical checks failed; the role
+                                    is operational but requires attention.
+            Critical              — One or more critical checks failed; the role is
+                                    non-functional or at risk of imminent failure.
+            RoleUnavailable       — The target role or feature is not installed on the
+                                    machine (e.g. DHCP tools missing).
+            InsufficientPrivilege — The current user lacks the permissions needed to
+                                    perform the health checks.
+            Unknown               — The health status could not be determined (e.g.
+                                    unexpected error during evaluation).
+
+    .NOTES
+        Author:        Franck SALLET
+        Version:       1.1.0
+        Last Modified: 2026-04-02
+        Requires:      PowerShell 5.1+ / Windows only
 #>
 enum PSWinOpsHealthStatus {
     Healthy

--- a/Public/rdp/Connect-RdpSession.ps1
+++ b/Public/rdp/Connect-RdpSession.ps1
@@ -60,17 +60,24 @@ function Connect-RdpSession {
             Dry-run: shows what would happen without opening the shadow window.
 
         .EXAMPLE
+            $adminCred = Get-Credential -UserName 'DOMAIN\admin'
             Connect-RdpSession -SessionID 5 -ControlMode View -Credential $adminCred
+
             Opens a view-only shadow of session 5, with mstsc.exe running as $adminCred.
 
         .OUTPUTS
             PSWinOps.RdpSessionAction
             Connection action result with session details and status.
+            In addition to the base RdpSessionAction properties (ComputerName,
+            SessionID, Action, Success, Timestamp), this function adds:
+            ControlMode [string] — 'Control' or 'View'.
+            ExitCode [int] — mstsc.exe process exit code.
+            Message [string] — human-readable result summary.
 
         .NOTES
             Author:        Franck SALLET
-            Version:       1.2.0
-            Last Modified: 2026-03-11
+            Version:       1.2.1
+            Last Modified: 2026-04-02
             Requires:      PowerShell 5.1+, mstsc.exe, qwinsta.exe
             Permissions:   Local Administrator on target machine
 

--- a/Public/rdp/Get-RdpSessionHistory.ps1
+++ b/Public/rdp/Get-RdpSessionHistory.ps1
@@ -40,9 +40,10 @@ function Get-RdpSessionHistory {
             Retrieves RDP session history from SRV01 and SRV02 for the last 7 days.
 
         .EXAMPLE
+            $cred = Get-Credential -UserName 'DOMAIN\admin'
             'WEB01', 'APP01' | Get-RdpSessionHistory -Credential $cred
 
-            Pipeline example: queries multiple servers using specified credentials.
+            Pipeline example: queries multiple servers using alternate credentials.
 
         .EXAMPLE
             Get-ADComputer -Filter "OperatingSystem -like '*Server*'" | Get-RdpSessionHistory -StartTime (Get-Date).AddHours(-24)
@@ -60,8 +61,8 @@ function Get-RdpSessionHistory {
 
         .NOTES
             Author:        Franck SALLET
-            Version:       1.1.0
-            Last Modified: 2026-03-19
+            Version:       1.1.1
+            Last Modified: 2026-04-02
             Requires:      PowerShell 5.1+
             Permissions:   Remote Event Log Readers group or local Administrator on target machines
 

--- a/Public/rdp/Get-RdpSessionLock.ps1
+++ b/Public/rdp/Get-RdpSessionLock.ps1
@@ -36,8 +36,11 @@ function Get-RdpSessionLock {
             Retrieves 30 days of lock/unlock history from SRV01.
 
         .EXAMPLE
+            $cred = Get-Credential -UserName 'DOMAIN\admin'
             'WEB01', 'APP01' | Get-RdpSessionLock -Credential $cred | Where-Object { $_.Action -eq 'Locked' }
-            Pipeline example: retrieves only lock events (not unlocks) from multiple servers.
+
+            Pipeline example: retrieves only lock events (not unlocks) from multiple servers
+            using alternate credentials.
 
         .EXAMPLE
             Get-ADComputer -Filter "OperatingSystem -like '*Server*'" | Get-RdpSessionLock -StartTime (Get-Date).AddHours(-24) | Group-Object -Property UserName
@@ -49,8 +52,8 @@ function Get-RdpSessionLock {
 
         .NOTES
             Author:        Franck SALLET
-            Version:       1.1.0
-            Last Modified: 2026-03-19
+            Version:       1.1.1
+            Last Modified: 2026-04-02
             Requires:      PowerShell 5.1+
             Permissions:   Event Log Readers group or local Administrator on target machines
             Note:          Security log access requires elevated permissions

--- a/Public/rdp/Remove-RdpSession.ps1
+++ b/Public/rdp/Remove-RdpSession.ps1
@@ -48,8 +48,10 @@ function Remove-RdpSession {
             Shows what would happen if session 3 were removed from WEB01.
 
         .EXAMPLE
+            $cred = Get-Credential -UserName 'DOMAIN\admin'
             'APP01' | Get-RdpSession | Where-Object { $_.UserName -eq 'DOMAIN\olduser' } | Remove-RdpSession -Credential $cred
-            Removes all sessions for a specific user on APP01 using provided credentials.
+
+            Removes all sessions for a specific user on APP01 using alternate credentials.
 
         .OUTPUTS
             PSWinOps.RdpSessionAction
@@ -57,8 +59,8 @@ function Remove-RdpSession {
 
         .NOTES
             Author:        Franck SALLET
-            Version:       2.0.0
-            Last Modified: 2026-03-20
+            Version:       2.0.1
+            Last Modified: 2026-04-02
             Requires:      PowerShell 5.1+, logoff.exe (built-in on all Windows editions)
             Permissions:   Local Administrator on target machines
             WinRM access required when using the -Credential parameter

--- a/Public/utils/ConvertFrom-MisencodedString.ps1
+++ b/Public/utils/ConvertFrom-MisencodedString.ps1
@@ -44,10 +44,12 @@ function ConvertFrom-MisencodedString {
             the corrected versions.
 
         .EXAMPLE
-            ConvertFrom-MisencodedString -String 'cafe' -SourceEncoding 'windows-1252' -TargetEncoding 'utf-8'
+            ConvertFrom-MisencodedString -String 'café' -SourceEncoding 'windows-1252' -TargetEncoding 'utf-8'
 
-            Fixes a string where UTF-8 characters were misinterpreted as Windows-1252.
-            Returns 'cafe' in proper UTF-8 encoding.
+            Attempts to fix a string where UTF-8 bytes were misinterpreted as Windows-1252.
+            Note: encoding conversion is lossy when characters have no exact mapping in the
+            target encoding. Characters outside the target range are replaced by fallback
+            characters (e.g. '?' for ASCII). Verify results for non-ASCII input.
 
         .EXAMPLE
             Get-Content -Path 'C:\Logs\misencoded.txt' | ConvertFrom-MisencodedString
@@ -60,8 +62,8 @@ function ConvertFrom-MisencodedString {
 
         .NOTES
             Author:        Franck SALLET
-            Version:       1.0.2
-            Last Modified: 2026-03-11
+            Version:       1.0.3
+            Last Modified: 2026-04-02
             Requires:      PowerShell 5.1+
             Permissions:   None required
             Module:        PSWinOps


### PR DESCRIPTION
- Make $cred/$adminCred examples runnable by adding Get-Credential calls (Get-RdpSessionLock, Get-RdpSessionHistory, Connect-RdpSession, Remove-RdpSession)
- Fix misleading ConvertFrom-MisencodedString example claiming lossless conversion
- Document Connect-RdpSession extra output properties (ControlMode, ExitCode, Message) vs base PSWinOps.RdpSessionAction shape
- Add full .SYNOPSIS/.DESCRIPTION/.NOTES to PSWinOpsHealthStatus enum
- Bump patch versions and Last Modified on all touched files