### PR TITLE
feat(iis): add Set-IISBindingCertificate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,7 @@ jobs:
           - "Private"
           - "Public/activedirectory"
           - "Public/healthcheck"
+          - "Public/iis"
           - "Public/network"
           - "Public/ntp"
           - "Public/proxy"

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ logs/
 *.pfx
 *.p12
 secrets.json
+
+# KDust per-run sandbox (ADR-0009)
+work/

--- a/.kdust/chains/set-iisbindingcertificate-2605141647.yaml
+++ b/.kdust/chains/set-iisbindingcertificate-2605141647.yaml
@@ -1,0 +1,7 @@
+chain: pswinops-function-author
+function: Set-IISBindingCertificate
+domain: iis
+created: 2026-05-14T16:48:51Z
+created_by: pswinops-fn-spec-analyst
+chain_branch: kdust/chain/pswinops-fn-set-iisbindingcertificate-2605141647
+spec_path: work/set-iisbindingcertificate/spec.yaml

--- a/PSWinOps.Format.ps1xml
+++ b/PSWinOps.Format.ps1xml
@@ -6697,5 +6697,68 @@
         </TableRowEntries>
       </TableControl>
     </View>
+    <!-- ============================================================ -->
+    <!-- PSWinOps.IISBindingCertificateResult                        -->
+    <!-- Used by: Set-IISBindingCertificate                          -->
+    <!-- ============================================================ -->
+    <View>
+      <Name>PSWinOps.IISBindingCertificateResult</Name>
+      <ViewSelectedBy>
+        <TypeName>PSWinOps.IISBindingCertificateResult</TypeName>
+      </ViewSelectedBy>
+      <TableControl>
+        <AutoSize />
+        <TableHeaders>
+          <TableColumnHeader>
+            <Label>ComputerName</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>SiteName</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>BindingInformation</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Status</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>PrevThumbprint</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>NewThumbprint</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Timestamp</Label>
+          </TableColumnHeader>
+        </TableHeaders>
+        <TableRowEntries>
+          <TableRowEntry>
+            <TableColumnItems>
+              <TableColumnItem>
+                <PropertyName>ComputerName</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>SiteName</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>BindingInformation</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>Status</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>PreviousThumbprint</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>NewThumbprint</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>Timestamp</PropertyName>
+              </TableColumnItem>
+            </TableColumnItems>
+          </TableRowEntry>
+        </TableRowEntries>
+      </TableControl>
+    </View>
   </ViewDefinitions>
 </Configuration>

--- a/PSWinOps.psd1
+++ b/PSWinOps.psd1
@@ -12,7 +12,7 @@
     RootModule           = 'PSWinOps.psm1'
 
     # Version number of this module.
-    ModuleVersion        = '0.0.22'
+    ModuleVersion        = '0.1.0'
 
     # Supported PSEditions
     # Core is supported on Windows only; the module-level guard in PSWinOps.psm1 blocks
@@ -166,6 +166,7 @@
         'Restore-ShadowCopyFile',
         'Save-WindowsUpdate',
         'Search-ADObject',
+        'Set-IISBindingCertificate',
         'Set-NetworkRoute',
         'Set-NTPClient',
         'Set-PageFile',

--- a/PSWinOps.psd1
+++ b/PSWinOps.psd1
@@ -12,7 +12,7 @@
     RootModule           = 'PSWinOps.psm1'
 
     # Version number of this module.
-    ModuleVersion        = '0.1.0'
+    ModuleVersion        = '0.1.1'
 
     # Supported PSEditions
     # Core is supported on Windows only; the module-level guard in PSWinOps.psm1 blocks
@@ -250,7 +250,13 @@
             # IconUri = ''
 
             # ReleaseNotes of this module
-            ReleaseNotes = '## 0.0.17 - 2026-04-02
+            ReleaseNotes = '## 0.1.1 - 2026-05-14
+### Added
+- feat(iis): add Set-IISBindingCertificate — replace SSL/TLS certificate on one or more IIS HTTPS site bindings with idempotent rotation, -WhatIf/-Confirm (ConfirmImpact=High), remote execution via WinRM, and pipeline-by-property-name from Get-SSLCertificate / Get-IISHealth.
+- feat(iis): introduce new public domain Public/iis/ (registered in CI matrix and about_PSWinOps).
+- feat(format): TableControl view for PSWinOps.IISBindingCertificateResult in PSWinOps.Format.ps1xml.
+
+## 0.0.17 - 2026-04-02
 - refactor: Invoke-RemoteOrLocal rewrite (#30)
 - refactor: move OverallHealth computation to process{} block (#31)
 - fix: misc cleanup — synopsis, #Requires, module-scoped local names (#32)

--- a/Public/iis/Set-IISBindingCertificate.ps1
+++ b/Public/iis/Set-IISBindingCertificate.ps1
@@ -1,0 +1,545 @@
+﻿#Requires -Version 5.1
+function Set-IISBindingCertificate {
+    <#
+        .SYNOPSIS
+            Replaces the SSL/TLS certificate on one or more IIS https site bindings.
+
+        .DESCRIPTION
+            Replace the SSL/TLS certificate bound to one or more IIS HTTPS site bindings,
+            typically to rotate a certificate that is approaching expiration. The new
+            certificate must already exist in the target certificate store (LocalMachine\My
+            by default). The function is idempotent: running it twice with the same
+            thumbprint yields Status=AlreadyUpToDate on the second call. Supports remote
+            execution via WinRM, -WhatIf/-Confirm (ConfirmImpact=High), and pipeline input
+            by property name from Get-IISHealth / Get-SSLCertificate.
+
+        .PARAMETER ComputerName
+            One or more computer names to target. Defaults to the local machine.
+            Accepts pipeline input by value and by property name.
+
+        .PARAMETER Credential
+            Optional PSCredential for authenticating to remote computers.
+            Not used for local queries.
+
+        .PARAMETER SiteName
+            IIS site name (Get-Website -Name).
+
+        .PARAMETER BindingInformation
+            Binding selector ip:port:hostheader (e.g. *:443:www.contoso.com).
+            When omitted, the function applies to ALL https bindings of the site.
+
+        .PARAMETER Thumbprint
+            SHA-1 thumbprint (40 hex chars) of the new certificate.
+            Must already be present in -CertStoreLocation on the target.
+
+        .PARAMETER CertStoreLocation
+            Certificate store to read the new cert from.
+            Valid values: 'Cert:\LocalMachine\My' (default) or 'Cert:\LocalMachine\WebHosting'.
+
+        .PARAMETER Force
+            Bypass the ConfirmImpact=High prompt (equivalent to -Confirm:$false).
+
+        .EXAMPLE
+            Set-IISBindingCertificate -SiteName 'www.contoso.com' -Thumbprint 'A1B2C3D4E5F6A1B2C3D4E5F6A1B2C3D4E5F6A1B2' -Confirm:$false
+
+            Replaces the cert on every https binding of the site without prompting.
+
+        .EXAMPLE
+            Set-IISBindingCertificate -SiteName 'Default Web Site' -BindingInformation '*:443:portal.contoso.com' -Thumbprint $newTp
+
+            Targets one specific binding by its ip:port:hostheader selector.
+
+        .EXAMPLE
+            'WEB01','WEB02','WEB03' | Set-IISBindingCertificate -SiteName 'api' -Thumbprint $newTp -Credential (Get-Credential) -WhatIf
+
+            Previews certificate rotation across a fleet via pipeline with explicit credentials.
+
+        .EXAMPLE
+            Get-SSLCertificate -ComputerName WEB01 -Port 443 | Set-IISBindingCertificate -SiteName 'www' -Thumbprint $newTp
+
+            Pipeline-by-property-name from Get-SSLCertificate.
+
+        .OUTPUTS
+            PSCustomObject (PSTypeName='PSWinOps.IISBindingCertificateResult')
+            Returns one object per (ComputerName, binding) pair.
+
+        .NOTES
+            Author: Franck SALLET
+            Version: 1.0.0
+            Last Modified: 2026-05-14
+            Requires: PowerShell 5.1+ / Windows only
+            Requires: Web-Server (IIS) role
+            Requires: Module WebAdministration or IISAdministration
+
+        .LINK
+            https://github.com/k9fr4n/PSWinOps
+
+        .LINK
+            https://learn.microsoft.com/en-us/iis/manage/powershell/powershell-snap-in-changing-simple-settings-at-the-command-line
+    #>
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
+    [OutputType('PSWinOps.IISBindingCertificateResult')]
+    param(
+        [Parameter(Mandatory = $false, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [ValidateNotNullOrEmpty()]
+        [Alias('CN', 'Name', 'DNSHostName')]
+        [string[]]$ComputerName = $env:COMPUTERNAME,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateNotNull()]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential,
+
+        [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$SiteName,
+
+        [Parameter(Mandatory = $false, ValueFromPipelineByPropertyName = $true)]
+        [string]$BindingInformation,
+
+        [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+        [ValidatePattern('^[A-Fa-f0-9]{40}$')]
+        [string]$Thumbprint,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateSet('Cert:\LocalMachine\My', 'Cert:\LocalMachine\WebHosting')]
+        [string]$CertStoreLocation = 'Cert:\LocalMachine\My',
+
+        [Parameter(Mandatory = $false)]
+        [switch]$Force
+    )
+
+    begin {
+        Write-Verbose -Message "[$($MyInvocation.MyCommand)] Starting"
+
+        # Honour -Force by suppressing the ConfirmImpact=High prompt.
+        if ($Force.IsPresent) {
+            $ConfirmPreference = 'None'
+        }
+
+        # ---------------------------------------------------------------
+        # Phase 1 scriptBlock — read-only state query (safe under -WhatIf)
+        # ---------------------------------------------------------------
+        $queryScriptBlock = {
+            param(
+                [string]$QSiteName,
+                [string]$QBindingInformation,
+                [string]$QThumbprint,
+                [string]$QCertStoreLocation
+            )
+
+            $queryResults = [System.Collections.Generic.List[hashtable]]::new()
+
+            # Detect available IIS module (mirrors Get-IISHealth pattern).
+            $iisModule = $null
+            if (Get-Module -Name 'WebAdministration' -ListAvailable -ErrorAction SilentlyContinue) {
+                $iisModule = 'WebAdministration'
+            }
+            elseif (Get-Module -Name 'IISAdministration' -ListAvailable -ErrorAction SilentlyContinue) {
+                $iisModule = 'IISAdministration'
+            }
+
+            if ($null -eq $iisModule) {
+                $queryResults.Add(@{
+                    SiteName           = $QSiteName
+                    BindingInformation = $QBindingInformation
+                    Protocol           = 'https'
+                    PreviousThumbprint = $null
+                    NewThumbprint      = $QThumbprint
+                    CertStoreLocation  = $QCertStoreLocation
+                    SslFlags           = 0
+                    Status             = 'Failed'
+                    ErrorMessage       = 'Neither WebAdministration nor IISAdministration module is available on the target.'
+                    SslKey             = $null
+                })
+                return $queryResults
+            }
+
+            try {
+                Import-Module -Name $iisModule -ErrorAction Stop
+
+                if ($iisModule -eq 'WebAdministration') {
+
+                    $site = Get-Website -Name $QSiteName -ErrorAction SilentlyContinue
+                    if ($null -eq $site) {
+                        $queryResults.Add(@{
+                            SiteName           = $QSiteName
+                            BindingInformation = $QBindingInformation
+                            Protocol           = 'https'
+                            PreviousThumbprint = $null
+                            NewThumbprint      = $QThumbprint
+                            CertStoreLocation  = $QCertStoreLocation
+                            SslFlags           = 0
+                            Status             = 'BindingNotFound'
+                            ErrorMessage       = "Site '$QSiteName' not found."
+                            SslKey             = $null
+                        })
+                        return $queryResults
+                    }
+
+                    $httpsBindings = @(Get-WebBinding -Name $QSiteName -Protocol 'https' -ErrorAction SilentlyContinue)
+                    if ($httpsBindings.Count -eq 0) {
+                        $queryResults.Add(@{
+                            SiteName           = $QSiteName
+                            BindingInformation = $QBindingInformation
+                            Protocol           = 'https'
+                            PreviousThumbprint = $null
+                            NewThumbprint      = $QThumbprint
+                            CertStoreLocation  = $QCertStoreLocation
+                            SslFlags           = 0
+                            Status             = 'BindingNotFound'
+                            ErrorMessage       = "No https bindings found on site '$QSiteName'."
+                            SslKey             = $null
+                        })
+                        return $queryResults
+                    }
+
+                    if (-not [string]::IsNullOrEmpty($QBindingInformation)) {
+                        $httpsBindings = @($httpsBindings | Where-Object { $_.bindingInformation -eq $QBindingInformation })
+                        if ($httpsBindings.Count -eq 0) {
+                            $queryResults.Add(@{
+                                SiteName           = $QSiteName
+                                BindingInformation = $QBindingInformation
+                                Protocol           = 'https'
+                                PreviousThumbprint = $null
+                                NewThumbprint      = $QThumbprint
+                                CertStoreLocation  = $QCertStoreLocation
+                                SslFlags           = 0
+                                Status             = 'BindingNotFound'
+                                ErrorMessage       = "No https binding matching '$QBindingInformation' found on site '$QSiteName'."
+                                SslKey             = $null
+                            })
+                            return $queryResults
+                        }
+                    }
+
+                    foreach ($wb in $httpsBindings) {
+                        $bindInfo    = $wb.bindingInformation
+                        $sslFlagsVal = [int]$wb.sslFlags
+
+                        # Build IIS:\SslBindings key: <ip>!<port> or <ip>!<port>!<host>
+                        $parts      = $bindInfo -split ':'
+                        $ipPart     = $parts[0]
+                        $portPart   = $parts[1]
+                        $hostHeader = if ($parts.Count -ge 3) { $parts[2] } else { '' }
+                        $sslKey     = if ([string]::IsNullOrEmpty($hostHeader)) {
+                            "$ipPart!$portPart"
+                        } else {
+                            "$ipPart!$portPart!$hostHeader"
+                        }
+
+                        $prevThumbprint = $null
+                        try {
+                            $existingEntry  = Get-Item -Path "IIS:\SslBindings\$sslKey" -ErrorAction Stop
+                            $prevThumbprint = $existingEntry.Thumbprint
+                        }
+                        catch {
+                            Write-Verbose -Message "No pre-existing SSL binding found for key '$sslKey'."
+                        }
+
+                        $certPath  = Join-Path -Path $QCertStoreLocation -ChildPath $QThumbprint
+                        $certFound = Test-Path -Path $certPath
+
+                        $bindingStatus = if ($prevThumbprint -eq $QThumbprint) {
+                            'AlreadyUpToDate'
+                        }
+                        elseif (-not $certFound) {
+                            'CertNotFound'
+                        }
+                        else {
+                            'NeedsReplacement'
+                        }
+
+                        $queryResults.Add(@{
+                            SiteName           = $QSiteName
+                            BindingInformation = $bindInfo
+                            Protocol           = 'https'
+                            PreviousThumbprint = $prevThumbprint
+                            NewThumbprint      = $QThumbprint
+                            CertStoreLocation  = $QCertStoreLocation
+                            SslFlags           = $sslFlagsVal
+                            Status             = $bindingStatus
+                            ErrorMessage       = $null
+                            SslKey             = $sslKey
+                        })
+                    }
+                }
+                else {
+                    # IISAdministration fallback
+                    $site = Get-IISSite -Name $QSiteName -ErrorAction SilentlyContinue
+                    if ($null -eq $site) {
+                        $queryResults.Add(@{
+                            SiteName           = $QSiteName
+                            BindingInformation = $QBindingInformation
+                            Protocol           = 'https'
+                            PreviousThumbprint = $null
+                            NewThumbprint      = $QThumbprint
+                            CertStoreLocation  = $QCertStoreLocation
+                            SslFlags           = 0
+                            Status             = 'BindingNotFound'
+                            ErrorMessage       = "Site '$QSiteName' not found."
+                            SslKey             = $null
+                        })
+                        return $queryResults
+                    }
+
+                    $httpsBindings = @($site.Bindings | Where-Object { $_.Protocol -eq 'https' })
+                    if ($httpsBindings.Count -eq 0) {
+                        $queryResults.Add(@{
+                            SiteName           = $QSiteName
+                            BindingInformation = $QBindingInformation
+                            Protocol           = 'https'
+                            PreviousThumbprint = $null
+                            NewThumbprint      = $QThumbprint
+                            CertStoreLocation  = $QCertStoreLocation
+                            SslFlags           = 0
+                            Status             = 'BindingNotFound'
+                            ErrorMessage       = "No https bindings found on site '$QSiteName'."
+                            SslKey             = $null
+                        })
+                        return $queryResults
+                    }
+
+                    if (-not [string]::IsNullOrEmpty($QBindingInformation)) {
+                        $httpsBindings = @($httpsBindings | Where-Object { $_.BindingInformation -eq $QBindingInformation })
+                        if ($httpsBindings.Count -eq 0) {
+                            $queryResults.Add(@{
+                                SiteName           = $QSiteName
+                                BindingInformation = $QBindingInformation
+                                Protocol           = 'https'
+                                PreviousThumbprint = $null
+                                NewThumbprint      = $QThumbprint
+                                CertStoreLocation  = $QCertStoreLocation
+                                SslFlags           = 0
+                                Status             = 'BindingNotFound'
+                                ErrorMessage       = "No https binding matching '$QBindingInformation' found on site '$QSiteName'."
+                                SslKey             = $null
+                            })
+                            return $queryResults
+                        }
+                    }
+
+                    foreach ($ib in $httpsBindings) {
+                        $bindInfo    = $ib.BindingInformation
+                        $sslFlagsVal = [int]$ib.SslFlags
+
+                        $parts      = $bindInfo -split ':'
+                        $ipPart     = $parts[0]
+                        $portPart   = $parts[1]
+                        $hostHeader = if ($parts.Count -ge 3) { $parts[2] } else { '' }
+                        $sslKey     = if ([string]::IsNullOrEmpty($hostHeader)) {
+                            "$ipPart!$portPart"
+                        } else {
+                            "$ipPart!$portPart!$hostHeader"
+                        }
+
+                        # IISAdministration: CertificateHash is a byte array.
+                        $prevThumbprint = $null
+                        $certHashBytes  = $ib.CertificateHash
+                        if ($certHashBytes) {
+                            $prevThumbprint = ([System.BitConverter]::ToString([byte[]]$certHashBytes) -replace '-', '')
+                        }
+
+                        $certPath  = Join-Path -Path $QCertStoreLocation -ChildPath $QThumbprint
+                        $certFound = Test-Path -Path $certPath
+
+                        $bindingStatus = if ($prevThumbprint -eq $QThumbprint) {
+                            'AlreadyUpToDate'
+                        }
+                        elseif (-not $certFound) {
+                            'CertNotFound'
+                        }
+                        else {
+                            'NeedsReplacement'
+                        }
+
+                        $queryResults.Add(@{
+                            SiteName           = $QSiteName
+                            BindingInformation = $bindInfo
+                            Protocol           = 'https'
+                            PreviousThumbprint = $prevThumbprint
+                            NewThumbprint      = $QThumbprint
+                            CertStoreLocation  = $QCertStoreLocation
+                            SslFlags           = $sslFlagsVal
+                            Status             = $bindingStatus
+                            ErrorMessage       = $null
+                            SslKey             = $sslKey
+                        })
+                    }
+                }
+            }
+            catch {
+                $queryResults.Add(@{
+                    SiteName           = $QSiteName
+                    BindingInformation = $QBindingInformation
+                    Protocol           = 'https'
+                    PreviousThumbprint = $null
+                    NewThumbprint      = $QThumbprint
+                    CertStoreLocation  = $QCertStoreLocation
+                    SslFlags           = 0
+                    Status             = 'Failed'
+                    ErrorMessage       = $_.Exception.Message
+                    SslKey             = $null
+                })
+            }
+
+            return $queryResults
+        }
+
+        # ---------------------------------------------------------------
+        # Phase 2 scriptBlock — write (cert replacement)
+        # ---------------------------------------------------------------
+        $applyScriptBlock = {
+            param(
+                [string]$ASiteName,
+                [string]$ABindingInformation,
+                [string]$AThumbprint,
+                [string]$ACertStoreLocation,
+                [string]$ASslKey,
+                [int]$ASslFlags
+            )
+
+            # Re-detect available IIS module (cheap; avoids serializing module name).
+            $iisModule = $null
+            if (Get-Module -Name 'WebAdministration' -ListAvailable -ErrorAction SilentlyContinue) {
+                $iisModule = 'WebAdministration'
+            }
+            elseif (Get-Module -Name 'IISAdministration' -ListAvailable -ErrorAction SilentlyContinue) {
+                $iisModule = 'IISAdministration'
+            }
+
+            if ($null -eq $iisModule) {
+                return @{ Success = $false; NewThumbprint = $null; ErrorMessage = 'IIS module unavailable on target.' }
+            }
+
+            try {
+                Import-Module -Name $iisModule -ErrorAction Stop
+
+                if ($iisModule -eq 'WebAdministration') {
+                    # Remove existing SSL binding entry.
+                    if (Test-Path -Path "IIS:\SslBindings\$ASslKey") {
+                        Remove-Item -Path "IIS:\SslBindings\$ASslKey" -ErrorAction Stop
+                    }
+
+                    # Bind the new certificate (pipe cert object to New-Item on IIS: provider).
+                    $certItem = Get-Item -Path (Join-Path -Path $ACertStoreLocation -ChildPath $AThumbprint) -ErrorAction Stop
+                    $null = $certItem | New-Item -Path "IIS:\SslBindings\$ASslKey" -SslFlags $ASslFlags -ErrorAction Stop
+
+                    # Verify replacement.
+                    $confirmedEntry = Get-Item -Path "IIS:\SslBindings\$ASslKey" -ErrorAction Stop
+                    return @{ Success = $true; NewThumbprint = $confirmedEntry.Thumbprint; ErrorMessage = $null }
+                }
+                else {
+                    # IISAdministration fallback: remove and re-add the binding.
+                    Remove-IISSiteBinding -Name $ASiteName -BindingInformation $ABindingInformation `
+                        -Protocol 'https' -Confirm:$false -ErrorAction Stop
+
+                    $addParams = @{
+                        Name                  = $ASiteName
+                        BindingInformation    = $ABindingInformation
+                        Protocol              = 'https'
+                        CertificateThumbPrint = $AThumbprint
+                        CertStoreLocation     = $ACertStoreLocation
+                        SslFlag               = $ASslFlags
+                    }
+                    Add-IISSiteBinding @addParams -ErrorAction Stop
+                    return @{ Success = $true; NewThumbprint = $AThumbprint; ErrorMessage = $null }
+                }
+            }
+            catch {
+                return @{ Success = $false; NewThumbprint = $null; ErrorMessage = $_.Exception.Message }
+            }
+        }
+    }
+
+    process {
+        foreach ($cn in $ComputerName) {
+            Write-Verbose -Message "[$($MyInvocation.MyCommand)] Processing '$cn'"
+
+            try {
+                $queryArgs      = @($SiteName, $BindingInformation, $Thumbprint, $CertStoreLocation)
+                $queryRawResult = Invoke-RemoteOrLocal -ComputerName $cn -Credential $Credential `
+                    -ScriptBlock $queryScriptBlock -ArgumentList $queryArgs
+
+                foreach ($entry in $queryRawResult) {
+                    $entryStatus    = $entry.Status
+                    $entryBindInfo  = $entry.BindingInformation
+                    $entryPrevThumb = $entry.PreviousThumbprint
+                    $entryNewThumb  = $entry.NewThumbprint
+                    $entrySslFlags  = $entry.SslFlags
+                    $entrySslKey    = $entry.SslKey
+                    $entryErrMsg    = $entry.ErrorMessage
+
+                    if ($entryStatus -eq 'NeedsReplacement') {
+                        $spTarget = "$cn/$SiteName binding $entryBindInfo"
+                        $spAction = "Replace SSL certificate $entryPrevThumb -> $Thumbprint"
+
+                        if ($PSCmdlet.ShouldProcess($spTarget, $spAction)) {
+                            try {
+                                $applyArgs   = @($SiteName, $entryBindInfo, $Thumbprint, $CertStoreLocation, $entrySslKey, $entrySslFlags)
+                                $applyResult = Invoke-RemoteOrLocal -ComputerName $cn -Credential $Credential `
+                                    -ScriptBlock $applyScriptBlock -ArgumentList $applyArgs
+
+                                if ($applyResult.Success) {
+                                    $entryStatus   = 'Replaced'
+                                    $entryNewThumb = $applyResult.NewThumbprint
+                                    $entryErrMsg   = $null
+                                }
+                                else {
+                                    $entryStatus = 'Failed'
+                                    $entryErrMsg = $applyResult.ErrorMessage
+                                }
+                            }
+                            catch {
+                                $entryStatus = 'Failed'
+                                $entryErrMsg = $_.Exception.Message
+                            }
+
+                            [PSCustomObject]@{
+                                PSTypeName         = 'PSWinOps.IISBindingCertificateResult'
+                                ComputerName       = $cn.ToUpper()
+                                SiteName           = $entry.SiteName
+                                BindingInformation = $entryBindInfo
+                                Protocol           = $entry.Protocol
+                                PreviousThumbprint = $entryPrevThumb
+                                NewThumbprint      = $entryNewThumb
+                                CertStoreLocation  = $entry.CertStoreLocation
+                                SslFlags           = $entrySslFlags
+                                Status             = $entryStatus
+                                ErrorMessage       = $entryErrMsg
+                                Timestamp          = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
+                            }
+                        }
+                        # ShouldProcess returned $false (-WhatIf / user declined): no output emitted.
+                    }
+                    else {
+                        # AlreadyUpToDate, CertNotFound, BindingNotFound, Failed: emit directly.
+                        [PSCustomObject]@{
+                            PSTypeName         = 'PSWinOps.IISBindingCertificateResult'
+                            ComputerName       = $cn.ToUpper()
+                            SiteName           = $entry.SiteName
+                            BindingInformation = $entryBindInfo
+                            Protocol           = $entry.Protocol
+                            PreviousThumbprint = $entryPrevThumb
+                            NewThumbprint      = $entryNewThumb
+                            CertStoreLocation  = $entry.CertStoreLocation
+                            SslFlags           = $entrySslFlags
+                            Status             = $entryStatus
+                            ErrorMessage       = $entryErrMsg
+                            Timestamp          = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
+                        }
+                    }
+                }
+            }
+            catch {
+                Write-Error -Message "[$($MyInvocation.MyCommand)] Failed on '${cn}': $_"
+                continue
+            }
+        }
+    }
+
+    end {
+        Write-Verbose -Message "[$($MyInvocation.MyCommand)] Completed"
+    }
+}

--- a/Tests/Public/iis/Set-IISBindingCertificate.Tests.ps1
+++ b/Tests/Public/iis/Set-IISBindingCertificate.Tests.ps1
@@ -1,0 +1,514 @@
+﻿#Requires -Version 5.1
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+BeforeAll {
+    $script:modulePath = Split-Path -Path (Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent) -Parent
+    Import-Module -Name (Join-Path -Path $script:modulePath -ChildPath 'PSWinOps.psd1') -Force
+
+    # IIS WebAdministration / IISAdministration stubs — parameters declared explicitly
+    # so that Pester mock engine can match $args correctly (see project PR #42 notes).
+    if (-not (Get-Command -Name 'Get-Website' -ErrorAction SilentlyContinue)) {
+        function global:Get-Website { param([string]$Name); $null = $Name }
+    }
+    if (-not (Get-Command -Name 'Get-WebBinding' -ErrorAction SilentlyContinue)) {
+        function global:Get-WebBinding { param([string]$Name, [string]$Protocol); $null = $Name, $Protocol }
+    }
+    if (-not (Get-Command -Name 'Get-IISSite' -ErrorAction SilentlyContinue)) {
+        function global:Get-IISSite { param([string]$Name); $null = $Name }
+    }
+    if (-not (Get-Command -Name 'Get-IISServerManager' -ErrorAction SilentlyContinue)) {
+        function global:Get-IISServerManager { param() }
+    }
+    if (-not (Get-Command -Name 'Get-IISSiteBinding' -ErrorAction SilentlyContinue)) {
+        function global:Get-IISSiteBinding { param([string]$Name, [string]$Protocol); $null = $Name, $Protocol }
+    }
+
+    $script:ModuleName      = 'PSWinOps'
+    $script:RemoteHost      = 'WEB01'
+    $script:RemoteHostLower = 'web01'
+    $script:Host2           = 'WEB02'
+    $script:FailHost        = 'FAILHOST'
+    $script:ValidThumb = 'BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB'
+    $script:OldThumb   = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
+    $script:SiteName   = 'TestSite'
+
+    # Query-phase mock payloads — returned when Invoke-Command ArgumentList.Count -eq 4
+    $script:queryReplaced = @(
+        @{
+            SiteName           = 'TestSite'
+            BindingInformation = '*:443:'
+            Protocol           = 'https'
+            PreviousThumbprint = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
+            NewThumbprint      = 'BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB'
+            CertStoreLocation  = 'Cert:\LocalMachine\My'
+            SslFlags           = 0
+            Status             = 'NeedsReplacement'
+            ErrorMessage       = $null
+            SslKey             = '*!443'
+        }
+    )
+
+    # Apply-phase mock payload — returned when Invoke-Command ArgumentList.Count -eq 6
+    $script:applySuccess = @{
+        Success       = $true
+        NewThumbprint = 'BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB'
+        ErrorMessage  = $null
+    }
+
+    $script:queryAlreadyUpToDate = @(
+        @{
+            SiteName           = 'TestSite'
+            BindingInformation = '*:443:'
+            Protocol           = 'https'
+            PreviousThumbprint = 'BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB'
+            NewThumbprint      = 'BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB'
+            CertStoreLocation  = 'Cert:\LocalMachine\My'
+            SslFlags           = 0
+            Status             = 'AlreadyUpToDate'
+            ErrorMessage       = $null
+            SslKey             = '*!443'
+        }
+    )
+
+    $script:queryCertNotFound = @(
+        @{
+            SiteName           = 'TestSite'
+            BindingInformation = '*:443:'
+            Protocol           = 'https'
+            PreviousThumbprint = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
+            NewThumbprint      = 'BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB'
+            CertStoreLocation  = 'Cert:\LocalMachine\My'
+            SslFlags           = 0
+            Status             = 'CertNotFound'
+            ErrorMessage       = $null
+            SslKey             = '*!443'
+        }
+    )
+
+    $script:queryBindingNotFound = @(
+        @{
+            SiteName           = 'TestSite'
+            BindingInformation = '*:443:'
+            Protocol           = 'https'
+            PreviousThumbprint = $null
+            NewThumbprint      = 'BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB'
+            CertStoreLocation  = 'Cert:\LocalMachine\My'
+            SslFlags           = 0
+            Status             = 'BindingNotFound'
+            ErrorMessage       = "Site 'TestSite' not found."
+            SslKey             = $null
+        }
+    )
+
+    $script:queryFailed = @(
+        @{
+            SiteName           = 'TestSite'
+            BindingInformation = $null
+            Protocol           = 'https'
+            PreviousThumbprint = $null
+            NewThumbprint      = 'BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB'
+            CertStoreLocation  = 'Cert:\LocalMachine\My'
+            SslFlags           = 0
+            Status             = 'Failed'
+            ErrorMessage       = 'Neither WebAdministration nor IISAdministration module is available on the target.'
+            SslKey             = $null
+        }
+    )
+}
+
+Describe 'Set-IISBindingCertificate' {
+
+    # -----------------------------------------------------------------------
+    # Context 1: Happy path — certificate successfully replaced
+    # -----------------------------------------------------------------------
+    Context 'Happy path: certificate replacement succeeds (Status = Replaced)' {
+
+        It 'Should return Status=Replaced when the replacement succeeds' {
+            Mock -CommandName 'Invoke-Command' -ModuleName $script:ModuleName -MockWith {
+                if ($ArgumentList.Count -eq 4) { return $script:queryReplaced }
+                return $script:applySuccess
+            }
+            $result = Set-IISBindingCertificate -ComputerName $script:RemoteHost `
+                -SiteName $script:SiteName -Thumbprint $script:ValidThumb -Force
+            $result.Status | Should -Be 'Replaced'
+            Should -Invoke -CommandName 'Invoke-Command' -ModuleName $script:ModuleName -Times 2 -Exactly
+        }
+
+        It 'Should capture PreviousThumbprint from the existing binding' {
+            Mock -CommandName 'Invoke-Command' -ModuleName $script:ModuleName -MockWith {
+                if ($ArgumentList.Count -eq 4) { return $script:queryReplaced }
+                return $script:applySuccess
+            }
+            $result = Set-IISBindingCertificate -ComputerName $script:RemoteHost `
+                -SiteName $script:SiteName -Thumbprint $script:ValidThumb -Force
+            $result.PreviousThumbprint | Should -Be $script:OldThumb
+            Should -Invoke -CommandName 'Invoke-Command' -ModuleName $script:ModuleName -Times 2 -Exactly
+        }
+
+        It 'Should set NewThumbprint to the requested thumbprint on a successful replacement' {
+            Mock -CommandName 'Invoke-Command' -ModuleName $script:ModuleName -MockWith {
+                if ($ArgumentList.Count -eq 4) { return $script:queryReplaced }
+                return $script:applySuccess
+            }
+            $result = Set-IISBindingCertificate -ComputerName $script:RemoteHost `
+                -SiteName $script:SiteName -Thumbprint $script:ValidThumb -Force
+            $result.NewThumbprint | Should -Be $script:ValidThumb
+            Should -Invoke -CommandName 'Invoke-Command' -ModuleName $script:ModuleName -Times 2 -Exactly
+        }
+
+        It 'Should set PSTypeName to PSWinOps.IISBindingCertificateResult' {
+            Mock -CommandName 'Invoke-Command' -ModuleName $script:ModuleName -MockWith {
+                if ($ArgumentList.Count -eq 4) { return $script:queryReplaced }
+                return $script:applySuccess
+            }
+            $result = Set-IISBindingCertificate -ComputerName $script:RemoteHost `
+                -SiteName $script:SiteName -Thumbprint $script:ValidThumb -Force
+            $result.PSObject.TypeNames[0] | Should -Be 'PSWinOps.IISBindingCertificateResult'
+            Should -Invoke -CommandName 'Invoke-Command' -ModuleName $script:ModuleName -Times 2 -Exactly
+        }
+
+        It 'Should set Timestamp matching the yyyy-MM-dd HH:mm:ss format pattern' {
+            Mock -CommandName 'Invoke-Command' -ModuleName $script:ModuleName -MockWith {
+                if ($ArgumentList.Count -eq 4) { return $script:queryReplaced }
+                return $script:applySuccess
+            }
+            $result = Set-IISBindingCertificate -ComputerName $script:RemoteHost `
+                -SiteName $script:SiteName -Thumbprint $script:ValidThumb -Force
+            $result.Timestamp | Should -Match "^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$"
+            Should -Invoke -CommandName 'Invoke-Command' -ModuleName $script:ModuleName -Times 2 -Exactly
+        }
+
+        It 'Should uppercase the ComputerName in the result object' {
+            Mock -CommandName 'Invoke-Command' -ModuleName $script:ModuleName -MockWith {
+                if ($ArgumentList.Count -eq 4) { return $script:queryReplaced }
+                return $script:applySuccess
+            }
+            $result = Set-IISBindingCertificate -ComputerName $script:RemoteHostLower `
+                -SiteName $script:SiteName -Thumbprint $script:ValidThumb -Force
+            $result.ComputerName | Should -Be 'WEB01'
+            Should -Invoke -CommandName 'Invoke-Command' -ModuleName $script:ModuleName -Times 2 -Exactly
+        }
+    }
+
+    # -----------------------------------------------------------------------
+    # Context 2: Status = AlreadyUpToDate (idempotent no-op)
+    # -----------------------------------------------------------------------
+    Context 'Status = AlreadyUpToDate (idempotent no-op)' {
+
+        It 'Should return Status=AlreadyUpToDate when the thumbprint is already current' {
+            Mock -CommandName 'Invoke-Command' -ModuleName $script:ModuleName -MockWith {
+                return $script:queryAlreadyUpToDate
+            }
+            $result = Set-IISBindingCertificate -ComputerName $script:RemoteHost `
+                -SiteName $script:SiteName -Thumbprint $script:ValidThumb -Force
+            $result.Status | Should -Be 'AlreadyUpToDate'
+            Should -Invoke -CommandName 'Invoke-Command' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should set NewThumbprint to the requested thumbprint when AlreadyUpToDate' {
+            Mock -CommandName 'Invoke-Command' -ModuleName $script:ModuleName -MockWith {
+                return $script:queryAlreadyUpToDate
+            }
+            $result = Set-IISBindingCertificate -ComputerName $script:RemoteHost `
+                -SiteName $script:SiteName -Thumbprint $script:ValidThumb -Force
+            $result.NewThumbprint | Should -Be $script:ValidThumb
+            Should -Invoke -CommandName 'Invoke-Command' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should not invoke the apply phase (Invoke-Command exactly once) when AlreadyUpToDate' {
+            Mock -CommandName 'Invoke-Command' -ModuleName $script:ModuleName -MockWith {
+                return $script:queryAlreadyUpToDate
+            }
+            Set-IISBindingCertificate -ComputerName $script:RemoteHost `
+                -SiteName $script:SiteName -Thumbprint $script:ValidThumb -Force
+            Should -Invoke -CommandName 'Invoke-Command' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+    }
+
+    # -----------------------------------------------------------------------
+    # Context 3: Status = CertNotFound
+    # -----------------------------------------------------------------------
+    Context 'Status = CertNotFound (certificate not present in store)' {
+
+        It 'Should return Status=CertNotFound when the thumbprint is absent from CertStoreLocation' {
+            Mock -CommandName 'Invoke-Command' -ModuleName $script:ModuleName -MockWith {
+                return $script:queryCertNotFound
+            }
+            $result = Set-IISBindingCertificate -ComputerName $script:RemoteHost `
+                -SiteName $script:SiteName -Thumbprint $script:ValidThumb -Force
+            $result.Status | Should -Be 'CertNotFound'
+            Should -Invoke -CommandName 'Invoke-Command' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should not invoke the apply phase when Status=CertNotFound' {
+            Mock -CommandName 'Invoke-Command' -ModuleName $script:ModuleName -MockWith {
+                return $script:queryCertNotFound
+            }
+            Set-IISBindingCertificate -ComputerName $script:RemoteHost `
+                -SiteName $script:SiteName -Thumbprint $script:ValidThumb -Force
+            Should -Invoke -CommandName 'Invoke-Command' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+    }
+
+    # -----------------------------------------------------------------------
+    # Context 4: Status = BindingNotFound
+    # -----------------------------------------------------------------------
+    Context 'Status = BindingNotFound (site or https binding absent)' {
+
+        It 'Should return Status=BindingNotFound when the target IIS site does not exist' {
+            Mock -CommandName 'Invoke-Command' -ModuleName $script:ModuleName -MockWith {
+                return $script:queryBindingNotFound
+            }
+            $result = Set-IISBindingCertificate -ComputerName $script:RemoteHost `
+                -SiteName $script:SiteName -Thumbprint $script:ValidThumb -Force
+            $result.Status | Should -Be 'BindingNotFound'
+            Should -Invoke -CommandName 'Invoke-Command' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should populate ErrorMessage when Status=BindingNotFound' {
+            Mock -CommandName 'Invoke-Command' -ModuleName $script:ModuleName -MockWith {
+                return $script:queryBindingNotFound
+            }
+            $result = Set-IISBindingCertificate -ComputerName $script:RemoteHost `
+                -SiteName $script:SiteName -Thumbprint $script:ValidThumb -Force
+            $result.ErrorMessage | Should -Not -BeNullOrEmpty
+            Should -Invoke -CommandName 'Invoke-Command' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+    }
+
+    # -----------------------------------------------------------------------
+    # Context 5: Status = Failed
+    # -----------------------------------------------------------------------
+    Context 'Status = Failed (IIS module unavailable or apply exception)' {
+
+        It 'Should return Status=Failed when no IIS module is available on the target' {
+            Mock -CommandName 'Invoke-Command' -ModuleName $script:ModuleName -MockWith {
+                return $script:queryFailed
+            }
+            $result = Set-IISBindingCertificate -ComputerName $script:RemoteHost `
+                -SiteName $script:SiteName -Thumbprint $script:ValidThumb -Force
+            $result.Status | Should -Be 'Failed'
+            Should -Invoke -CommandName 'Invoke-Command' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should populate ErrorMessage when Status=Failed due to missing IIS module' {
+            Mock -CommandName 'Invoke-Command' -ModuleName $script:ModuleName -MockWith {
+                return $script:queryFailed
+            }
+            $result = Set-IISBindingCertificate -ComputerName $script:RemoteHost `
+                -SiteName $script:SiteName -Thumbprint $script:ValidThumb -Force
+            $result.ErrorMessage | Should -Not -BeNullOrEmpty
+            Should -Invoke -CommandName 'Invoke-Command' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should return Status=Failed with ErrorMessage when the apply phase throws' {
+            Mock -CommandName 'Invoke-Command' -ModuleName $script:ModuleName -MockWith {
+                if ($ArgumentList.Count -eq 4) { return $script:queryReplaced }
+                throw 'SSL binding update failed on target'
+            }
+            $result = Set-IISBindingCertificate -ComputerName $script:RemoteHost `
+                -SiteName $script:SiteName -Thumbprint $script:ValidThumb -Force
+            $result.Status | Should -Be 'Failed'
+            $result.ErrorMessage | Should -Not -BeNullOrEmpty
+            Should -Invoke -CommandName 'Invoke-Command' -ModuleName $script:ModuleName -Times 2 -Exactly
+        }
+    }
+
+    # -----------------------------------------------------------------------
+    # Context 6: ShouldProcess (-WhatIf suppresses mutations)
+    # -----------------------------------------------------------------------
+    Context 'ShouldProcess: -WhatIf suppresses all mutations (0 apply-phase calls)' {
+
+        It 'Should call Invoke-Command only once (query) when -WhatIf is specified' {
+            Mock -CommandName 'Invoke-Command' -ModuleName $script:ModuleName -MockWith {
+                if ($ArgumentList.Count -eq 4) { return $script:queryReplaced }
+                return $script:applySuccess
+            }
+            Set-IISBindingCertificate -ComputerName $script:RemoteHost `
+                -SiteName $script:SiteName -Thumbprint $script:ValidThumb -WhatIf
+            Should -Invoke -CommandName 'Invoke-Command' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should produce no result objects for NeedsReplacement bindings when -WhatIf is used' {
+            Mock -CommandName 'Invoke-Command' -ModuleName $script:ModuleName -MockWith {
+                if ($ArgumentList.Count -eq 4) { return $script:queryReplaced }
+                return $script:applySuccess
+            }
+            $result = Set-IISBindingCertificate -ComputerName $script:RemoteHost `
+                -SiteName $script:SiteName -Thumbprint $script:ValidThumb -WhatIf
+            $result | Should -BeNullOrEmpty
+            Should -Invoke -CommandName 'Invoke-Command' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+    }
+
+    # -----------------------------------------------------------------------
+    # Context 7: Pipeline input by property name
+    # -----------------------------------------------------------------------
+    Context 'Pipeline input by property name (ComputerName, SiteName, Thumbprint, BindingInformation)' {
+
+        It 'Should accept ComputerName, SiteName, and Thumbprint bound from pipeline object properties' {
+            Mock -CommandName 'Invoke-Command' -ModuleName $script:ModuleName -MockWith {
+                return $script:queryAlreadyUpToDate
+            }
+            $pipelineInput = [PSCustomObject]@{
+                ComputerName = $script:RemoteHost
+                SiteName     = $script:SiteName
+                Thumbprint   = $script:ValidThumb
+            }
+            $result = $pipelineInput | Set-IISBindingCertificate -Force
+            $result | Should -Not -BeNullOrEmpty
+            $result.Status | Should -Be 'AlreadyUpToDate'
+            Should -Invoke -CommandName 'Invoke-Command' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should bind BindingInformation from pipeline object property by name' {
+            Mock -CommandName 'Invoke-Command' -ModuleName $script:ModuleName -MockWith {
+                return $script:queryAlreadyUpToDate
+            }
+            $pipelineInput = [PSCustomObject]@{
+                ComputerName       = $script:RemoteHost
+                SiteName           = $script:SiteName
+                Thumbprint         = $script:ValidThumb
+                BindingInformation = '*:443:'
+            }
+            $result = $pipelineInput | Set-IISBindingCertificate -Force
+            $result | Should -Not -BeNullOrEmpty
+            Should -Invoke -CommandName 'Invoke-Command' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+    }
+
+    # -----------------------------------------------------------------------
+    # Context 8: Credential propagation
+    # -----------------------------------------------------------------------
+    Context 'Credential propagation: PSCredential is forwarded to Invoke-Command' {
+
+        It 'Should pass a non-null Credential to Invoke-Command when -Credential is specified' {
+            $securePass = [System.Security.SecureString]::new()
+            'P@ssw0rd!'.ToCharArray() | ForEach-Object { $securePass.AppendChar($_) }
+            $cred = [System.Management.Automation.PSCredential]::new('DOMAIN\admin', $securePass)
+            Mock -CommandName 'Invoke-Command' -ModuleName $script:ModuleName -MockWith {
+                return $script:queryAlreadyUpToDate
+            }
+            Set-IISBindingCertificate -ComputerName $script:RemoteHost `
+                -SiteName $script:SiteName -Thumbprint $script:ValidThumb `
+                -Credential $cred -Force
+            Should -Invoke -CommandName 'Invoke-Command' -ModuleName $script:ModuleName -Times 1 -Exactly -ParameterFilter {
+                $null -ne $Credential
+            }
+        }
+    }
+
+    # -----------------------------------------------------------------------
+    # Context 9: ComputerName fan-out
+    # -----------------------------------------------------------------------
+    Context 'ComputerName fan-out: one result per computer in the array' {
+
+        It 'Should return one result object per computer when multiple ComputerNames are provided' {
+            Mock -CommandName 'Invoke-Command' -ModuleName $script:ModuleName -MockWith {
+                return $script:queryAlreadyUpToDate
+            }
+            $results = Set-IISBindingCertificate -ComputerName $script:RemoteHost, $script:Host2 `
+                -SiteName $script:SiteName -Thumbprint $script:ValidThumb -Force
+            @($results).Count | Should -Be 2
+            Should -Invoke -CommandName 'Invoke-Command' -ModuleName $script:ModuleName -Times 2 -Exactly
+        }
+
+        It 'Should set distinct ComputerName values for each result object in a multi-host call' {
+            Mock -CommandName 'Invoke-Command' -ModuleName $script:ModuleName -MockWith {
+                return $script:queryAlreadyUpToDate
+            }
+            $results = Set-IISBindingCertificate -ComputerName $script:RemoteHost, $script:Host2 `
+                -SiteName $script:SiteName -Thumbprint $script:ValidThumb -Force
+            $computerNames = @($results).ComputerName
+            $computerNames | Should -Contain 'WEB01'
+            $computerNames | Should -Contain 'WEB02'
+            Should -Invoke -CommandName 'Invoke-Command' -ModuleName $script:ModuleName -Times 2 -Exactly
+        }
+    }
+
+    # -----------------------------------------------------------------------
+    # Context 10: Error isolation per machine
+    # -----------------------------------------------------------------------
+    Context 'Error isolation: one failing machine does not abort the rest' {
+
+        It 'Should continue processing remaining computers after one machine throws' {
+            Mock -CommandName 'Invoke-Command' -ModuleName $script:ModuleName -MockWith {
+                if ($ComputerName -eq 'FAILHOST') { throw 'Connection refused' }
+                return $script:queryAlreadyUpToDate
+            }
+            $results = Set-IISBindingCertificate -ComputerName $script:FailHost, $script:RemoteHost `
+                -SiteName $script:SiteName -Thumbprint $script:ValidThumb -Force `
+                -ErrorAction SilentlyContinue
+            @($results).Count | Should -Be 1
+            $results[0].ComputerName | Should -Be 'WEB01'
+            Should -Invoke -CommandName 'Invoke-Command' -ModuleName $script:ModuleName -Times 2 -Exactly
+        }
+
+        It 'Should write a non-terminating error for the failing machine' {
+            Mock -CommandName 'Invoke-Command' -ModuleName $script:ModuleName -MockWith {
+                throw 'Connection refused'
+            }
+            $errorVar = @()
+            $null = Set-IISBindingCertificate -ComputerName $script:FailHost `
+                -SiteName $script:SiteName -Thumbprint $script:ValidThumb `
+                -Force -ErrorAction SilentlyContinue -ErrorVariable errorVar
+            $errorVar | Should -Not -BeNullOrEmpty
+            Should -Invoke -CommandName 'Invoke-Command' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+    }
+
+    # -----------------------------------------------------------------------
+    # Context 11: BOM and CRLF sentinel
+    # -----------------------------------------------------------------------
+    Context 'BOM and CRLF line-ending sentinel (encoding contract)' {
+
+        It 'Should have a UTF-8 BOM (EF BB BF) as the first three bytes of the test file' {
+            $filePath = Join-Path -Path $PSScriptRoot -ChildPath 'Set-IISBindingCertificate.Tests.ps1'
+            $bytes = [System.IO.File]::ReadAllBytes($filePath)
+            $bytes[0] | Should -Be 0xEF
+            $bytes[1] | Should -Be 0xBB
+            $bytes[2] | Should -Be 0xBF
+        }
+
+        It 'Should use CRLF line endings throughout the test file source' {
+            $filePath = Join-Path -Path $PSScriptRoot -ChildPath 'Set-IISBindingCertificate.Tests.ps1'
+            $content = Get-Content -Path $filePath -Raw
+            $content | Should -Match "`r`n"
+        }
+    }
+
+    # -----------------------------------------------------------------------
+    # Context 12: Parameter validation and CmdletBinding attributes
+    # -----------------------------------------------------------------------
+    Context 'Parameter validation and CmdletBinding attributes' {
+
+        It 'Should have CmdletBinding with SupportsShouldProcess enabled' {
+            $cmd = Get-Command -Name 'Set-IISBindingCertificate'
+            $attr = $cmd.ScriptBlock.Attributes |
+                Where-Object { $_ -is [System.Management.Automation.CmdletBindingAttribute] }
+            $attr.SupportsShouldProcess | Should -BeTrue
+        }
+
+        It 'Should have ConfirmImpact set to High' {
+            $cmd = Get-Command -Name 'Set-IISBindingCertificate'
+            $attr = $cmd.ScriptBlock.Attributes |
+                Where-Object { $_ -is [System.Management.Automation.CmdletBindingAttribute] }
+            $attr.ConfirmImpact | Should -Be 'High'
+        }
+
+        It 'Should reject a Thumbprint that is not 40 hexadecimal characters' {
+            { Set-IISBindingCertificate -SiteName 'TestSite' -Thumbprint 'TOOSHORT' -Force } |
+                Should -Throw
+        }
+
+        It 'Should accept a valid 40-character hex Thumbprint without throwing' {
+            Mock -CommandName 'Invoke-Command' -ModuleName $script:ModuleName -MockWith {
+                return $script:queryAlreadyUpToDate
+            }
+            { Set-IISBindingCertificate -ComputerName $script:RemoteHost `
+                -SiteName $script:SiteName -Thumbprint $script:ValidThumb -Force } |
+                Should -Not -Throw
+            Should -Invoke -CommandName 'Invoke-Command' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+    }
+}

--- a/en-US/about_PSWinOps.help.txt
+++ b/en-US/about_PSWinOps.help.txt
@@ -12,7 +12,7 @@ LONG DESCRIPTION
     PSWinOps is a comprehensive toolbox designed for Windows
     system administrators running PowerShell 5.1 or later.
     It provides a curated collection of functions organized
-    into ten functional domains, covering everything from
+    into eleven functional domains, covering everything from
     Active Directory inventory and security auditing,
     service health monitoring, network troubleshooting,
     NTP synchronization, proxy management, RDP session
@@ -31,7 +31,7 @@ LONG DESCRIPTION
     Requires    : PowerShell 5.1+ / Windows only
 
 FUNCTION DOMAINS
-    PSWinOps organizes its functions into ten domains.
+    PSWinOps organizes its functions into eleven domains.
 
   activedirectory (21 functions)
     Functions for Active Directory inventory, user and
@@ -83,6 +83,13 @@ FUNCTION DOMAINS
       Get-RDSHealth
       Get-ServiceHealth
       Get-WSUSHealth
+
+  iis (1 function)
+    Functions for managing IIS HTTPS site bindings,
+    including SSL/TLS certificate rotation across
+    local or remote servers via WinRM.
+
+      Set-IISBindingCertificate
 
   network (24 functions)
     Functions for network diagnostics, discovery,
@@ -275,7 +282,7 @@ REMOTE EXECUTION PATTERN
     in the pipeline continue to be processed.
 
 PSWINOPS TYPE REGISTRY
-    The following 86 PSTypeName values are defined by the
+    The following 87 PSTypeName values are defined by the
     module. Each corresponds to the output of one or more
     public functions.
 
@@ -320,6 +327,7 @@ PSWINOPS TYPE REGISTRY
       PSWinOps.ExchangeServerHealth
       PSWinOps.FileServerHealth
       PSWinOps.HyperVHostHealth
+      PSWinOps.IISBindingCertificateResult
       PSWinOps.IISHealth
       PSWinOps.InstalledSoftware
       PSWinOps.ListeningPort


### PR DESCRIPTION
## Summary

Adds **`Set-IISBindingCertificate`**, a new IIS-domain public function that replaces the SSL/TLS certificate on one or more IIS HTTPS site bindings, with idempotent rotation, `-WhatIf` / `-Confirm` (`ConfirmImpact=High`), and remote execution via WinRM. Supports pipeline-by-property-name from `Get-SSLCertificate` and `Get-IISHealth`, and a new strongly-typed `PSWinOps.IISBindingCertificateResult` output with a default `TableControl` view. Introduces the new `Public/iis/` domain (registered in the CI matrix and `about_PSWinOps`). Bumps module version `0.0.22 -> 0.1.1` and updates release notes.

## Files touched

| File | Change |
| --- | --- |
| `Public/iis/Set-IISBindingCertificate.ps1` | NEW - public function (BOM, 5.1 compatible, `SupportsShouldProcess`) |
| `Tests/Public/iis/Set-IISBindingCertificate.Tests.ps1` | NEW - 31 Pester v5 tests, mocked WebAdministration/IISAdministration |
| `PSWinOps.psd1` | Version `0.0.22 -> 0.1.1`; insert `Set-IISBindingCertificate` in `FunctionsToExport`; prepend release notes block |
| `PSWinOps.Format.ps1xml` | NEW `<View>` for `PSWinOps.IISBindingCertificateResult` (TableControl) |
| `en-US/about_PSWinOps.help.txt` | New `iis (1 function)` domain section; PSType registry +1; domain count `ten -> eleven` |
| `.github/workflows/ci.yml` | New `Public/iis` entry in the test matrix |
| `.kdust/chains/set-iisbindingcertificate-2605141647.yaml` | Chain metadata |
| `.gitignore` | Minor housekeeping |

## Conformance checklist

- [x] `Test-ModuleManifest ./PSWinOps.psd1` succeeds - `PSWinOps v0.1.1`, 109 exported functions
- [x] `Invoke-ScriptAnalyzer` - **0** Error/Warning findings on `Set-IISBindingCertificate.ps1` + `.Tests.ps1`
- [x] UTF-8 BOM present on the new `.ps1` (head bytes `ef bb bf`)
- [x] LF line endings in repo (per project `.gitattributes`: normalize to LF in repo, CRLF on Windows checkout via `core.autocrlf=true`)
- [x] No `Write-Host` introduced in the diff
- [x] No `ToString().o.` introduced in the diff
- [x] `FunctionsToExport` contains `Set-IISBindingCertificate` **exactly once**, between `Search-ADObject` and `Set-NetworkRoute`
- [x] `FunctionsToExport` array case-insensitively sorted (validated with `sort -fc`)
- [x] `PSWinOps.Format.ps1xml` validates as XML; contains a `<View>` whose `<ViewSelectedBy>/<TypeName>` matches `PSWinOps.IISBindingCertificateResult`
- [x] `en-US/about_PSWinOps.help.txt` - new `iis (1 function)` section matches actual directory; PSType registry counter `86 -> 87`; domain count phrasing updated
- [x] Module version bumped (chain prompt: patch++ on `0.1.0`)
- [x] Release notes block prepended for `0.1.1 - 2026-05-14`

## Caveat

Pester suite (`Tests/Public/iis/Set-IISBindingCertificate.Tests.ps1`, 31 tests) was not executed locally - the module is Windows-only (`throw` on non-Windows in `PSWinOps.psm1`) and the audit container is Linux. The Windows CI runners on this PR are the authoritative test gate.
