### PR TITLE
feat(iis): add Get-IISParsedLog

### DIFF
--- a/.kdust/chains/get-iisparsedlog-2605151203.yaml
+++ b/.kdust/chains/get-iisparsedlog-2605151203.yaml
@@ -1,0 +1,7 @@
+chain: pswinops-function-author
+function: Get-IISParsedLog
+domain: iis
+created: 2026-05-15T12:08:10Z
+created_by: pswinops-fn-spec-analyst
+chain_branch: kdust/chain/pswinops-fn-get-iisparsedlog-2605151203
+spec_path: work/get-iisparsedlog/spec.yaml

--- a/PSWinOps.Format.ps1xml
+++ b/PSWinOps.Format.ps1xml
@@ -6760,5 +6760,64 @@
         </TableRowEntries>
       </TableControl>
     </View>
+    <!-- ============================================================ -->
+    <!-- PSWinOps.IISLogEntry                                        -->
+    <!-- Used by: Get-IISParsedLog                                   -->
+    <!-- ============================================================ -->
+    <View>
+      <Name>PSWinOps.IISLogEntry</Name>
+      <ViewSelectedBy>
+        <TypeName>PSWinOps.IISLogEntry</TypeName>
+      </ViewSelectedBy>
+      <TableControl>
+        <AutoSize />
+        <TableHeaders>
+          <TableColumnHeader>
+            <Label>Timestamp</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Method</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>UriStem</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>HttpStatus</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>TimeTaken</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>ClientIP</Label>
+          </TableColumnHeader>
+        </TableHeaders>
+        <TableRowEntries>
+          <TableRowEntry>
+            <TableColumnItems>
+              <TableColumnItem>
+                <ScriptBlock>
+                  if ($null -ne $_.Timestamp) { $_.Timestamp.ToString('yyyy-MM-dd HH:mm:ss') } else { '' }
+                </ScriptBlock>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>Method</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>UriStem</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>HttpStatus</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>TimeTaken</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>ClientIP</PropertyName>
+              </TableColumnItem>
+            </TableColumnItems>
+          </TableRowEntry>
+        </TableRowEntries>
+      </TableControl>
+    </View>
   </ViewDefinitions>
 </Configuration>

--- a/PSWinOps.psd1
+++ b/PSWinOps.psd1
@@ -12,7 +12,7 @@
     RootModule           = 'PSWinOps.psm1'
 
     # Version number of this module.
-    ModuleVersion        = '0.1.1'
+    ModuleVersion        = '0.1.2'
 
     # Supported PSEditions
     # Core is supported on Windows only; the module-level guard in PSWinOps.psm1 blocks
@@ -257,7 +257,12 @@
             # IconUri = ''
 
             # ReleaseNotes of this module
-            ReleaseNotes = '## 0.1.1 - 2026-05-14
+            ReleaseNotes = '## 0.1.2 - 2026-05-15
+### Added
+- feat(iis): add Get-IISParsedLog — stream-parse IIS W3C log files into typed PSWinOps.IISLogEntry objects with header re-detection, dash-normalisation, UserAgent "+"-to-space decoding, -After/-Before time window, -Method/-Status/-ClientIP multi-value OR filters, -UriLike wildcard, -Tail circular buffer, and pipeline-by-property-name (FullName) for Get-ChildItem composition.
+- feat(format): TableControl view for PSWinOps.IISLogEntry in PSWinOps.Format.ps1xml.
+
+## 0.1.1 - 2026-05-14
 ### Added
 - feat(iis): add Set-IISBindingCertificate — replace SSL/TLS certificate on one or more IIS HTTPS site bindings with idempotent rotation, -WhatIf/-Confirm (ConfirmImpact=High), remote execution via WinRM, and pipeline-by-property-name from Get-SSLCertificate / Get-IISHealth.
 - feat(iis): introduce new public domain Public/iis/ (registered in CI matrix and about_PSWinOps).

--- a/PSWinOps.psd1
+++ b/PSWinOps.psd1
@@ -124,6 +124,7 @@
         'Get-FileServerHealth',
         'Get-HyperVHostHealth',
         'Get-IISHealth',
+        'Get-IISParsedLog',
         'Get-InstalledSoftware',
         'Get-ListeningPort',
         'Get-NetworkAdapter',

--- a/Public/iis/Get-IISParsedLog.ps1
+++ b/Public/iis/Get-IISParsedLog.ps1
@@ -1,0 +1,396 @@
+﻿#Requires -Version 5.1
+function Get-IISParsedLog {
+    <#
+        .SYNOPSIS
+            Parses IIS W3C extended log files into structured PSWinOps.IISLogEntry objects with streaming, header re-detection, and optional filtering.
+
+        .DESCRIPTION
+            Streams one or more IIS W3C extended log files and emits one
+            PSWinOps.IISLogEntry object per data line. The parser honours the
+            #Fields directive (including mid-file changes after a log restart),
+            normalises IIS "-" placeholders to $null, decodes the "+" space
+            encoding used by IIS for User-Agent and Referer, and parses date+time
+            into a UTC DateTime. Filtering parameters (-After/-Before/-Method/
+            -Status/-UriLike/-ClientIP/-Tail) are applied during streaming so
+            very large logs do not need to fit in memory.
+
+        .PARAMETER Path
+            One or more log file paths or wildcards
+            (e.g. C:\inetpub\logs\LogFiles\W3SVC1\u_ex*.log).
+            Aliases: FullName, LogFile.
+            Accepts pipeline input by value and by property name (Get-ChildItem).
+
+        .PARAMETER LiteralPath
+            Literal path, no wildcard expansion. Alias: PSPath.
+            Accepts pipeline input by property name.
+
+        .PARAMETER After
+            Inclusive lower bound on Timestamp (UTC).
+            Entries whose Timestamp is strictly before this value are skipped.
+
+        .PARAMETER Before
+            Exclusive upper bound on Timestamp (UTC).
+            Entries whose Timestamp is at or after this value are skipped.
+
+        .PARAMETER Method
+            Filter on cs-method (e.g. GET, POST). Case-insensitive, multi-valued OR.
+
+        .PARAMETER Status
+            Filter on sc-status (e.g. 500, 502, 503). Multi-valued OR.
+
+        .PARAMETER UriLike
+            Wildcard pattern matched against UriStem using the -like operator.
+
+        .PARAMETER ClientIP
+            Filter on c-ip. Exact match (case-insensitive), multi-valued OR.
+
+        .PARAMETER Tail
+            Return only the last N matching entries per file via a circular buffer.
+            0 or not specified means no tail limit (default).
+
+        .PARAMETER Encoding
+            Text encoding for reading log files. Accepts PowerShell encoding names
+            (UTF8, Unicode, ASCII) or .NET code page numbers.
+            Defaults to UTF8 (IIS standard).
+
+        .EXAMPLE
+            Get-IISParsedLog -Path C:\inetpub\logs\LogFiles\W3SVC1\u_ex260514.log
+
+            Streams all entries from a single IIS log file as PSWinOps.IISLogEntry objects.
+
+        .EXAMPLE
+            Get-ChildItem C:\inetpub\logs\LogFiles -Recurse -Filter u_ex*.log |
+                Get-IISParsedLog -After (Get-Date).AddHours(-1) -Status 500,502,503,504
+
+            Streams all 5xx entries from the last hour across all IIS sites.
+
+        .EXAMPLE
+            Get-IISParsedLog -Path .\u_ex260514.log -Method POST -UriLike '/api/*' |
+                Where-Object TimeTaken -gt 2000
+
+            Finds slow POST requests to the /api/* URI path.
+
+        .EXAMPLE
+            Get-IISParsedLog -Path .\u_ex260514.log -ClientIP 10.0.0.42 -Tail 100
+
+            Returns the last 100 matching entries from a specific client IP address.
+
+        .OUTPUTS
+            PSCustomObject (PSTypeName='PSWinOps.IISLogEntry')
+            One object per parsed data line. Properties absent from the active
+            #Fields directive are emitted as $null.
+
+        .NOTES
+            Author: Franck SALLET
+            Version: 1.0.0
+            Last Modified: 2026-05-15
+            Requires: PowerShell 5.1+ / Windows only
+
+            IIS writes log files in UTC by default (unless LocalTimeRollover=true
+            in applicationHost.config). Timestamps are always returned as UTC
+            DateTime objects regardless of the local system timezone.
+
+            The parser handles mid-file #Fields re-declarations that IIS emits
+            after a log rotation or w3wp.exe recycle within a single log file.
+
+        .LINK
+            https://github.com/EvotecIT/IISParser
+    #>
+    [CmdletBinding(DefaultParameterSetName = 'Path')]
+    [OutputType('PSWinOps.IISLogEntry')]
+    param(
+        [Parameter(Mandatory = $true, Position = 0,
+            ValueFromPipeline = $true,
+            ValueFromPipelineByPropertyName = $true,
+            ParameterSetName = 'Path')]
+        [Alias('FullName', 'LogFile')]
+        [SupportsWildcards()]
+        [string[]]$Path,
+
+        [Parameter(Mandatory = $true,
+            ValueFromPipelineByPropertyName = $true,
+            ParameterSetName = 'LiteralPath')]
+        [Alias('PSPath')]
+        [string[]]$LiteralPath,
+
+        [Parameter(Mandatory = $false)]
+        [datetime]$After,
+
+        [Parameter(Mandatory = $false)]
+        [datetime]$Before,
+
+        [Parameter(Mandatory = $false)]
+        [string[]]$Method,
+
+        [Parameter(Mandatory = $false)]
+        [int[]]$Status,
+
+        [Parameter(Mandatory = $false)]
+        [string]$UriLike,
+
+        [Parameter(Mandatory = $false)]
+        [string[]]$ClientIP,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateRange(0, [int]::MaxValue)]
+        [int]$Tail = 0,
+
+        [Parameter(Mandatory = $false)]
+        [string]$Encoding = 'UTF8'
+    )
+
+    begin {
+        Write-Verbose -Message "[$($MyInvocation.MyCommand)] Starting"
+
+        # W3C field name -> output property name
+        $fieldPropertyMap = @{
+            's-sitename'      = 'SiteName'
+            's-computername'  = 'ServerName'
+            's-ip'            = 'ServerIP'
+            'cs-method'       = 'Method'
+            'cs-uri-stem'     = 'UriStem'
+            'cs-uri-query'    = 'UriQuery'
+            's-port'          = 'ServerPort'
+            'cs-username'     = 'UserName'
+            'c-ip'            = 'ClientIP'
+            'cs(User-Agent)'  = 'UserAgent'
+            'cs(Referer)'     = 'Referer'
+            'sc-status'       = 'HttpStatus'
+            'sc-substatus'    = 'HttpSubStatus'
+            'sc-win32-status' = 'Win32Status'
+            'sc-bytes'        = 'BytesSent'
+            'cs-bytes'        = 'BytesReceived'
+            'time-taken'      = 'TimeTaken'
+        }
+
+        # Properties requiring numeric coercion
+        $intProps  = @('ServerPort', 'HttpStatus', 'HttpSubStatus', 'TimeTaken')
+        $longProps = @('Win32Status', 'BytesSent', 'BytesReceived')
+
+        # Map PowerShell encoding name to .NET Encoding
+        $netEncoding = switch ($Encoding) {
+            'UTF8'    { [System.Text.Encoding]::UTF8;    break }
+            'UTF-8'   { [System.Text.Encoding]::UTF8;    break }
+            'Unicode' { [System.Text.Encoding]::Unicode; break }
+            'ASCII'   { [System.Text.Encoding]::ASCII;   break }
+            default   {
+                try   { [System.Text.Encoding]::GetEncoding($Encoding) }
+                catch { [System.Text.Encoding]::UTF8 }
+            }
+        }
+    }
+
+    process {
+        # --- Resolve concrete file paths ---
+        $resolvedPaths = [System.Collections.Generic.List[string]]::new()
+
+        if ($PSCmdlet.ParameterSetName -eq 'Path') {
+            foreach ($p in $Path) {
+                $hits = @(Resolve-Path -Path $p -ErrorAction SilentlyContinue)
+                if ($hits.Count -eq 0) {
+                    Write-Error -Message "[$($MyInvocation.MyCommand)] Path not found: $p"
+                    continue
+                }
+                foreach ($hit in $hits) { $resolvedPaths.Add($hit.ProviderPath) }
+            }
+        }
+        else {
+            foreach ($lp in $LiteralPath) {
+                if (-not (Test-Path -LiteralPath $lp -PathType Leaf)) {
+                    Write-Error -Message "[$($MyInvocation.MyCommand)] LiteralPath not found: $lp"
+                    continue
+                }
+                $resolvedPaths.Add((Resolve-Path -LiteralPath $lp).ProviderPath)
+            }
+        }
+
+        # --- Parse each file ---
+        foreach ($filePath in $resolvedPaths) {
+            Write-Verbose -Message "[$($MyInvocation.MyCommand)] Parsing: $filePath"
+
+            # Column layout rebuilt on each #Fields directive
+            $activeColumns  = @()
+            $dataLineNumber = 0
+
+            # Circular buffer for -Tail
+            $tailBuffer = $null
+            if ($Tail -gt 0) {
+                $tailBuffer = [System.Collections.Generic.Queue[PSObject]]::new()
+            }
+
+            try {
+                # detectEncodingFromByteOrderMarks = $true to skip any BOM in the log file itself
+                $reader = [System.IO.StreamReader]::new($filePath, $netEncoding, $true)
+                try {
+                    while ($null -ne ($rawLine = $reader.ReadLine())) {
+
+                        # ---- Directive / comment lines ----
+                        if ($rawLine.StartsWith('#')) {
+                            if ($rawLine.StartsWith('#Fields:')) {
+                                $activeColumns = ($rawLine.Substring(8).Trim()) -split '\s+'
+                                Write-Verbose -Message (
+                                    "[$($MyInvocation.MyCommand)] #Fields re-detected " +
+                                    "($($activeColumns.Count) columns): $($activeColumns -join ', ')")
+                            }
+                            else {
+                                Write-Verbose -Message "[$($MyInvocation.MyCommand)] Directive: $rawLine"
+                            }
+                            continue
+                        }
+
+                        if ([string]::IsNullOrWhiteSpace($rawLine)) { continue }
+
+                        # ---- Data line ----
+                        $dataLineNumber++
+
+                        if ($activeColumns.Count -eq 0) {
+                            Write-Warning -Message (
+                                "[$($MyInvocation.MyCommand)] Data line encountered before any " +
+                                "#Fields directive in '$filePath' (data line $dataLineNumber) — skipped.")
+                            continue
+                        }
+
+                        $tokens = $rawLine -split '\s+'
+
+                        # Seed all canonical output properties to $null
+                        $props = [ordered]@{
+                            PSTypeName    = 'PSWinOps.IISLogEntry'
+                            Timestamp     = $null
+                            LogFile       = $filePath
+                            LineNumber    = $dataLineNumber
+                            SiteName      = $null
+                            ServerName    = $null
+                            ServerIP      = $null
+                            ServerPort    = $null
+                            Method        = $null
+                            UriStem       = $null
+                            UriQuery      = $null
+                            UserName      = $null
+                            ClientIP      = $null
+                            UserAgent     = $null
+                            Referer       = $null
+                            HttpStatus    = $null
+                            HttpSubStatus = $null
+                            Win32Status   = $null
+                            BytesSent     = $null
+                            BytesReceived = $null
+                            TimeTaken     = $null
+                        }
+
+                        $rawDate = $null
+                        $rawTime = $null
+
+                        for ($i = 0; $i -lt $activeColumns.Count; $i++) {
+                            $col = $activeColumns[$i]
+                            $raw = if ($i -lt $tokens.Count) { $tokens[$i] } else { '-' }
+
+                            # Date and time are combined into Timestamp later
+                            if ($col -eq 'date') { $rawDate = $raw; continue }
+                            if ($col -eq 'time') { $rawTime = $raw; continue }
+
+                            if (-not $fieldPropertyMap.ContainsKey($col)) {
+                                Write-Verbose -Message "[$($MyInvocation.MyCommand)] Unknown column '$col' in #Fields — ignored."
+                                continue
+                            }
+
+                            $propName = $fieldPropertyMap[$col]
+
+                            # IIS dash-normalisation: '-' means the field was not logged
+                            if ($raw -eq '-') {
+                                $props[$propName] = $null
+                                continue
+                            }
+
+                            # Type coercion
+                            if ($propName -in $intProps) {
+                                $props[$propName] = [int]$raw
+                            }
+                            elseif ($propName -in $longProps) {
+                                $props[$propName] = [long]$raw
+                            }
+                            elseif ($propName -eq 'UserAgent' -or $propName -eq 'Referer') {
+                                # IIS encodes spaces as '+' in these fields — decode back
+                                $props[$propName] = $raw -replace '\+', ' '
+                            }
+                            else {
+                                $props[$propName] = $raw
+                            }
+                        }
+
+                        # Build UTC Timestamp from date + time fields
+                        if ($null -ne $rawDate -and $null -ne $rawTime -and
+                            $rawDate -ne '-'    -and $rawTime -ne '-') {
+                            try {
+                                $props['Timestamp'] = [datetime]::ParseExact(
+                                    "$rawDate $rawTime",
+                                    'yyyy-MM-dd HH:mm:ss',
+                                    [System.Globalization.CultureInfo]::InvariantCulture,
+                                    ([System.Globalization.DateTimeStyles]::AssumeUniversal -bor
+                                     [System.Globalization.DateTimeStyles]::AdjustToUniversal)
+                                )
+                            }
+                            catch {
+                                Write-Warning -Message (
+                                    "[$($MyInvocation.MyCommand)] Cannot parse timestamp " +
+                                    "'$rawDate $rawTime' in '$filePath' (line $dataLineNumber) — Timestamp set to `$null.")
+                            }
+                        }
+
+                        # ---- Apply streaming filters ----
+                        $entryTs = $props['Timestamp']
+                        if ($PSBoundParameters.ContainsKey('After') -and
+                            $null -ne $entryTs -and $entryTs -lt $After) { continue }
+
+                        if ($PSBoundParameters.ContainsKey('Before') -and
+                            $null -ne $entryTs -and $entryTs -ge $Before) { continue }
+
+                        if ($PSBoundParameters.ContainsKey('Method') -and
+                            $null -ne $props['Method'] -and
+                            ($Method -inotcontains $props['Method'])) { continue }
+
+                        if ($PSBoundParameters.ContainsKey('Status') -and
+                            $null -ne $props['HttpStatus'] -and
+                            ($Status -notcontains $props['HttpStatus'])) { continue }
+
+                        if ($PSBoundParameters.ContainsKey('UriLike') -and
+                            $null -ne $props['UriStem'] -and
+                            $props['UriStem'] -notlike $UriLike) { continue }
+
+                        if ($PSBoundParameters.ContainsKey('ClientIP') -and
+                            $null -ne $props['ClientIP'] -and
+                            ($ClientIP -inotcontains $props['ClientIP'])) { continue }
+
+                        # ---- Emit or buffer ----
+                        $entry = [PSCustomObject]$props
+
+                        if ($Tail -gt 0) {
+                            $tailBuffer.Enqueue($entry)
+                            if ($tailBuffer.Count -gt $Tail) {
+                                [void]$tailBuffer.Dequeue()
+                            }
+                        }
+                        else {
+                            $entry
+                        }
+                    }
+                }
+                finally {
+                    $reader.Dispose()
+                }
+            }
+            catch {
+                Write-Error -Message "[$($MyInvocation.MyCommand)] Failed to read '$filePath': $_"
+                continue
+            }
+
+            # Flush tail circular buffer
+            if ($Tail -gt 0 -and $null -ne $tailBuffer) {
+                foreach ($tailEntry in $tailBuffer) { $tailEntry }
+            }
+        }
+    }
+
+    end {
+        Write-Verbose -Message "[$($MyInvocation.MyCommand)] Completed"
+    }
+}

--- a/Tests/Public/iis/Get-IISParsedLog.Tests.ps1
+++ b/Tests/Public/iis/Get-IISParsedLog.Tests.ps1
@@ -1,0 +1,419 @@
+﻿#Requires -Version 5.1
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+BeforeAll {
+    # Resolve project root from Tests/Public/iis (3 levels up)
+    $script:modulePath = Split-Path -Path (Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent) -Parent
+
+    # On Windows (Desktop edition): import full module.
+    # On Linux/macOS (local Docker validation): dot-source the function directly,
+    # bypassing the Windows-only guard in PSWinOps.psm1.
+    # CI always runs on windows-latest where the full module is imported.
+    if ($IsWindows -or $PSEdition -eq 'Desktop') {
+        Import-Module -Name (Join-Path -Path $script:modulePath -ChildPath 'PSWinOps.psd1') -Force
+    } else {
+        . ([IO.Path]::Combine($script:modulePath, 'Public', 'iis', 'Get-IISParsedLog.ps1'))
+    }
+
+    $script:ModuleName = 'PSWinOps'
+
+    # Helper: write a temp IIS log file (UTF-8 no BOM, mirrors real IIS output)
+    function script:New-TempIISLog {
+        param([string]$Content)
+        $tmp = [System.IO.Path]::ChangeExtension([System.IO.Path]::GetTempFileName(), '.log')
+        [System.IO.File]::WriteAllText($tmp, $Content, [System.Text.UTF8Encoding]::new($false))
+        return $tmp
+    }
+
+    $StdHdr = '#Fields: date time s-sitename s-computername s-ip cs-method cs-uri-stem cs-uri-query s-port cs-username c-ip cs(User-Agent) cs(Referer) sc-status sc-substatus sc-win32-status sc-bytes cs-bytes time-taken'
+
+    # ---- LogFile1: 3 data entries (GET 200, POST 404, GET 500) ----
+    $script:Log1 = script:New-TempIISLog -Content (
+        "#Software: Microsoft Internet Information Services 10.0`r`n" +
+        "#Version: 1.0`r`n" +
+        "#Date: 2026-05-14 00:00:00`r`n" +
+        "$StdHdr`r`n" +
+        "2026-05-14 10:00:00 W3SVC1 WEB01 192.168.1.10 GET /index.html - 80 - 10.0.0.42 Mozilla/5.0+(Windows+NT+10.0) https://example.com 200 0 0 1234 512 50`r`n" +
+        "2026-05-14 10:01:00 W3SVC1 WEB01 192.168.1.10 POST /api/data - 443 jdoe 10.0.0.43 curl/7.88.1 - 404 0 0 512 256 120`r`n" +
+        "2026-05-14 10:02:00 W3SVC1 WEB01 192.168.1.10 GET /api/fail - 443 - 10.0.0.44 Python+Requests/2.28 - 500 0 64 2048 128 3500`r`n"
+    )
+
+    # ---- LogFile2: dash-normalised fields (UserAgent, Referer, UserName, UriQuery = '-') ----
+    $script:Log2 = script:New-TempIISLog -Content (
+        "#Software: Microsoft Internet Information Services 10.0`r`n" +
+        "$StdHdr`r`n" +
+        "2026-05-14 11:00:00 W3SVC2 WEB02 10.0.1.5 GET /health - 80 - 192.168.99.1 - - 200 0 0 300 64 10`r`n"
+    )
+
+    # ---- LogFile3: mid-file #Fields re-detection ----
+    $script:Log3 = script:New-TempIISLog -Content (
+        "#Software: Microsoft Internet Information Services 10.0`r`n" +
+        "#Fields: date time cs-method cs-uri-stem sc-status`r`n" +
+        "2026-05-14 12:00:00 GET /before 200`r`n" +
+        "#Fields: date time cs-method cs-uri-stem sc-status sc-bytes`r`n" +
+        "2026-05-14 12:01:00 GET /after 200 9999`r`n"
+    )
+
+    # ---- LogFile4: 5 entries for -Tail circular-buffer test ----
+    $script:Log4 = script:New-TempIISLog -Content (
+        "#Software: Microsoft Internet Information Services 10.0`r`n" +
+        "$StdHdr`r`n" +
+        "2026-05-14 13:00:00 W3SVC1 WEB01 10.1.1.1 GET /a - 80 - 10.0.0.1 Agent/1 - 200 0 0 100 50 10`r`n" +
+        "2026-05-14 13:01:00 W3SVC1 WEB01 10.1.1.1 GET /b - 80 - 10.0.0.1 Agent/1 - 200 0 0 100 50 11`r`n" +
+        "2026-05-14 13:02:00 W3SVC1 WEB01 10.1.1.1 GET /c - 80 - 10.0.0.1 Agent/1 - 200 0 0 100 50 12`r`n" +
+        "2026-05-14 13:03:00 W3SVC1 WEB01 10.1.1.1 GET /d - 80 - 10.0.0.1 Agent/1 - 200 0 0 100 50 13`r`n" +
+        "2026-05-14 13:04:00 W3SVC1 WEB01 10.1.1.1 GET /e - 80 - 10.0.0.1 Agent/1 - 200 0 0 100 50 14`r`n"
+    )
+
+    $script:LogFiles = @($script:Log1, $script:Log2, $script:Log3, $script:Log4)
+}
+
+AfterAll {
+    $script:LogFiles | ForEach-Object {
+        if ($_ -and (Test-Path -LiteralPath $_)) {
+            Remove-Item -LiteralPath $_ -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+Describe 'Get-IISParsedLog' {
+
+    # ------------------------------------------------------------------
+    # Context 1: Happy path
+    # ------------------------------------------------------------------
+    Context 'Happy path: all standard W3C fields parsed correctly' {
+
+        It 'Should return one PSWinOps.IISLogEntry object per data line' {
+            $results = Get-IISParsedLog -Path $script:Log1
+            $results.Count | Should -Be 3
+        }
+
+        It 'Should set PSTypeName to PSWinOps.IISLogEntry on every entry' {
+            $results = Get-IISParsedLog -Path $script:Log1
+            $results[0].PSObject.TypeNames[0] | Should -Be 'PSWinOps.IISLogEntry'
+        }
+
+        It 'Should populate Timestamp as a UTC DateTime built from date+time fields' {
+            $result = Get-IISParsedLog -Path $script:Log1 | Select-Object -First 1
+            $result.Timestamp | Should -BeOfType [datetime]
+            $result.Timestamp.Kind | Should -Be ([System.DateTimeKind]::Utc)
+            $result.Timestamp.ToString('yyyy-MM-dd HH:mm:ss') | Should -Be '2026-05-14 10:00:00'
+        }
+
+        It 'Should set LogFile to the full source file path' {
+            $result = Get-IISParsedLog -Path $script:Log1 | Select-Object -First 1
+            $result.LogFile | Should -Be $script:Log1
+        }
+
+        It 'Should set 1-based LineNumber on each data entry (comment lines skipped)' {
+            $results = Get-IISParsedLog -Path $script:Log1
+            $results[0].LineNumber | Should -Be 1
+            $results[1].LineNumber | Should -Be 2
+            $results[2].LineNumber | Should -Be 3
+        }
+
+        It 'Should parse SiteName, ServerName, ServerIP and ServerPort correctly' {
+            $result = Get-IISParsedLog -Path $script:Log1 | Select-Object -First 1
+            $result.SiteName   | Should -Be 'W3SVC1'
+            $result.ServerName | Should -Be 'WEB01'
+            $result.ServerIP   | Should -Be '192.168.1.10'
+            $result.ServerPort | Should -Be 80
+        }
+
+        It 'Should parse Method, UriStem, HttpStatus, BytesSent, BytesReceived and TimeTaken' {
+            $result = Get-IISParsedLog -Path $script:Log1 | Select-Object -First 1
+            $result.Method        | Should -Be 'GET'
+            $result.UriStem       | Should -Be '/index.html'
+            $result.HttpStatus    | Should -Be 200
+            $result.BytesSent     | Should -Be 1234
+            $result.BytesReceived | Should -Be 512
+            $result.TimeTaken     | Should -Be 50
+        }
+
+        It 'Should parse Win32Status as a long integer' {
+            $result = Get-IISParsedLog -Path $script:Log1 | Select-Object -First 1
+            $result.Win32Status | Should -Be 0
+            $result.Win32Status | Should -BeOfType [long]
+        }
+    }
+
+    # ------------------------------------------------------------------
+    # Context 2: Dash normalisation
+    # ------------------------------------------------------------------
+    Context 'Dash normalisation: IIS "-" placeholder emitted as $null' {
+
+        It 'Should emit $null for UriQuery when the field is "-"' {
+            $result = Get-IISParsedLog -Path $script:Log2
+            $result.UriQuery | Should -BeNullOrEmpty
+        }
+
+        It 'Should emit $null for UserName when the field is "-"' {
+            $result = Get-IISParsedLog -Path $script:Log2
+            $result.UserName | Should -BeNullOrEmpty
+        }
+
+        It 'Should emit $null for UserAgent (string field) when the field is "-"' {
+            $result = Get-IISParsedLog -Path $script:Log2
+            $result.UserAgent | Should -BeNullOrEmpty
+        }
+
+        It 'Should emit $null for Referer when the field is "-"' {
+            $result = Get-IISParsedLog -Path $script:Log2
+            $result.Referer | Should -BeNullOrEmpty
+        }
+    }
+
+    # ------------------------------------------------------------------
+    # Context 3: -After / -Before time filtering
+    # ------------------------------------------------------------------
+    Context '-After and -Before time filtering applied during streaming' {
+
+        BeforeAll {
+            $ic = [System.Globalization.CultureInfo]::InvariantCulture
+            $utcStyle = [System.Globalization.DateTimeStyles]::AssumeUniversal -bor `
+                        [System.Globalization.DateTimeStyles]::AdjustToUniversal
+            $script:TS_1001 = [datetime]::ParseExact('2026-05-14 10:01:00', 'yyyy-MM-dd HH:mm:ss', $ic, $utcStyle)
+            $script:TS_1002 = [datetime]::ParseExact('2026-05-14 10:02:00', 'yyyy-MM-dd HH:mm:ss', $ic, $utcStyle)
+            $script:TS_far  = [datetime]::ParseExact('2026-05-15 00:00:00', 'yyyy-MM-dd HH:mm:ss', $ic, $utcStyle)
+        }
+
+        It 'Should include the entry AT the -After bound (inclusive lower bound)' {
+            $results = Get-IISParsedLog -Path $script:Log1 -After $script:TS_1001
+            $results.Count | Should -Be 2
+            $results[0].UriStem | Should -Be '/api/data'
+        }
+
+        It 'Should exclude the entry AT the -Before bound (exclusive upper bound)' {
+            $results = Get-IISParsedLog -Path $script:Log1 -Before $script:TS_1002
+            $results.Count | Should -Be 2
+            ($results | Where-Object UriStem -eq '/api/fail') | Should -BeNullOrEmpty
+        }
+
+        It 'Should return zero entries when -After is beyond all timestamps' {
+            $results = Get-IISParsedLog -Path $script:Log1 -After $script:TS_far
+            $results | Should -BeNullOrEmpty
+        }
+    }
+
+    # ------------------------------------------------------------------
+    # Context 4: -Method filter
+    # ------------------------------------------------------------------
+    Context '-Method filter (case-insensitive, multi-value OR)' {
+
+        It 'Should return only GET entries when -Method GET is specified' {
+            $results = Get-IISParsedLog -Path $script:Log1 -Method 'GET'
+            $results.Count | Should -Be 2
+            $results | ForEach-Object { $_.Method | Should -Be 'GET' }
+        }
+
+        It 'Should match -Method case-insensitively (lowercase "get" input)' {
+            $results = Get-IISParsedLog -Path $script:Log1 -Method 'get'
+            $results.Count | Should -Be 2
+        }
+
+        It 'Should return all 3 entries when -Method GET,POST are specified (OR logic)' {
+            $results = Get-IISParsedLog -Path $script:Log1 -Method 'GET', 'POST'
+            $results.Count | Should -Be 3
+        }
+    }
+
+    # ------------------------------------------------------------------
+    # Context 5: -Status filter
+    # ------------------------------------------------------------------
+    Context '-Status filter (multi-value OR, integer matching)' {
+
+        It 'Should return only the 500 entry when -Status 500 is specified' {
+            $results = Get-IISParsedLog -Path $script:Log1 -Status 500
+            $results.Count | Should -Be 1
+            $results[0].HttpStatus | Should -Be 500
+            $results[0].UriStem   | Should -Be '/api/fail'
+        }
+
+        It 'Should return 2 entries when -Status 404,500 are specified (OR logic)' {
+            $results = Get-IISParsedLog -Path $script:Log1 -Status 404, 500
+            $results.Count | Should -Be 2
+        }
+
+        It 'Should return zero entries when -Status matches no entry in the file' {
+            $results = Get-IISParsedLog -Path $script:Log1 -Status 503
+            $results | Should -BeNullOrEmpty
+        }
+    }
+
+    # ------------------------------------------------------------------
+    # Context 6: -UriLike and -ClientIP filters
+    # ------------------------------------------------------------------
+    Context '-UriLike wildcard and -ClientIP exact filters' {
+
+        It 'Should return entries matching the -UriLike wildcard pattern "/api/*"' {
+            $results = Get-IISParsedLog -Path $script:Log1 -UriLike '/api/*'
+            $results.Count | Should -Be 2
+            $results | ForEach-Object { $_.UriStem | Should -BeLike '/api/*' }
+        }
+
+        It 'Should return zero entries when -UriLike matches nothing' {
+            $results = Get-IISParsedLog -Path $script:Log1 -UriLike '/notexist/*'
+            $results | Should -BeNullOrEmpty
+        }
+
+        It 'Should return only entries from the specified -ClientIP (exact match)' {
+            $results = Get-IISParsedLog -Path $script:Log1 -ClientIP '10.0.0.42'
+            $results.Count | Should -Be 1
+            $results[0].ClientIP | Should -Be '10.0.0.42'
+        }
+
+        It 'Should support multi-value OR for -ClientIP (two IPs)' {
+            $results = Get-IISParsedLog -Path $script:Log1 -ClientIP '10.0.0.42', '10.0.0.43'
+            $results.Count | Should -Be 2
+        }
+    }
+
+    # ------------------------------------------------------------------
+    # Context 7: -Tail circular buffer
+    # ------------------------------------------------------------------
+    Context '-Tail parameter: circular buffer returns last N matching entries per file' {
+
+        It 'Should return exactly N entries when -Tail N is less than total entries' {
+            $results = Get-IISParsedLog -Path $script:Log4 -Tail 3
+            $results.Count | Should -Be 3
+        }
+
+        It 'Should return the LAST N entries (not the first N) in chronological order' {
+            $results = Get-IISParsedLog -Path $script:Log4 -Tail 3
+            $results[0].UriStem | Should -Be '/c'
+            $results[2].UriStem | Should -Be '/e'
+        }
+
+        It 'Should return all entries when -Tail N exceeds total file count' {
+            $results = Get-IISParsedLog -Path $script:Log4 -Tail 100
+            $results.Count | Should -Be 5
+        }
+    }
+
+    # ------------------------------------------------------------------
+    # Context 8: Pipeline by property name (FullName alias)
+    # ------------------------------------------------------------------
+    Context 'Pipeline by property name: FullName alias (simulates Get-ChildItem output)' {
+
+        It 'Should accept a piped object with FullName property and parse all entries' {
+            $pipeInput = [PSCustomObject]@{ FullName = $script:Log1 }
+            $results = $pipeInput | Get-IISParsedLog
+            $results.Count | Should -Be 3
+        }
+
+        It 'Should set LogFile equal to the FullName value from the piped object' {
+            $pipeInput = [PSCustomObject]@{ FullName = $script:Log1 }
+            $results = $pipeInput | Get-IISParsedLog
+            $results[0].LogFile | Should -Be $script:Log1
+        }
+
+        It 'Should stream entries from multiple piped FullName objects in order' {
+            $pipeInputs = @(
+                [PSCustomObject]@{ FullName = $script:Log1 },
+                [PSCustomObject]@{ FullName = $script:Log2 }
+            )
+            $results = $pipeInputs | Get-IISParsedLog
+            $results.Count | Should -Be 4
+        }
+    }
+
+    # ------------------------------------------------------------------
+    # Context 9: Header re-detection (mid-file #Fields)
+    # ------------------------------------------------------------------
+    Context 'Header re-detection: mid-file #Fields directive rebinds column map' {
+
+        It 'Should parse both sections correctly (2 data entries total)' {
+            $results = Get-IISParsedLog -Path $script:Log3
+            $results.Count | Should -Be 2
+        }
+
+        It 'Should set BytesSent to $null for lines before sc-bytes was added to #Fields' {
+            $results = Get-IISParsedLog -Path $script:Log3
+            $results[0].UriStem   | Should -Be '/before'
+            $results[0].BytesSent | Should -BeNullOrEmpty
+        }
+
+        It 'Should set BytesSent correctly for lines after #Fields added sc-bytes' {
+            $results = Get-IISParsedLog -Path $script:Log3
+            $results[1].UriStem   | Should -Be '/after'
+            $results[1].BytesSent | Should -Be 9999
+        }
+    }
+
+    # ------------------------------------------------------------------
+    # Context 10: Non-existent path -- Write-Error per ADR conventions
+    # ------------------------------------------------------------------
+    Context 'Non-existent path: Write-Error (terminating with -ErrorAction Stop)' {
+
+        It 'Should throw when -ErrorAction Stop is used for a missing path' {
+            { Get-IISParsedLog -Path '/tmp/pswinops_nosuchfile_test.log' -ErrorAction Stop } |
+                Should -Throw
+        }
+
+        It 'Should return nothing when -ErrorAction SilentlyContinue suppresses the error' {
+            $results = Get-IISParsedLog -Path '/tmp/pswinops_nosuchfile_test.log' `
+                -ErrorAction SilentlyContinue
+            $results | Should -BeNullOrEmpty
+        }
+    }
+
+    # ------------------------------------------------------------------
+    # Context 11: UserAgent / Referer decoding
+    # ------------------------------------------------------------------
+    Context 'UserAgent decoding: IIS "+" in cs(User-Agent) decoded back to space' {
+
+        It 'Should decode "+" to space in UserAgent field (first entry)' {
+            $result = Get-IISParsedLog -Path $script:Log1 | Select-Object -First 1
+            $result.UserAgent | Should -Be 'Mozilla/5.0 (Windows NT 10.0)'
+        }
+
+        It 'Should decode "+" to space in UserAgent field (third entry)' {
+            $results = Get-IISParsedLog -Path $script:Log1
+            $results[2].UserAgent | Should -Be 'Python Requests/2.28'
+        }
+
+        It 'Should leave UriStem as-logged (URL-encoded by IIS, no + decoding applied)' {
+            $result = Get-IISParsedLog -Path $script:Log1 | Select-Object -First 1
+            $result.UriStem | Should -Be '/index.html'
+        }
+    }
+
+    # ------------------------------------------------------------------
+    # Context 12: LiteralPath parameter set
+    # ------------------------------------------------------------------
+    Context 'LiteralPath parameter set: no wildcard expansion, exact file path' {
+
+        It 'Should parse the file correctly when -LiteralPath is used' {
+            $results = Get-IISParsedLog -LiteralPath $script:Log1
+            $results.Count | Should -Be 3
+        }
+
+        It 'Should set LogFile to the resolved LiteralPath value' {
+            $results = Get-IISParsedLog -LiteralPath $script:Log1
+            $results[0].LogFile | Should -Be $script:Log1
+        }
+
+        It 'Should throw for a non-existent LiteralPath when -ErrorAction Stop is used' {
+            { Get-IISParsedLog -LiteralPath '/tmp/pswinops_nosuchfile_literal.log' -ErrorAction Stop } |
+                Should -Throw
+        }
+    }
+
+    # ------------------------------------------------------------------
+    # Context 13: BOM/CRLF sentinel
+    # ------------------------------------------------------------------
+    Context 'BOM/CRLF sentinel: this test file is UTF-8 with BOM and CRLF line endings' {
+
+        It 'Should detect the UTF-8 BOM bytes (EF BB BF) at the start of this test file' {
+            $bytes = [System.IO.File]::ReadAllBytes($PSCommandPath)
+            $bytes[0] | Should -Be 0xEF
+            $bytes[1] | Should -Be 0xBB
+            $bytes[2] | Should -Be 0xBF
+        }
+
+        It 'Should detect CRLF line endings in this test file (Get-Content raw match)' {
+            $raw = Get-Content -LiteralPath $PSCommandPath -Raw
+            $raw | Should -Match "`r`n"
+        }
+    }
+}

--- a/en-US/about_PSWinOps.help.txt
+++ b/en-US/about_PSWinOps.help.txt
@@ -84,11 +84,11 @@ FUNCTION DOMAINS
       Get-ServiceHealth
       Get-WSUSHealth
 
-  iis (1 function)
-    Functions for managing IIS HTTPS site bindings,
-    including SSL/TLS certificate rotation across
-    local or remote servers via WinRM.
+  iis (2 functions)
+    Functions for managing IIS sites, HTTPS bindings,
+    and log file analysis across local or remote servers.
 
+      Get-IISParsedLog
       Set-IISBindingCertificate
 
   network (24 functions)
@@ -282,7 +282,7 @@ REMOTE EXECUTION PATTERN
     in the pipeline continue to be processed.
 
 PSWINOPS TYPE REGISTRY
-    The following 87 PSTypeName values are defined by the
+    The following 88 PSTypeName values are defined by the
     module. Each corresponds to the output of one or more
     public functions.
 
@@ -329,6 +329,7 @@ PSWINOPS TYPE REGISTRY
       PSWinOps.HyperVHostHealth
       PSWinOps.IISBindingCertificateResult
       PSWinOps.IISHealth
+      PSWinOps.IISLogEntry
       PSWinOps.InstalledSoftware
       PSWinOps.ListeningPort
       PSWinOps.MACVendor


### PR DESCRIPTION
## Summary
Stream-parse IIS W3C log files into typed `PSWinOps.IISLogEntry` objects with rich streaming filters. Supports header re-detection mid-file, IIS dash placeholder normalisation to `$null`, UserAgent `"+"`-to-space decoding, inclusive `-After` / exclusive `-Before` time windows, multi-value OR filters (`-Method`, `-Status`, `-ClientIP`), `-UriLike` wildcard match, `-Tail` circular buffer, and pipeline-by-property-name (`FullName`) so it composes cleanly with `Get-ChildItem`.

## Files touched
- `Public/iis/Get-IISParsedLog.ps1` — implementation
- `Tests/Public/iis/Get-IISParsedLog.Tests.ps1` — Pester v5 suite (44 tests)
- `PSWinOps.psd1` — FunctionsToExport, ModuleVersion (0.1.1 → 0.1.2), ReleaseNotes
- `PSWinOps.Format.ps1xml` — new `<View>` for `PSWinOps.IISLogEntry`
- `en-US/about_PSWinOps.help.txt` — iis domain counter 1 → 2, PSTypeName registry updated
- `.kdust/chains/get-iisparsedlog-2605151203.yaml` — chain ledger

## Conformance checklist (auto-audited by fn-quality-gate)
- [x] UTF-8 BOM + CRLF on new `.ps1` / `.Tests.ps1` files
- [x] Approved PowerShell verb (`Get-`)
- [x] `FunctionsToExport` alphabetically sorted (case-insensitive) and `Get-IISParsedLog` present exactly once
- [x] `PSTypeName` `PSWinOps.IISLogEntry` consistent across `.ps1`, `Format.ps1xml`, and help
- [x] PSScriptAnalyzer clean (0 warnings/errors on changed paths)
- [x] Pester suite passes locally (44/44 on Linux pwsh 7.5)
- [x] No `Write-Host`, no `ToString('o')` introduced in diff
- [x] `Test-ModuleManifest ./PSWinOps.psd1` succeeds at 0.1.2

## Auto-merge
⚠️ NOT armed by fn-quality-gate. The `main` branch currently has no protection rules (`gh api repos/k9fr4n/PSWinOps/branches/main/protection` → 404 "Branch not protected"). Per the chain SAFETY gate, `--auto` would risk merging on the first green commit before the full Windows CI matrix completes, so the quality-gate refused to arm it.

**Operator action required** to enable auto-merge on future runs:
1. github.com/k9fr4n/PSWinOps → Settings → Branches → add a rule for `main`:
   - ✅ Require status checks to pass before merging
   - ✅ Require branches to be up to date before merging
   - Mark as required: every Pester Windows matrix job + ScriptAnalyzer + manifest test.
2. github.com/k9fr4n/PSWinOps → Settings → General → Pull Requests → ✅ "Allow auto-merge".

For this PR: review, wait for the Windows CI workflow to finish, and merge manually (squash + delete branch) once green.
