### PR TITLE
feat(iis): add Get-IISWorkerProcess

### DIFF
--- a/.kdust/chains/get-iisworkerprocess-2605151620.yaml
+++ b/.kdust/chains/get-iisworkerprocess-2605151620.yaml
@@ -1,0 +1,7 @@
+chain: pswinops-function-author
+function: Get-IISWorkerProcess
+domain: iis
+created: 2026-05-15T16:22:25Z
+created_by: pswinops-fn-spec-analyst
+chain_branch: kdust/chain/pswinops-fn-get-iisworkerprocess-2605151620
+spec_path: work/get-iisworkerprocess/spec.yaml

--- a/PSWinOps.Format.ps1xml
+++ b/PSWinOps.Format.ps1xml
@@ -6819,5 +6819,101 @@
         </TableRowEntries>
       </TableControl>
     </View>
+
+    <!-- ============================================================ -->
+    <!-- PSWinOps.IISWorkerProcess                                    -->
+    <!-- Used by: Get-IISWorkerProcess                                -->
+    <!-- ============================================================ -->
+    <View>
+      <Name>PSWinOps.IISWorkerProcess</Name>
+      <ViewSelectedBy>
+        <TypeName>PSWinOps.IISWorkerProcess</TypeName>
+      </ViewSelectedBy>
+      <TableControl>
+        <AutoSize />
+        <TableHeaders>
+          <TableColumnHeader>
+            <Label>ComputerName</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>PID</Label>
+            <Alignment>Right</Alignment>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>AppPoolName</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Sites</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Identity</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Status</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>UptimeSec</Label>
+            <Alignment>Right</Alignment>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>WorkingSetMB</Label>
+            <Alignment>Right</Alignment>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>CPUSec</Label>
+            <Alignment>Right</Alignment>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Threads</Label>
+            <Alignment>Right</Alignment>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Handles</Label>
+            <Alignment>Right</Alignment>
+          </TableColumnHeader>
+        </TableHeaders>
+        <TableRowEntries>
+          <TableRowEntry>
+            <TableColumnItems>
+              <TableColumnItem>
+                <PropertyName>ComputerName</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>ProcessId</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>AppPoolName</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <ScriptBlock>
+                  if ($_.Sites) { $_.Sites -join ', ' } else { '' }
+                </ScriptBlock>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>Identity</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>Status</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>UptimeSeconds</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>WorkingSetMB</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>CPUSeconds</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>ThreadCount</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>HandleCount</PropertyName>
+              </TableColumnItem>
+            </TableColumnItems>
+          </TableRowEntry>
+        </TableRowEntries>
+      </TableControl>
+    </View>
   </ViewDefinitions>
 </Configuration>

--- a/PSWinOps.psd1
+++ b/PSWinOps.psd1
@@ -12,7 +12,7 @@
     RootModule           = 'PSWinOps.psm1'
 
     # Version number of this module.
-    ModuleVersion        = '0.1.2'
+    ModuleVersion        = '0.1.3'
 
     # Supported PSEditions
     # Core is supported on Windows only; the module-level guard in PSWinOps.psm1 blocks
@@ -258,7 +258,12 @@
             # IconUri = ''
 
             # ReleaseNotes of this module
-            ReleaseNotes = '## 0.1.2 - 2026-05-15
+            ReleaseNotes = '## 0.1.3 - 2026-05-15
+### Added
+- feat(iis): add Get-IISWorkerProcess — inventory IIS w3wp.exe worker processes joined with owning AppPoolName, served Sites/Applications, identity/IdentityType, PID, StartTime/UptimeSeconds, CPUSeconds, WorkingSetMB/PrivateMemoryMB/VirtualMemoryMB, ThreadCount/HandleCount, with multi-host remoting via Invoke-RemoteOrLocal, graceful WebAdministration → IISAdministration → appcmd/CIM fallback, -AppPoolName (wildcards) and -ProcessId filters, and the standard PSWinOps Status enum (Running/Orphaned/Failed/IISNotInstalled/NoWorkerProcess).
+- feat(format): TableControl view for PSWinOps.IISWorkerProcess in PSWinOps.Format.ps1xml.
+
+## 0.1.2 - 2026-05-15
 ### Added
 - feat(iis): add Get-IISParsedLog — stream-parse IIS W3C log files into typed PSWinOps.IISLogEntry objects with header re-detection, dash-normalisation, UserAgent "+"-to-space decoding, -After/-Before time window, -Method/-Status/-ClientIP multi-value OR filters, -UriLike wildcard, -Tail circular buffer, and pipeline-by-property-name (FullName) for Get-ChildItem composition.
 - feat(format): TableControl view for PSWinOps.IISLogEntry in PSWinOps.Format.ps1xml.

--- a/PSWinOps.psd1
+++ b/PSWinOps.psd1
@@ -125,6 +125,7 @@
         'Get-HyperVHostHealth',
         'Get-IISHealth',
         'Get-IISParsedLog',
+        'Get-IISWorkerProcess',
         'Get-InstalledSoftware',
         'Get-ListeningPort',
         'Get-NetworkAdapter',

--- a/Public/iis/Get-IISWorkerProcess.ps1
+++ b/Public/iis/Get-IISWorkerProcess.ps1
@@ -1,0 +1,590 @@
+﻿#Requires -Version 5.1
+function Get-IISWorkerProcess {
+    <#
+        .SYNOPSIS
+            Inventories IIS worker processes (w3wp.exe) enriched with app pool, sites, identity, and resource metrics.
+
+        .DESCRIPTION
+            Enumerates every w3wp.exe process on one or more target servers and joins
+            it with IIS configuration so each row carries the owning application pool,
+            the sites and applications it serves, its identity, PID, uptime, CPU time,
+            memory footprint (working set / private / virtual), thread count and handle
+            count. Provides the operational overview that the native IISAdministration
+            module does not expose in a single cmdlet. Falls back gracefully from
+            WebAdministration to IISAdministration to appcmd/CIM when modules are
+            missing, and from Get-Process to CIM Win32_Process when needed.
+
+        .PARAMETER ComputerName
+            One or more computer names to query. Defaults to the local machine.
+            Accepts pipeline input by value and by property name.
+
+        .PARAMETER Credential
+            Optional PSCredential for authenticating to remote computers.
+            Not used for local queries.
+
+        .PARAMETER AppPoolName
+            Restrict the inventory to w3wp processes belonging to one or more named
+            application pools. Wildcards accepted via -like.
+
+        .PARAMETER ProcessId
+            Filter to specific worker process PIDs (useful when correlating with
+            Get-Process / event logs).
+
+        .EXAMPLE
+            Get-IISWorkerProcess
+
+            Returns all running w3wp.exe processes on the local machine enriched with
+            app pool, site, identity and resource data.
+
+        .EXAMPLE
+            Get-IISWorkerProcess -ComputerName 'WEB01'
+
+            Returns IIS worker process inventory from a single remote server.
+
+        .EXAMPLE
+            'WEB01','WEB02' | Get-IISWorkerProcess -Credential (Get-Credential)
+
+            Queries multiple remote servers via pipeline with alternate credentials.
+
+        .EXAMPLE
+            Get-IISWorkerProcess -AppPoolName 'DefaultAppPool','API*'
+
+            Returns only worker processes belonging to DefaultAppPool or any pool
+            whose name matches API*.
+
+        .EXAMPLE
+            Get-IISWorkerProcess | Sort-Object WorkingSetMB -Descending | Select-Object -First 5
+
+            Returns the top 5 worker processes by working set memory.
+
+        .OUTPUTS
+            PSCustomObject (PSTypeName='PSWinOps.IISWorkerProcess')
+
+        .NOTES
+            Author: Franck SALLET
+            Version: 1.0.0
+            Last Modified: 2026-05-15
+            Requires: PowerShell 5.1+ / Windows only
+            Requires: Web-Server (IIS) role
+            Optional: Module WebAdministration or IISAdministration (falls back to appcmd)
+
+        .LINK
+            https://github.com/k9fr4n/PSWinOps
+
+        .LINK
+            https://learn.microsoft.com/en-us/iis/get-started/planning-your-iis-architecture/introduction-to-iis-architecture#worker-processes
+    #>
+    [CmdletBinding()]
+    [OutputType('PSWinOps.IISWorkerProcess')]
+    param(
+        [Parameter(Mandatory = $false, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [ValidateNotNullOrEmpty()]
+        [Alias('CN', 'Name', 'DNSHostName')]
+        [string[]]$ComputerName = $env:COMPUTERNAME,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateNotNull()]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential,
+
+        [Parameter(Mandatory = $false)]
+        [string[]]$AppPoolName,
+
+        [Parameter(Mandatory = $false)]
+        [int[]]$ProcessId
+    )
+
+    begin {
+        Write-Verbose -Message "[$($MyInvocation.MyCommand)] Starting"
+
+        $scriptBlock = {
+            param(
+                [string[]]$FilterAppPool,
+                [int[]]$FilterPid
+            )
+
+            $results = [System.Collections.Generic.List[hashtable]]::new()
+
+            # ── 1. Verify IIS (W3SVC) presence ───────────────────────────────
+            try {
+                $null = Get-Service -Name 'W3SVC' -ErrorAction Stop
+            }
+            catch {
+                $results.Add(@{
+                    ProcessId       = $null
+                    AppPoolName     = $null
+                    Sites           = @()
+                    Applications    = @()
+                    Identity        = $null
+                    IdentityType    = $null
+                    StartTime       = $null
+                    UptimeSeconds   = $null
+                    CPUSeconds      = $null
+                    WorkingSetMB    = $null
+                    PrivateMemoryMB = $null
+                    VirtualMemoryMB = $null
+                    ThreadCount     = $null
+                    HandleCount     = $null
+                    CommandLine     = $null
+                    Status          = 'IISNotInstalled'
+                    ErrorMessage    = "W3SVC service not found: $($_.Exception.Message)"
+                })
+                return $results
+            }
+
+            # ── 2. Collect w3wp.exe process data ─────────────────────────────
+            # Primary path: Get-Process (gives CPU/memory/threads/handles/starttime)
+            $procMap    = @{}   # int PID -> System.Diagnostics.Process
+            $cimProcMap = @{}   # int PID -> CIM Win32_Process (for CommandLine + fallback)
+
+            try {
+                foreach ($p in @(Get-Process -Name 'w3wp' -ErrorAction Stop)) {
+                    $procMap[[int]$p.Id] = $p
+                }
+            }
+            catch {
+                Write-Verbose -Message '[Get-IISWorkerProcess] Get-Process w3wp returned no results; using CIM fallback.'
+            }
+
+            # CIM is always queried for CommandLine (not exposed by Get-Process)
+            try {
+                $cimInstances = @(Get-CimInstance -ClassName 'Win32_Process' `
+                    -Filter "Name='w3wp.exe'" -ErrorAction Stop)
+                foreach ($cp in $cimInstances) {
+                    $cpid = [int]$cp.ProcessId
+                    $cimProcMap[$cpid] = $cp
+                    if (-not $procMap.ContainsKey($cpid)) {
+                        $procMap[$cpid] = $null
+                    }
+                }
+            }
+            catch {
+                Write-Verbose -Message '[Get-IISWorkerProcess] CIM Win32_Process query failed.'
+            }
+
+            if ($procMap.Count -eq 0) {
+                $results.Add(@{
+                    ProcessId       = $null
+                    AppPoolName     = $null
+                    Sites           = @()
+                    Applications    = @()
+                    Identity        = $null
+                    IdentityType    = $null
+                    StartTime       = $null
+                    UptimeSeconds   = $null
+                    CPUSeconds      = $null
+                    WorkingSetMB    = $null
+                    PrivateMemoryMB = $null
+                    VirtualMemoryMB = $null
+                    ThreadCount     = $null
+                    HandleCount     = $null
+                    CommandLine     = $null
+                    Status          = 'NoWorkerProcess'
+                    ErrorMessage    = $null
+                })
+                return $results
+            }
+
+            # ── 3. PID -> AppPool mapping via appcmd ─────────────────────────
+            $pidToPool = @{}
+            $appcmdExe = Join-Path -Path $env:windir -ChildPath 'system32\inetsrv\appcmd.exe'
+
+            if (Test-Path -LiteralPath $appcmdExe -PathType Leaf) {
+                try {
+                    $wpRaw = & $appcmdExe list wp /xml 2>$null
+                    if (-not [string]::IsNullOrWhiteSpace($wpRaw)) {
+                        [xml]$wpXml = $wpRaw
+                        foreach ($wpNode in @($wpXml.appcmd.WP)) {
+                            if ($null -ne $wpNode) {
+                                $pidToPool[[int]$wpNode.PID] = $wpNode.'APPPOOL.NAME'
+                            }
+                        }
+                    }
+                }
+                catch {
+                    Write-Verbose -Message "[Get-IISWorkerProcess] appcmd list wp failed: $($_.Exception.Message)"
+                }
+            }
+
+            # ── 4. AppPool identity + Sites/Apps via IIS module or appcmd ────
+            $poolIdentityMap = @{}
+            $poolToSites     = @{}
+            $poolToApps      = @{}
+            $iisLoaded       = $false
+
+            # -- WebAdministration path --
+            if (-not $iisLoaded -and
+                (Get-Module -Name 'WebAdministration' -ListAvailable -ErrorAction SilentlyContinue)) {
+                try {
+                    Import-Module -Name 'WebAdministration' -ErrorAction Stop
+
+                    foreach ($pool in @(Get-ChildItem -Path 'IIS:\AppPools' `
+                            -ErrorAction SilentlyContinue)) {
+                        $pm           = $pool.processModel
+                        $rawIdType    = [string]$pm.identityType
+                        $identityType = switch ($rawIdType) {
+                            'ApplicationPoolIdentity' { 'ApplicationPoolIdentity' }
+                            'LocalSystem'             { 'LocalSystem'             }
+                            'LocalService'            { 'LocalService'            }
+                            'NetworkService'          { 'NetworkService'          }
+                            'SpecificUser'            { 'SpecificUser'            }
+                            default                   { 'Unknown'                 }
+                        }
+                        $identity = if ($identityType -eq 'SpecificUser') {
+                            [string]$pm.userName
+                        }
+                        else { $identityType }
+                        $poolIdentityMap[$pool.Name] = @{
+                            Identity     = $identity
+                            IdentityType = $identityType
+                        }
+                    }
+
+                    foreach ($site in @(Get-Website -ErrorAction SilentlyContinue)) {
+                        $pn = [string]$site.applicationPool
+                        if (-not $poolToSites.ContainsKey($pn)) {
+                            $poolToSites[$pn] = [System.Collections.Generic.List[string]]::new()
+                        }
+                        if (-not $poolToSites[$pn].Contains($site.Name)) {
+                            $poolToSites[$pn].Add($site.Name)
+                        }
+                    }
+
+                    foreach ($app in @(Get-WebApplication -ErrorAction SilentlyContinue)) {
+                        $pn       = [string]$app.applicationPool
+                        $siteName = $app.PSParentPath -replace '^.*\\Sites\\', ''
+                        if (-not $poolToApps.ContainsKey($pn)) {
+                            $poolToApps[$pn] = [System.Collections.Generic.List[string]]::new()
+                        }
+                        $poolToApps[$pn].Add("$siteName$($app.Path)")
+                    }
+
+                    $iisLoaded = $true
+                }
+                catch {
+                    Write-Verbose -Message "[Get-IISWorkerProcess] WebAdministration failed: $($_.Exception.Message)"
+                }
+            }
+
+            # -- IISAdministration path --
+            if (-not $iisLoaded -and
+                (Get-Module -Name 'IISAdministration' -ListAvailable -ErrorAction SilentlyContinue)) {
+                try {
+                    Import-Module -Name 'IISAdministration' -ErrorAction Stop
+
+                    foreach ($pool in @(Get-IISAppPool -ErrorAction Stop)) {
+                        $rawIdType    = $pool.ProcessModel.IdentityType.ToString()
+                        $identityType = switch ($rawIdType) {
+                            'ApplicationPoolIdentity' { 'ApplicationPoolIdentity' }
+                            'LocalSystem'             { 'LocalSystem'             }
+                            'LocalService'            { 'LocalService'            }
+                            'NetworkService'          { 'NetworkService'          }
+                            'SpecificUser'            { 'SpecificUser'            }
+                            default                   { 'Unknown'                 }
+                        }
+                        $identity = if ($identityType -eq 'SpecificUser') {
+                            [string]$pool.ProcessModel.UserName
+                        }
+                        else { $identityType }
+                        $poolIdentityMap[$pool.Name] = @{
+                            Identity     = $identity
+                            IdentityType = $identityType
+                        }
+                    }
+
+                    foreach ($site in @(Get-IISSite -ErrorAction Stop)) {
+                        foreach ($app in $site.Applications) {
+                            $pn = [string]$app.ApplicationPoolName
+                            if ($app.Path -eq '/') {
+                                if (-not $poolToSites.ContainsKey($pn)) {
+                                    $poolToSites[$pn] = [System.Collections.Generic.List[string]]::new()
+                                }
+                                if (-not $poolToSites[$pn].Contains($site.Name)) {
+                                    $poolToSites[$pn].Add($site.Name)
+                                }
+                            }
+                            else {
+                                if (-not $poolToApps.ContainsKey($pn)) {
+                                    $poolToApps[$pn] = [System.Collections.Generic.List[string]]::new()
+                                }
+                                $poolToApps[$pn].Add("$($site.Name)$($app.Path)")
+                            }
+                        }
+                    }
+
+                    $iisLoaded = $true
+                }
+                catch {
+                    Write-Verbose -Message "[Get-IISWorkerProcess] IISAdministration failed: $($_.Exception.Message)"
+                }
+            }
+
+            # -- appcmd fallback for identity + site/app mapping --
+            if (-not $iisLoaded -and (Test-Path -LiteralPath $appcmdExe -PathType Leaf)) {
+                try {
+                    $rawPools = & $appcmdExe list apppool /xml /config:* 2>$null
+                    if (-not [string]::IsNullOrWhiteSpace($rawPools)) {
+                        [xml]$poolXml = $rawPools
+                        foreach ($poolNode in @($poolXml.appcmd.APPPOOL)) {
+                            if ($null -eq $poolNode) { continue }
+                            $addNode      = $poolNode.add
+                            $rawIdType    = [string]$addNode.processModel.identityType
+                            $identityType = switch ($rawIdType) {
+                                'ApplicationPoolIdentity' { 'ApplicationPoolIdentity' }
+                                'LocalSystem'             { 'LocalSystem'             }
+                                'LocalService'            { 'LocalService'            }
+                                'NetworkService'          { 'NetworkService'          }
+                                'SpecificUser'            { 'SpecificUser'            }
+                                default                   { 'Unknown'                 }
+                            }
+                            $identity = if ($identityType -eq 'SpecificUser') {
+                                [string]$addNode.processModel.userName
+                            }
+                            else { $identityType }
+                            $poolIdentityMap[$poolNode.'APPPOOL.NAME'] = @{
+                                Identity     = $identity
+                                IdentityType = $identityType
+                            }
+                        }
+                    }
+                }
+                catch {
+                    Write-Verbose -Message "[Get-IISWorkerProcess] appcmd list apppool failed: $($_.Exception.Message)"
+                }
+
+                try {
+                    $rawApps = & $appcmdExe list app /xml 2>$null
+                    if (-not [string]::IsNullOrWhiteSpace($rawApps)) {
+                        [xml]$appXml = $rawApps
+                        foreach ($appNode in @($appXml.appcmd.APP)) {
+                            if ($null -eq $appNode) { continue }
+                            $pn      = [string]$appNode.'APPPOOL.NAME'
+                            $appName = [string]$appNode.'APP.NAME'
+                            $parts   = $appName -split '/', 2
+                            $sn      = $parts[0]
+                            $vPath   = if ($parts.Count -gt 1) { '/' + $parts[1] } else { '/' }
+
+                            if ($vPath -eq '/') {
+                                if (-not $poolToSites.ContainsKey($pn)) {
+                                    $poolToSites[$pn] = [System.Collections.Generic.List[string]]::new()
+                                }
+                                if (-not $poolToSites[$pn].Contains($sn)) {
+                                    $poolToSites[$pn].Add($sn)
+                                }
+                            }
+                            else {
+                                if (-not $poolToApps.ContainsKey($pn)) {
+                                    $poolToApps[$pn] = [System.Collections.Generic.List[string]]::new()
+                                }
+                                $poolToApps[$pn].Add("$sn$vPath")
+                            }
+                        }
+                    }
+                }
+                catch {
+                    Write-Verbose -Message "[Get-IISWorkerProcess] appcmd list app failed: $($_.Exception.Message)"
+                }
+            }
+
+            # ── 5. Build result objects ───────────────────────────────────────
+            foreach ($workerPid in ($procMap.Keys | Sort-Object)) {
+                $pool = if ($pidToPool.ContainsKey($workerPid)) {
+                    $pidToPool[$workerPid]
+                }
+                else { '' }
+
+                # Apply business filters
+                if ($FilterPid.Count -gt 0 -and ($FilterPid -notcontains $workerPid)) { continue }
+
+                if ($FilterAppPool.Count -gt 0) {
+                    $poolMatched = $false
+                    foreach ($fp in $FilterAppPool) {
+                        if ($pool -like $fp) { $poolMatched = $true; break }
+                    }
+                    if (-not $poolMatched) { continue }
+                }
+
+                # Identity
+                $identity     = if ($poolIdentityMap.ContainsKey($pool)) {
+                    $poolIdentityMap[$pool].Identity
+                }
+                else { '' }
+                $identityType = if ($poolIdentityMap.ContainsKey($pool)) {
+                    $poolIdentityMap[$pool].IdentityType
+                }
+                else { 'Unknown' }
+
+                # Sites / Applications
+                $sites = if ($poolToSites.ContainsKey($pool)) {
+                    @($poolToSites[$pool])
+                }
+                else { @() }
+                $apps  = if ($poolToApps.ContainsKey($pool)) {
+                    @($poolToApps[$pool])
+                }
+                else { @() }
+
+                # Status
+                $status = if ([string]::IsNullOrEmpty($pool)) { 'Orphaned' } else { 'Running' }
+
+                # Process metrics
+                $procObj      = $procMap[$workerPid]
+                $cimObj       = if ($cimProcMap.ContainsKey($workerPid)) {
+                    $cimProcMap[$workerPid]
+                }
+                else { $null }
+                $startTime    = $null
+                $uptimeSecs   = [long]0
+                $cpuSecs      = [double]0
+                $workingSetMB = [long]0
+                $privateMemMB = [long]0
+                $virtualMemMB = [long]0
+                $threadCount  = 0
+                $handleCount  = 0
+                $commandLine  = ''
+
+                if ($null -ne $procObj -and $procObj -is [System.Diagnostics.Process]) {
+                    try {
+                        $startTime = $procObj.StartTime
+                    }
+                    catch {
+                        Write-Verbose -Message "[Get-IISWorkerProcess] Cannot read StartTime for PID $workerPid."
+                    }
+                    if ($null -ne $startTime) {
+                        $uptimeSecs = [long]([datetime]::Now - $startTime).TotalSeconds
+                    }
+                    try {
+                        $cpuSecs = [Math]::Round($procObj.TotalProcessorTime.TotalSeconds, 2)
+                    }
+                    catch {
+                        Write-Verbose -Message "[Get-IISWorkerProcess] Cannot read CPU time for PID $workerPid."
+                    }
+                    $workingSetMB = [long]($procObj.WorkingSet64       / 1MB)
+                    $privateMemMB = [long]($procObj.PrivateMemorySize64 / 1MB)
+                    $virtualMemMB = [long]($procObj.VirtualMemorySize64 / 1MB)
+                    try {
+                        $threadCount = $procObj.Threads.Count
+                    }
+                    catch {
+                        Write-Verbose -Message "[Get-IISWorkerProcess] Cannot read thread count for PID $workerPid."
+                    }
+                    try {
+                        $handleCount = $procObj.HandleCount
+                    }
+                    catch {
+                        Write-Verbose -Message "[Get-IISWorkerProcess] Cannot read handle count for PID $workerPid."
+                    }
+                }
+                elseif ($null -ne $cimObj) {
+                    $startTime = $cimObj.CreationDate
+                    if ($null -ne $startTime) {
+                        $uptimeSecs = [long]([datetime]::Now - $startTime).TotalSeconds
+                    }
+                    $workingSetMB = [long]($cimObj.WorkingSetSize / 1MB)
+                    $threadCount  = [int]$cimObj.ThreadCount
+                    $handleCount  = [int]$cimObj.HandleCount
+                }
+
+                if ($null -ne $cimObj) {
+                    $commandLine = [string]$cimObj.CommandLine
+                }
+
+                $results.Add(@{
+                    ProcessId       = $workerPid
+                    AppPoolName     = $pool
+                    Sites           = $sites
+                    Applications    = $apps
+                    Identity        = $identity
+                    IdentityType    = $identityType
+                    StartTime       = $startTime
+                    UptimeSeconds   = $uptimeSecs
+                    CPUSeconds      = $cpuSecs
+                    WorkingSetMB    = $workingSetMB
+                    PrivateMemoryMB = $privateMemMB
+                    VirtualMemoryMB = $virtualMemMB
+                    ThreadCount     = $threadCount
+                    HandleCount     = $handleCount
+                    CommandLine     = $commandLine
+                    Status          = $status
+                    ErrorMessage    = $null
+                })
+            }
+
+            if ($results.Count -eq 0) {
+                $results.Add(@{
+                    ProcessId       = $null
+                    AppPoolName     = $null
+                    Sites           = @()
+                    Applications    = @()
+                    Identity        = $null
+                    IdentityType    = $null
+                    StartTime       = $null
+                    UptimeSeconds   = $null
+                    CPUSeconds      = $null
+                    WorkingSetMB    = $null
+                    PrivateMemoryMB = $null
+                    VirtualMemoryMB = $null
+                    ThreadCount     = $null
+                    HandleCount     = $null
+                    CommandLine     = $null
+                    Status          = 'NoWorkerProcess'
+                    ErrorMessage    = $null
+                })
+            }
+
+            return $results
+        }
+    }
+
+    process {
+        $filterPoolArg = if ($PSBoundParameters.ContainsKey('AppPoolName')) { $AppPoolName } else { @() }
+        $filterPidArg  = if ($PSBoundParameters.ContainsKey('ProcessId'))   { $ProcessId  } else { @() }
+
+        foreach ($machine in $ComputerName) {
+            $displayName = $machine.ToUpper()
+            Write-Verbose -Message "[$($MyInvocation.MyCommand)] Querying '$machine'"
+
+            try {
+                $rawResults = Invoke-RemoteOrLocal `
+                    -ComputerName $machine `
+                    -Credential   $Credential `
+                    -ScriptBlock  $scriptBlock `
+                    -ArgumentList @($filterPoolArg, $filterPidArg)
+
+                foreach ($entry in $rawResults) {
+                    [PSCustomObject]@{
+                        PSTypeName      = 'PSWinOps.IISWorkerProcess'
+                        ComputerName    = $displayName
+                        ProcessId       = $entry.ProcessId
+                        AppPoolName     = $entry.AppPoolName
+                        Sites           = $entry.Sites
+                        Applications    = $entry.Applications
+                        Identity        = $entry.Identity
+                        IdentityType    = $entry.IdentityType
+                        StartTime       = $entry.StartTime
+                        UptimeSeconds   = $entry.UptimeSeconds
+                        CPUSeconds      = $entry.CPUSeconds
+                        WorkingSetMB    = $entry.WorkingSetMB
+                        PrivateMemoryMB = $entry.PrivateMemoryMB
+                        VirtualMemoryMB = $entry.VirtualMemoryMB
+                        ThreadCount     = $entry.ThreadCount
+                        HandleCount     = $entry.HandleCount
+                        CommandLine     = $entry.CommandLine
+                        Status          = $entry.Status
+                        ErrorMessage    = $entry.ErrorMessage
+                        Timestamp       = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
+                    }
+                }
+            }
+            catch {
+                Write-Error -Message "[$($MyInvocation.MyCommand)] Failed on '$machine': $_"
+                continue
+            }
+        }
+    }
+
+    end {
+        Write-Verbose -Message "[$($MyInvocation.MyCommand)] Completed"
+    }
+}

--- a/Tests/Public/iis/Get-IISWorkerProcess.Tests.ps1
+++ b/Tests/Public/iis/Get-IISWorkerProcess.Tests.ps1
@@ -1,0 +1,410 @@
+﻿#Requires -Version 5.1
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSUseDeclaredVarsMoreThanAssignments', '',
+    Justification = 'Script-scoped variables are assigned in mocks and assertions across separate scopes'
+)]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSAvoidUsingConvertToSecureStringWithPlainText', '',
+    Justification = 'Test fixture only — not a real credential'
+)]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSAvoidUsingComputerNameHardcoded', '',
+    Justification = 'Fake target names used exclusively in test fixtures — no real machines are contacted'
+)]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSReviewUnusedParameter', '',
+    Justification = 'Stub parameters are declared to satisfy the Pester mock engine (PR #42) but have no body'
+)]
+param()
+
+BeforeAll {
+    $script:modulePath = Split-Path -Path (Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent) -Parent
+    Import-Module -Name (Join-Path -Path $script:modulePath -ChildPath 'PSWinOps.psd1') -Force
+
+    # IIS module command stubs — parameters declared explicitly so the Pester mock
+    # engine can match arguments correctly (project convention, see PR #42).
+    if (-not (Get-Command -Name 'Get-Website' -ErrorAction SilentlyContinue)) {
+        function global:Get-Website { param([string]$Name) }
+    }
+    if (-not (Get-Command -Name 'Get-WebApplication' -ErrorAction SilentlyContinue)) {
+        function global:Get-WebApplication { param([string]$Site, [string]$Name) }
+    }
+    if (-not (Get-Command -Name 'Get-IISAppPool' -ErrorAction SilentlyContinue)) {
+        function global:Get-IISAppPool { param([string]$Name) }
+    }
+    if (-not (Get-Command -Name 'Get-IISSite' -ErrorAction SilentlyContinue)) {
+        function global:Get-IISSite { param([string]$Name) }
+    }
+    if (-not (Get-Command -Name 'Get-IISServerManager' -ErrorAction SilentlyContinue)) {
+        function global:Get-IISServerManager { param() }
+    }
+
+    $script:ModuleName = 'PSWinOps'
+
+    # ── Reusable mock payloads ────────────────────────────────────────────────
+
+    $script:mockRunning = @(
+        @{
+            ProcessId       = 1234
+            AppPoolName     = 'DefaultAppPool'
+            Sites           = @('Default Web Site')
+            Applications    = @()
+            Identity        = 'ApplicationPoolIdentity'
+            IdentityType    = 'ApplicationPoolIdentity'
+            StartTime       = (Get-Date).AddHours(-2)
+            UptimeSeconds   = [long]7200
+            CPUSeconds      = [double]12.5
+            WorkingSetMB    = [long]256
+            PrivateMemoryMB = [long]128
+            VirtualMemoryMB = [long]512
+            ThreadCount     = 32
+            HandleCount     = 512
+            CommandLine     = 'c:\windows\system32\inetsrv\w3wp.exe -ap "DefaultAppPool"'
+            Status          = 'Running'
+            ErrorMessage    = $null
+        }
+    )
+
+    $script:mockOrphaned = @(
+        @{
+            ProcessId       = 5678
+            AppPoolName     = ''
+            Sites           = @()
+            Applications    = @()
+            Identity        = ''
+            IdentityType    = 'Unknown'
+            StartTime       = $null
+            UptimeSeconds   = [long]0
+            CPUSeconds      = [double]0
+            WorkingSetMB    = [long]0
+            PrivateMemoryMB = [long]0
+            VirtualMemoryMB = [long]0
+            ThreadCount     = 0
+            HandleCount     = 0
+            CommandLine     = ''
+            Status          = 'Orphaned'
+            ErrorMessage    = $null
+        }
+    )
+
+    $script:mockFailed = @(
+        @{
+            ProcessId       = $null
+            AppPoolName     = $null
+            Sites           = @()
+            Applications    = @()
+            Identity        = $null
+            IdentityType    = $null
+            StartTime       = $null
+            UptimeSeconds   = $null
+            CPUSeconds      = $null
+            WorkingSetMB    = $null
+            PrivateMemoryMB = $null
+            VirtualMemoryMB = $null
+            ThreadCount     = $null
+            HandleCount     = $null
+            CommandLine     = $null
+            Status          = 'Failed'
+            ErrorMessage    = 'CIM query timed out'
+        }
+    )
+
+    $script:mockIISNotInstalled = @(
+        @{
+            ProcessId       = $null
+            AppPoolName     = $null
+            Sites           = @()
+            Applications    = @()
+            Identity        = $null
+            IdentityType    = $null
+            StartTime       = $null
+            UptimeSeconds   = $null
+            CPUSeconds      = $null
+            WorkingSetMB    = $null
+            PrivateMemoryMB = $null
+            VirtualMemoryMB = $null
+            ThreadCount     = $null
+            HandleCount     = $null
+            CommandLine     = $null
+            Status          = 'IISNotInstalled'
+            ErrorMessage    = 'W3SVC service not found: Cannot find service'
+        }
+    )
+
+    $script:mockNoWorkerProcess = @(
+        @{
+            ProcessId       = $null
+            AppPoolName     = $null
+            Sites           = @()
+            Applications    = @()
+            Identity        = $null
+            IdentityType    = $null
+            StartTime       = $null
+            UptimeSeconds   = $null
+            CPUSeconds      = $null
+            WorkingSetMB    = $null
+            PrivateMemoryMB = $null
+            VirtualMemoryMB = $null
+            ThreadCount     = $null
+            HandleCount     = $null
+            CommandLine     = $null
+            Status          = 'NoWorkerProcess'
+            ErrorMessage    = $null
+        }
+    )
+}
+
+Describe 'Get-IISWorkerProcess' {
+
+    # ── Context 1 ─────────────────────────────────────────────────────────────
+    # Happy path: worker process is Running and all output properties are set.
+    # ─────────────────────────────────────────────────────────────────────────
+    Context 'Happy path: Running worker process enriched with pool and resource data' {
+
+        It 'Should return Status Running with correct PSTypeName' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith { return $script:mockRunning }
+            $result = Get-IISWorkerProcess -ComputerName 'WEB01'
+            $result.Status | Should -Be 'Running'
+            $result.PSObject.TypeNames[0] | Should -Be 'PSWinOps.IISWorkerProcess'
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should populate AppPoolName, Sites and ProcessId from mock data' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith { return $script:mockRunning }
+            $result = Get-IISWorkerProcess -ComputerName 'WEB01'
+            $result.AppPoolName | Should -Be 'DefaultAppPool'
+            $result.ProcessId   | Should -Be 1234
+            $result.Sites       | Should -Contain 'Default Web Site'
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should set ComputerName to upper-case display form' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith { return $script:mockRunning }
+            $result = Get-IISWorkerProcess -ComputerName 'web01'
+            $result.ComputerName | Should -Be 'WEB01'
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should populate resource metrics (WorkingSetMB, ThreadCount, HandleCount)' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith { return $script:mockRunning }
+            $result = Get-IISWorkerProcess -ComputerName 'WEB01'
+            $result.WorkingSetMB    | Should -Be 256
+            $result.PrivateMemoryMB | Should -Be 128
+            $result.VirtualMemoryMB | Should -Be 512
+            $result.ThreadCount     | Should -Be 32
+            $result.HandleCount     | Should -Be 512
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should populate identity and uptime fields' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith { return $script:mockRunning }
+            $result = Get-IISWorkerProcess -ComputerName 'WEB01'
+            $result.Identity      | Should -Be 'ApplicationPoolIdentity'
+            $result.IdentityType  | Should -Be 'ApplicationPoolIdentity'
+            $result.UptimeSeconds | Should -Be 7200
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+    }
+
+    # ── Context 2 ─────────────────────────────────────────────────────────────
+    # Status = Orphaned: w3wp.exe running but its app pool is gone from IIS.
+    # ─────────────────────────────────────────────────────────────────────────
+    Context 'Status = Orphaned: w3wp running but app pool no longer exists in IIS config' {
+
+        It 'Should return Status Orphaned with empty AppPoolName' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith { return $script:mockOrphaned }
+            $result = Get-IISWorkerProcess -ComputerName 'WEB01'
+            $result.Status      | Should -Be 'Orphaned'
+            $result.AppPoolName | Should -BeNullOrEmpty
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+    }
+
+    # ── Context 3 ─────────────────────────────────────────────────────────────
+    # Status = Failed: exception thrown inside the scriptblock.
+    # ─────────────────────────────────────────────────────────────────────────
+    Context 'Status = Failed: exception during data collection' {
+
+        It 'Should return Status Failed with a non-empty ErrorMessage' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith { return $script:mockFailed }
+            $result = Get-IISWorkerProcess -ComputerName 'WEB01'
+            $result.Status       | Should -Be 'Failed'
+            $result.ErrorMessage | Should -Not -BeNullOrEmpty
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+    }
+
+    # ── Context 4 ─────────────────────────────────────────────────────────────
+    # Status = IISNotInstalled: W3SVC service absent on target.
+    # ─────────────────────────────────────────────────────────────────────────
+    Context 'Status = IISNotInstalled: W3SVC service not found on target' {
+
+        It 'Should return Status IISNotInstalled and ErrorMessage mentioning W3SVC' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith { return $script:mockIISNotInstalled }
+            $result = Get-IISWorkerProcess -ComputerName 'WEB01'
+            $result.Status       | Should -Be 'IISNotInstalled'
+            $result.ErrorMessage | Should -Match 'W3SVC'
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+    }
+
+    # ── Context 5 ─────────────────────────────────────────────────────────────
+    # Status = NoWorkerProcess: IIS installed but no w3wp.exe currently running.
+    # ─────────────────────────────────────────────────────────────────────────
+    Context 'Status = NoWorkerProcess: IIS installed but no w3wp.exe currently running' {
+
+        It 'Should return Status NoWorkerProcess with null ProcessId' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith { return $script:mockNoWorkerProcess }
+            $result = Get-IISWorkerProcess -ComputerName 'WEB01'
+            $result.Status    | Should -Be 'NoWorkerProcess'
+            $result.ProcessId | Should -BeNullOrEmpty
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+    }
+
+    # ── Context 6 ─────────────────────────────────────────────────────────────
+    # ShouldProcess: Get-IISWorkerProcess is read-only; -WhatIf makes 0 mutations.
+    # ─────────────────────────────────────────────────────────────────────────
+    Context 'ShouldProcess: read-only function — -WhatIf makes 0 mutations' {
+
+        It 'Should throw when called with -WhatIf (SupportsShouldProcess not declared)' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith { return @() }
+            { Get-IISWorkerProcess -WhatIf -ErrorAction Stop } | Should -Throw
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 0 -Exactly
+        }
+    }
+
+    # ── Context 7 ─────────────────────────────────────────────────────────────
+    # Pipeline by property name: ComputerName and DNSHostName alias binding.
+    # ─────────────────────────────────────────────────────────────────────────
+    Context 'Pipeline by property name (ComputerName / DNSHostName alias)' {
+
+        It 'Should fan-out across pipeline objects bound by ComputerName property' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith { return $script:mockRunning }
+            $pipeObjects = @(
+                [PSCustomObject]@{ ComputerName = 'WEB01' }
+                [PSCustomObject]@{ ComputerName = 'WEB02' }
+            )
+            $results = $pipeObjects | Get-IISWorkerProcess
+            @($results).Count | Should -Be 2
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 2 -Exactly
+        }
+
+        It 'Should bind a pipeline object via the DNSHostName alias and set ComputerName' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith { return $script:mockRunning }
+            $pipeObj = [PSCustomObject]@{ DNSHostName = 'WEB03' }
+            $result  = $pipeObj | Get-IISWorkerProcess
+            $result | Should -Not -BeNullOrEmpty
+            $result.ComputerName | Should -Be 'WEB03'
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+    }
+
+    # ── Context 8 ─────────────────────────────────────────────────────────────
+    # Credential propagation: PSCredential must reach Invoke-RemoteOrLocal.
+    # ─────────────────────────────────────────────────────────────────────────
+    Context 'Credential propagation: PSCredential forwarded to Invoke-RemoteOrLocal' {
+
+        It 'Should forward Credential to Invoke-RemoteOrLocal and return results' {
+            $securePass          = ConvertTo-SecureString -String 'P@ssw0rd!' -AsPlainText -Force
+            $cred                = [System.Management.Automation.PSCredential]::new('DOMAIN\svcacct', $securePass)
+            $script:capturedCred = $null
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith {
+                $script:capturedCred = $Credential
+                return $script:mockRunning
+            }
+            $result = Get-IISWorkerProcess -ComputerName 'WEB01' -Credential $cred
+            $result.Status                | Should -Be 'Running'
+            $script:capturedCred          | Should -Not -BeNullOrEmpty
+            $script:capturedCred.UserName | Should -Be 'DOMAIN\svcacct'
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+    }
+
+    # ── Context 9 ─────────────────────────────────────────────────────────────
+    # ComputerName fan-out: multiple machines queried in sequence.
+    # ─────────────────────────────────────────────────────────────────────────
+    Context 'ComputerName fan-out: two machines queried in sequence' {
+
+        It 'Should return one result row per machine with correct ComputerName labels' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith { return $script:mockRunning }
+            $results = Get-IISWorkerProcess -ComputerName 'WEB01', 'WEB02'
+            @($results).Count        | Should -Be 2
+            $results[0].ComputerName | Should -Be 'WEB01'
+            $results[1].ComputerName | Should -Be 'WEB02'
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 2 -Exactly
+        }
+    }
+
+    # ── Context 10 ────────────────────────────────────────────────────────────
+    # Error isolation: a failure on one machine must not suppress other results.
+    # ─────────────────────────────────────────────────────────────────────────
+    Context 'Error isolation: failed machine does not suppress results from healthy machine' {
+
+        It 'Should return results for the healthy machine when the first machine throws' {
+            $script:isolationCallCount = 0
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith {
+                $script:isolationCallCount++
+                if ($script:isolationCallCount -eq 1) { throw 'WinRM connection refused' }
+                return $script:mockRunning
+            }
+            $results = Get-IISWorkerProcess -ComputerName 'FAIL01', 'WEB02' -ErrorAction SilentlyContinue
+            @($results).Count     | Should -Be 1
+            $results.ComputerName | Should -Be 'WEB02'
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 2 -Exactly
+        }
+    }
+
+    # ── Context 11 ────────────────────────────────────────────────────────────
+    # BOM/CRLF sentinel: test file must be UTF-8 BOM with CRLF line endings.
+    # ─────────────────────────────────────────────────────────────────────────
+    Context 'BOM/CRLF sentinel: test file encoding compliance' {
+
+        It 'Should have UTF-8 BOM as first three bytes (EF BB BF)' {
+            $filePath = Join-Path -Path $PSScriptRoot -ChildPath 'Get-IISWorkerProcess.Tests.ps1'
+            $bytes = [System.IO.File]::ReadAllBytes($filePath)
+            $bytes[0] | Should -Be 0xEF
+            $bytes[1] | Should -Be 0xBB
+            $bytes[2] | Should -Be 0xBF
+        }
+
+        It 'Should use CRLF line endings throughout the test file' {
+            $filePath = Join-Path -Path $PSScriptRoot -ChildPath 'Get-IISWorkerProcess.Tests.ps1'
+            $raw = [System.IO.File]::ReadAllText($filePath)
+            $raw | Should -Match "`r`n"
+        }
+    }
+
+    # ── Context 12 ────────────────────────────────────────────────────────────
+    # Timestamp: each result must carry a yyyy-MM-dd HH:mm:ss formatted string.
+    # ─────────────────────────────────────────────────────────────────────────
+    Context 'Timestamp property matches yyyy-MM-dd HH:mm:ss format' {
+
+        It 'Should produce Timestamp matching yyyy-MM-dd HH:mm:ss pattern' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith { return $script:mockRunning }
+            $result = Get-IISWorkerProcess -ComputerName 'WEB01'
+            $result.Timestamp | Should -Match "\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}"
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+    }
+
+    # ── Context 13 ────────────────────────────────────────────────────────────
+    # AppPoolName filter: array forwarded as ArgumentList[0] to Invoke-RemoteOrLocal.
+    # ─────────────────────────────────────────────────────────────────────────
+    Context 'AppPoolName filter: filter array forwarded as ArgumentList[0] to Invoke-RemoteOrLocal' {
+
+        It 'Should pass AppPoolName patterns as first element of ArgumentList' {
+            $script:capturedPoolFilter = $null
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith {
+                $script:capturedPoolFilter = $ArgumentList[0]
+                return @()
+            }
+            Get-IISWorkerProcess -ComputerName 'WEB01' -AppPoolName 'API*', 'DefaultAppPool'
+            $script:capturedPoolFilter | Should -Contain 'API*'
+            $script:capturedPoolFilter | Should -Contain 'DefaultAppPool'
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+    }
+}

--- a/en-US/about_PSWinOps.help.txt
+++ b/en-US/about_PSWinOps.help.txt
@@ -84,11 +84,13 @@ FUNCTION DOMAINS
       Get-ServiceHealth
       Get-WSUSHealth
 
-  iis (2 functions)
+  iis (3 functions)
     Functions for managing IIS sites, HTTPS bindings,
-    and log file analysis across local or remote servers.
+    log file analysis, and worker process monitoring
+    across local or remote servers.
 
       Get-IISParsedLog
+      Get-IISWorkerProcess
       Set-IISBindingCertificate
 
   network (24 functions)
@@ -282,7 +284,7 @@ REMOTE EXECUTION PATTERN
     in the pipeline continue to be processed.
 
 PSWINOPS TYPE REGISTRY
-    The following 88 PSTypeName values are defined by the
+    The following 89 PSTypeName values are defined by the
     module. Each corresponds to the output of one or more
     public functions.
 
@@ -330,6 +332,7 @@ PSWINOPS TYPE REGISTRY
       PSWinOps.IISBindingCertificateResult
       PSWinOps.IISHealth
       PSWinOps.IISLogEntry
+      PSWinOps.IISWorkerProcess
       PSWinOps.InstalledSoftware
       PSWinOps.ListeningPort
       PSWinOps.MACVendor


### PR DESCRIPTION
## Summary
Enumerates every w3wp.exe process on one or more target servers and joins it with IIS configuration so each row carries the owning application pool, the sites and applications it serves, its identity, PID, uptime, CPU time, memory footprint (working set / private / virtual), thread count and handle count. Provides the operational overview that the native IISAdministration module does not expose in a single cmdlet. Falls back gracefully from WebAdministration to IISAdministration to appcmd/CIM when modules are missing, and from Get-Process to CIM Win32_Process when needed.

## Files touched
- `Public/iis/Get-IISWorkerProcess.ps1` — implementation
- `Tests/Public/iis/Get-IISWorkerProcess.Tests.ps1` — Pester v5 suite
- `PSWinOps.psd1` — FunctionsToExport, ModuleVersion (0.1.2 → 0.1.3), ReleaseNotes
- `PSWinOps.Format.ps1xml` — new `<View>` for `PSWinOps.IISWorkerProcess`
- `en-US/about_PSWinOps.help.txt` — iis counter bumped (2 → 3), PSTypeName registry +1

## Conformance checklist (auto-audited by fn-quality-gate)
- [x] UTF-8 BOM + CRLF on all new files
- [x] Approved PowerShell verb (`Get`)
- [x] `FunctionsToExport` alphabetically sorted, `Get-IISWorkerProcess` present exactly once
- [x] `PSTypeName` (`PSWinOps.IISWorkerProcess`) consistent across .ps1 / Format.ps1xml / help
- [x] PSScriptAnalyzer clean (0 warnings on the changed paths, `-Severity Error,Warning`)
- [x] `Test-ModuleManifest ./PSWinOps.psd1` succeeds (111 functions, version 0.1.3)
- [x] No `Write-Host`, no `ToString('o')` introduced in the diff
- [x] `PSWinOps.Format.ps1xml` validates as XML, `<ViewSelectedBy>/<TypeName>` matches the spec
- [x] Pester suite — deferred to the Windows CI matrix (module guard throws on non-Windows hosts; `pswinops-fn-ci-watcher` enforces the green-gate)

## Auto-merge
✅ Armed via `gh pr merge --auto --squash --delete-branch`. Will merge automatically once all required Windows CI checks are green (`validate`, `lint`, `test (Public/iis)` and the rest of the matrix — 14 required contexts, strict up-to-date enforced). Any failure is picked up by `pswinops-fn-ci-watcher`, which loops back through `pswinops-fn-author MODE=fix` (max 3 iterations).
