### PR TITLE
feat(iis): add Get-IISCurrentRequest

### DIFF
--- a/.kdust/chains/get-iiscurrentrequest-2605151729.yaml
+++ b/.kdust/chains/get-iiscurrentrequest-2605151729.yaml
@@ -1,0 +1,7 @@
+chain: pswinops-function-author
+function: Get-IISCurrentRequest
+domain: iis
+created: 2026-05-15T17:29:47Z
+created_by: pswinops-fn-spec-analyst
+chain_branch: kdust/chain/pswinops-fn-get-iiscurrentrequest-2605151729
+spec_path: work/get-iiscurrentrequest/spec.yaml

--- a/PSWinOps.Format.ps1xml
+++ b/PSWinOps.Format.ps1xml
@@ -6915,5 +6915,89 @@
         </TableRowEntries>
       </TableControl>
     </View>
+
+    <!-- ============================================================ -->
+    <!-- PSWinOps.IISCurrentRequest                                   -->
+    <!-- Used by: Get-IISCurrentRequest                               -->
+    <!-- ============================================================ -->
+    <View>
+      <Name>PSWinOps.IISCurrentRequest</Name>
+      <ViewSelectedBy>
+        <TypeName>PSWinOps.IISCurrentRequest</TypeName>
+      </ViewSelectedBy>
+      <TableControl>
+        <AutoSize />
+        <TableHeaders>
+          <TableColumnHeader>
+            <Label>ComputerName</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>PID</Label>
+            <Alignment>Right</Alignment>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>AppPoolName</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>SiteName</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Verb</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Url</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>ClientIP</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>ElapsedMs</Label>
+            <Alignment>Right</Alignment>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>PipelineState</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Status</Label>
+          </TableColumnHeader>
+        </TableHeaders>
+        <TableRowEntries>
+          <TableRowEntry>
+            <TableColumnItems>
+              <TableColumnItem>
+                <PropertyName>ComputerName</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>ProcessId</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>AppPoolName</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>SiteName</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>Verb</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>Url</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>ClientIPAddress</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>TimeElapsedMs</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>PipelineState</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>Status</PropertyName>
+              </TableColumnItem>
+            </TableColumnItems>
+          </TableRowEntry>
+        </TableRowEntries>
+      </TableControl>
+    </View>
   </ViewDefinitions>
 </Configuration>

--- a/PSWinOps.psd1
+++ b/PSWinOps.psd1
@@ -12,7 +12,7 @@
     RootModule           = 'PSWinOps.psm1'
 
     # Version number of this module.
-    ModuleVersion        = '0.1.3'
+    ModuleVersion        = '0.1.4'
 
     # Supported PSEditions
     # Core is supported on Windows only; the module-level guard in PSWinOps.psm1 blocks
@@ -259,7 +259,12 @@
             # IconUri = ''
 
             # ReleaseNotes of this module
-            ReleaseNotes = '## 0.1.3 - 2026-05-15
+            ReleaseNotes = '## 0.1.4 - 2026-05-15
+### Added
+- feat(iis): add Get-IISCurrentRequest — list HTTP requests currently executing in IIS (typed equivalent of `appcmd list requests`) with per-request ComputerName, ProcessId, AppPoolName, SiteName, Url, Verb, ClientIPAddress, TimeElapsed/TimeElapsedMs, PipelineState; multi-host remoting via Invoke-RemoteOrLocal; -AppPoolName / -SiteName wildcards and -MinElapsedMs threshold filters; standard PSWinOps Status enum (InFlight/NoRequests/IISNotInstalled/AppcmdMissing/Failed) + ErrorMessage + Timestamp tail.
+- feat(format): TableControl view for PSWinOps.IISCurrentRequest in PSWinOps.Format.ps1xml.
+
+## 0.1.3 - 2026-05-15
 ### Added
 - feat(iis): add Get-IISWorkerProcess — inventory IIS w3wp.exe worker processes joined with owning AppPoolName, served Sites/Applications, identity/IdentityType, PID, StartTime/UptimeSeconds, CPUSeconds, WorkingSetMB/PrivateMemoryMB/VirtualMemoryMB, ThreadCount/HandleCount, with multi-host remoting via Invoke-RemoteOrLocal, graceful WebAdministration → IISAdministration → appcmd/CIM fallback, -AppPoolName (wildcards) and -ProcessId filters, and the standard PSWinOps Status enum (Running/Orphaned/Failed/IISNotInstalled/NoWorkerProcess).
 - feat(format): TableControl view for PSWinOps.IISWorkerProcess in PSWinOps.Format.ps1xml.

--- a/PSWinOps.psd1
+++ b/PSWinOps.psd1
@@ -123,6 +123,7 @@
         'Get-ExchangeServerHealth',
         'Get-FileServerHealth',
         'Get-HyperVHostHealth',
+        'Get-IISCurrentRequest',
         'Get-IISHealth',
         'Get-IISParsedLog',
         'Get-IISWorkerProcess',

--- a/Public/iis/Get-IISCurrentRequest.ps1
+++ b/Public/iis/Get-IISCurrentRequest.ps1
@@ -1,0 +1,377 @@
+﻿#Requires -Version 5.1
+function Get-IISCurrentRequest {
+    <#
+        .SYNOPSIS
+            Lists HTTP requests currently executing in IIS (typed equivalent of `appcmd list requests`).
+
+        .DESCRIPTION
+            Enumerates every request actively being processed by IIS worker processes
+            on one or more target servers, joining each entry with the owning
+            application pool, the served site, the absolute URL, HTTP verb, client IP,
+            elapsed time and pipeline state. Provides real-time visibility on stuck or
+            long-running requests -- diagnostic data that the IISAdministration module
+            does not expose. Implementation parses `appcmd.exe list requests /xml`
+            inside a remoting-aware scriptblock dispatched through Invoke-RemoteOrLocal.
+
+        .PARAMETER ComputerName
+            One or more computer names to query. Defaults to the local machine.
+            Accepts pipeline input by value and by property name.
+
+        .PARAMETER Credential
+            Optional PSCredential for authenticating to remote computers.
+            Not used for local queries.
+
+        .PARAMETER AppPoolName
+            Restrict the result set to requests served by one or more named
+            application pools. Wildcards accepted via -like.
+
+        .PARAMETER SiteName
+            Restrict the result set to requests targeting one or more named IIS
+            sites. Wildcards accepted via -like.
+
+        .PARAMETER MinElapsedMs
+            Return only requests whose TimeElapsedMs is greater than or equal to
+            this threshold. Handy to surface stuck or long-running requests.
+
+        .EXAMPLE
+            Get-IISCurrentRequest
+
+            Returns all in-flight HTTP requests on the local IIS instance.
+
+        .EXAMPLE
+            Get-IISCurrentRequest -ComputerName 'WEB01'
+
+            Returns in-flight requests from a single remote server.
+
+        .EXAMPLE
+            'WEB01','WEB02' | Get-IISCurrentRequest -Credential (Get-Credential)
+
+            Queries multiple remote servers via pipeline with alternate credentials.
+
+        .EXAMPLE
+            Get-IISCurrentRequest -MinElapsedMs 5000 | Sort-Object TimeElapsedMs -Descending
+
+            Surfaces stuck requests running for more than 5 seconds, sorted by elapsed time.
+
+        .EXAMPLE
+            Get-IISCurrentRequest -SiteName 'www.contoso.com' -AppPoolName 'API*'
+
+            Filters in-flight requests to a specific site and application pool pattern.
+
+        .OUTPUTS
+            PSCustomObject (PSTypeName='PSWinOps.IISCurrentRequest')
+
+        .NOTES
+            Author: Franck SALLET
+            Version: 1.0.0
+            Last Modified: 2026-05-15
+            Requires: PowerShell 5.1+ / Windows only
+            Requires: Web-Server (IIS) role
+            Requires: IIS Management Scripts and Tools feature (for appcmd.exe)
+
+        .LINK
+            https://github.com/k9fr4n/PSWinOps
+
+        .LINK
+            https://learn.microsoft.com/en-us/iis/get-started/getting-started-with-iis/getting-started-with-appcmdexe#list-the-currently-executing-requests
+    #>
+    [CmdletBinding()]
+    [OutputType('PSWinOps.IISCurrentRequest')]
+    param(
+        [Parameter(Mandatory = $false, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [ValidateNotNullOrEmpty()]
+        [Alias('CN', 'Name', 'DNSHostName')]
+        [string[]]$ComputerName = $env:COMPUTERNAME,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateNotNull()]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential,
+
+        [Parameter(Mandatory = $false)]
+        [string[]]$AppPoolName,
+
+        [Parameter(Mandatory = $false)]
+        [string[]]$SiteName,
+
+        [Parameter(Mandatory = $false)]
+        [int]$MinElapsedMs
+    )
+
+    begin {
+        Write-Verbose -Message "[$($MyInvocation.MyCommand)] Starting"
+
+        $scriptBlock = {
+            param(
+                [string[]]$FilterAppPool,
+                [string[]]$FilterSite,
+                [int]$FilterMinElapsedMs
+            )
+
+            $results = [System.Collections.Generic.List[hashtable]]::new()
+            $ts      = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
+
+            # -- 1. Verify IIS (W3SVC) presence
+            try {
+                $null = Get-Service -Name 'W3SVC' -ErrorAction Stop
+            }
+            catch {
+                $results.Add(@{
+                    ProcessId       = $null
+                    AppPoolName     = $null
+                    SiteName        = $null
+                    Url             = $null
+                    Verb            = $null
+                    ClientIPAddress = $null
+                    TimeElapsed     = $null
+                    TimeElapsedMs   = $null
+                    PipelineState   = $null
+                    Status          = 'IISNotInstalled'
+                    ErrorMessage    = "W3SVC service not found: $($_.Exception.Message)"
+                    Timestamp       = $ts
+                })
+                return $results
+            }
+
+            # -- 2. Verify appcmd.exe presence
+            $appcmdExe = Join-Path -Path $env:windir -ChildPath 'system32\inetsrv\appcmd.exe'
+            if (-not (Test-Path -LiteralPath $appcmdExe -PathType Leaf)) {
+                $results.Add(@{
+                    ProcessId       = $null
+                    AppPoolName     = $null
+                    SiteName        = $null
+                    Url             = $null
+                    Verb            = $null
+                    ClientIPAddress = $null
+                    TimeElapsed     = $null
+                    TimeElapsedMs   = $null
+                    PipelineState   = $null
+                    Status          = 'AppcmdMissing'
+                    ErrorMessage    = "appcmd.exe not found at '$appcmdExe'. Install the IIS Management Scripts and Tools feature."
+                    Timestamp       = $ts
+                })
+                return $results
+            }
+
+            # -- 3. Query in-flight requests via appcmd /xml
+            $rawXml = $null
+            try {
+                $rawXml = & $appcmdExe list requests /xml 2>$null
+            }
+            catch {
+                $results.Add(@{
+                    ProcessId       = $null
+                    AppPoolName     = $null
+                    SiteName        = $null
+                    Url             = $null
+                    Verb            = $null
+                    ClientIPAddress = $null
+                    TimeElapsed     = $null
+                    TimeElapsedMs   = $null
+                    PipelineState   = $null
+                    Status          = 'Failed'
+                    ErrorMessage    = "appcmd.exe execution failed: $($_.Exception.Message)"
+                    Timestamp       = $ts
+                })
+                return $results
+            }
+
+            if ([string]::IsNullOrWhiteSpace($rawXml)) {
+                $results.Add(@{
+                    ProcessId       = $null
+                    AppPoolName     = $null
+                    SiteName        = $null
+                    Url             = $null
+                    Verb            = $null
+                    ClientIPAddress = $null
+                    TimeElapsed     = $null
+                    TimeElapsedMs   = $null
+                    PipelineState   = $null
+                    Status          = 'NoRequests'
+                    ErrorMessage    = $null
+                    Timestamp       = $ts
+                })
+                return $results
+            }
+
+            # -- 4. Parse XML
+            try {
+                [xml]$doc = $rawXml
+            }
+            catch {
+                $results.Add(@{
+                    ProcessId       = $null
+                    AppPoolName     = $null
+                    SiteName        = $null
+                    Url             = $null
+                    Verb            = $null
+                    ClientIPAddress = $null
+                    TimeElapsed     = $null
+                    TimeElapsedMs   = $null
+                    PipelineState   = $null
+                    Status          = 'Failed'
+                    ErrorMessage    = "Failed to parse appcmd XML output: $($_.Exception.Message)"
+                    Timestamp       = $ts
+                })
+                return $results
+            }
+
+            $requestNodes = @($doc.appcmd.REQUEST)
+            if ($requestNodes.Count -eq 0 -or ($requestNodes.Count -eq 1 -and $null -eq $requestNodes[0])) {
+                $results.Add(@{
+                    ProcessId       = $null
+                    AppPoolName     = $null
+                    SiteName        = $null
+                    Url             = $null
+                    Verb            = $null
+                    ClientIPAddress = $null
+                    TimeElapsed     = $null
+                    TimeElapsedMs   = $null
+                    PipelineState   = $null
+                    Status          = 'NoRequests'
+                    ErrorMessage    = $null
+                    Timestamp       = $ts
+                })
+                return $results
+            }
+
+            # -- 5. Valid pipeline state values
+            $validStates = [System.Collections.Generic.HashSet[string]] @(
+                'BeginRequest', 'AuthenticateRequest', 'AuthorizeRequest',
+                'ResolveRequestCache', 'MapRequestHandler', 'AcquireRequestState',
+                'PreExecuteRequestHandler', 'ExecuteRequestHandler',
+                'ReleaseRequestState', 'UpdateRequestCache', 'LogRequest',
+                'EndRequest', 'SendResponse'
+            )
+
+            # -- 6. Build result rows
+            $matchedAny = $false
+            foreach ($req in $requestNodes) {
+                if ($null -eq $req) { continue }
+
+                $poolName  = $req.'APPPOOL.NAME'
+                $site      = $req.'SITE.NAME'
+                $elapsedMs = [long]$req.'TIME.ELAPSED'
+                $pipeRaw   = $req.'PIPELINE_STATE'
+
+                $pipelineState = if ($validStates.Contains($pipeRaw)) { $pipeRaw } else { 'Unknown' }
+
+                # Caller-side filtering
+                if ($FilterAppPool -and $FilterAppPool.Count -gt 0) {
+                    $poolMatch = $false
+                    foreach ($pat in $FilterAppPool) {
+                        if ($poolName -like $pat) { $poolMatch = $true; break }
+                    }
+                    if (-not $poolMatch) { continue }
+                }
+
+                if ($FilterSite -and $FilterSite.Count -gt 0) {
+                    $siteMatch = $false
+                    foreach ($pat in $FilterSite) {
+                        if ($site -like $pat) { $siteMatch = $true; break }
+                    }
+                    if (-not $siteMatch) { continue }
+                }
+
+                if ($FilterMinElapsedMs -gt 0 -and $elapsedMs -lt $FilterMinElapsedMs) { continue }
+
+                $matchedAny = $true
+                $results.Add(@{
+                    ProcessId       = if ($req.'WORKER_PROCESS.PID') { [int]$req.'WORKER_PROCESS.PID' } else { $null }
+                    AppPoolName     = $poolName
+                    SiteName        = $site
+                    Url             = $req.URL
+                    Verb            = $req.VERB
+                    ClientIPAddress = $req.CLIENTIP
+                    TimeElapsed     = [System.TimeSpan]::FromMilliseconds($elapsedMs)
+                    TimeElapsedMs   = $elapsedMs
+                    PipelineState   = $pipelineState
+                    Status          = 'InFlight'
+                    ErrorMessage    = $null
+                    Timestamp       = $ts
+                })
+            }
+
+            if (-not $matchedAny) {
+                $results.Add(@{
+                    ProcessId       = $null
+                    AppPoolName     = $null
+                    SiteName        = $null
+                    Url             = $null
+                    Verb            = $null
+                    ClientIPAddress = $null
+                    TimeElapsed     = $null
+                    TimeElapsedMs   = $null
+                    PipelineState   = $null
+                    Status          = 'NoRequests'
+                    ErrorMessage    = $null
+                    Timestamp       = $ts
+                })
+            }
+
+            return $results
+        }
+    }
+
+    process {
+        foreach ($cn in $ComputerName) {
+            Write-Verbose -Message "[$($MyInvocation.MyCommand)] Querying '$cn'"
+
+            try {
+                $invokeParams = @{
+                    ComputerName = $cn
+                    ScriptBlock  = $scriptBlock
+                    ArgumentList = @($AppPoolName, $SiteName, $MinElapsedMs)
+                }
+                if ($PSBoundParameters.ContainsKey('Credential')) {
+                    $invokeParams['Credential'] = $Credential
+                }
+
+                $rawResults = Invoke-RemoteOrLocal @invokeParams
+            }
+            catch {
+                [PSCustomObject]@{
+                    PSTypeName      = 'PSWinOps.IISCurrentRequest'
+                    ComputerName    = $cn
+                    ProcessId       = $null
+                    AppPoolName     = $null
+                    SiteName        = $null
+                    Url             = $null
+                    Verb            = $null
+                    ClientIPAddress = $null
+                    TimeElapsed     = $null
+                    TimeElapsedMs   = $null
+                    PipelineState   = $null
+                    Status          = 'Failed'
+                    ErrorMessage    = $_.Exception.Message
+                    Timestamp       = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
+                }
+                continue
+            }
+
+            foreach ($row in $rawResults) {
+                [PSCustomObject]@{
+                    PSTypeName      = 'PSWinOps.IISCurrentRequest'
+                    ComputerName    = $cn
+                    ProcessId       = $row.ProcessId
+                    AppPoolName     = $row.AppPoolName
+                    SiteName        = $row.SiteName
+                    Url             = $row.Url
+                    Verb            = $row.Verb
+                    ClientIPAddress = $row.ClientIPAddress
+                    TimeElapsed     = $row.TimeElapsed
+                    TimeElapsedMs   = $row.TimeElapsedMs
+                    PipelineState   = $row.PipelineState
+                    Status          = $row.Status
+                    ErrorMessage    = $row.ErrorMessage
+                    Timestamp       = $row.Timestamp
+                }
+            }
+        }
+    }
+
+    end {
+        Write-Verbose -Message "[$($MyInvocation.MyCommand)] Done"
+    }
+}

--- a/Tests/Public/iis/Get-IISCurrentRequest.Tests.ps1
+++ b/Tests/Public/iis/Get-IISCurrentRequest.Tests.ps1
@@ -1,0 +1,520 @@
+﻿#Requires -Version 5.1
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSUseDeclaredVarsMoreThanAssignments', '',
+    Justification = 'Script-scoped variables are assigned in mocks and assertions across separate scopes'
+)]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSAvoidUsingConvertToSecureStringWithPlainText', '',
+    Justification = 'Test fixture only -- not a real credential'
+)]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSAvoidUsingComputerNameHardcoded', '',
+    Justification = 'Fake target names used exclusively in test fixtures -- no real machines are contacted'
+)]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSReviewUnusedParameter', '',
+    Justification = 'Stub parameters are declared to satisfy the Pester mock engine (PR #42) but have no body'
+)]
+param()
+
+BeforeAll {
+    $script:modulePath = Split-Path -Path (Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent) -Parent
+    Import-Module -Name (Join-Path -Path $script:modulePath -ChildPath 'PSWinOps.psd1') -Force
+    $script:ModuleName = 'PSWinOps'
+
+    # ---------------------------------------------------------------------------
+    # Reusable mock payloads
+    # ---------------------------------------------------------------------------
+
+    $script:mockInFlight = @(
+        @{
+            ProcessId       = 4812
+            AppPoolName     = 'DefaultAppPool'
+            SiteName        = 'Default Web Site'
+            Url             = 'http://web01.contoso.com/api/data?q=test'
+            Verb            = 'GET'
+            ClientIPAddress = '192.168.1.10'
+            TimeElapsed     = [System.TimeSpan]::FromMilliseconds(1523)
+            TimeElapsedMs   = [long]1523
+            PipelineState   = 'ExecuteRequestHandler'
+            Status          = 'InFlight'
+            ErrorMessage    = $null
+            Timestamp       = (Get-Date -Format 'yyyy-MM-dd HH:mm:ss')
+        }
+    )
+
+    $script:mockNoRequests = @(
+        @{
+            ProcessId       = $null
+            AppPoolName     = $null
+            SiteName        = $null
+            Url             = $null
+            Verb            = $null
+            ClientIPAddress = $null
+            TimeElapsed     = $null
+            TimeElapsedMs   = $null
+            PipelineState   = $null
+            Status          = 'NoRequests'
+            ErrorMessage    = $null
+            Timestamp       = (Get-Date -Format 'yyyy-MM-dd HH:mm:ss')
+        }
+    )
+
+    $script:mockIISNotInstalled = @(
+        @{
+            ProcessId       = $null
+            AppPoolName     = $null
+            SiteName        = $null
+            Url             = $null
+            Verb            = $null
+            ClientIPAddress = $null
+            TimeElapsed     = $null
+            TimeElapsedMs   = $null
+            PipelineState   = $null
+            Status          = 'IISNotInstalled'
+            ErrorMessage    = 'W3SVC service not found: Cannot find any service with service name W3SVC'
+            Timestamp       = (Get-Date -Format 'yyyy-MM-dd HH:mm:ss')
+        }
+    )
+
+    $script:mockAppcmdMissing = @(
+        @{
+            ProcessId       = $null
+            AppPoolName     = $null
+            SiteName        = $null
+            Url             = $null
+            Verb            = $null
+            ClientIPAddress = $null
+            TimeElapsed     = $null
+            TimeElapsedMs   = $null
+            PipelineState   = $null
+            Status          = 'AppcmdMissing'
+            ErrorMessage    = 'appcmd.exe not found. Install the IIS Management Scripts and Tools feature.'
+            Timestamp       = (Get-Date -Format 'yyyy-MM-dd HH:mm:ss')
+        }
+    )
+
+    $script:mockFailed = @(
+        @{
+            ProcessId       = $null
+            AppPoolName     = $null
+            SiteName        = $null
+            Url             = $null
+            Verb            = $null
+            ClientIPAddress = $null
+            TimeElapsed     = $null
+            TimeElapsedMs   = $null
+            PipelineState   = $null
+            Status          = 'Failed'
+            ErrorMessage    = 'appcmd.exe execution failed: Access is denied'
+            Timestamp       = (Get-Date -Format 'yyyy-MM-dd HH:mm:ss')
+        }
+    )
+
+    $script:mockMultiRequest = @(
+        @{
+            ProcessId       = 4812
+            AppPoolName     = 'APIPool'
+            SiteName        = 'api.contoso.com'
+            Url             = 'http://api.contoso.com/v1/items'
+            Verb            = 'POST'
+            ClientIPAddress = '10.0.0.5'
+            TimeElapsed     = [System.TimeSpan]::FromMilliseconds(6200)
+            TimeElapsedMs   = [long]6200
+            PipelineState   = 'ExecuteRequestHandler'
+            Status          = 'InFlight'
+            ErrorMessage    = $null
+            Timestamp       = (Get-Date -Format 'yyyy-MM-dd HH:mm:ss')
+        }
+        @{
+            ProcessId       = 7360
+            AppPoolName     = 'DefaultAppPool'
+            SiteName        = 'Default Web Site'
+            Url             = 'http://web01.contoso.com/home'
+            Verb            = 'GET'
+            ClientIPAddress = '192.168.1.20'
+            TimeElapsed     = [System.TimeSpan]::FromMilliseconds(320)
+            TimeElapsedMs   = [long]320
+            PipelineState   = 'SendResponse'
+            Status          = 'InFlight'
+            ErrorMessage    = $null
+            Timestamp       = (Get-Date -Format 'yyyy-MM-dd HH:mm:ss')
+        }
+    )
+}
+
+Describe 'Get-IISCurrentRequest' {
+
+    # == Context 1 ==============================================================
+    # Happy path: InFlight request with all output properties populated.
+    # ===========================================================================
+    Context 'Happy path: InFlight request with all properties populated' {
+
+        It 'Should return Status InFlight with correct PSTypeName' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith { return $script:mockInFlight }
+            $result = Get-IISCurrentRequest -ComputerName 'WEB01'
+            $result.Status                | Should -Be 'InFlight'
+            $result.PSObject.TypeNames[0] | Should -Be 'PSWinOps.IISCurrentRequest'
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should populate Url, Verb, ClientIPAddress and AppPoolName from mock' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith { return $script:mockInFlight }
+            $result = Get-IISCurrentRequest -ComputerName 'WEB01'
+            $result.Url             | Should -Be 'http://web01.contoso.com/api/data?q=test'
+            $result.Verb            | Should -Be 'GET'
+            $result.ClientIPAddress | Should -Be '192.168.1.10'
+            $result.AppPoolName     | Should -Be 'DefaultAppPool'
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should populate ProcessId, SiteName and PipelineState' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith { return $script:mockInFlight }
+            $result = Get-IISCurrentRequest -ComputerName 'WEB01'
+            $result.ProcessId     | Should -Be 4812
+            $result.SiteName      | Should -Be 'Default Web Site'
+            $result.PipelineState | Should -Be 'ExecuteRequestHandler'
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should populate TimeElapsed as TimeSpan and TimeElapsedMs as long' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith { return $script:mockInFlight }
+            $result = Get-IISCurrentRequest -ComputerName 'WEB01'
+            $result.TimeElapsed   | Should -BeOfType [System.TimeSpan]
+            $result.TimeElapsedMs | Should -Be 1523
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should set ComputerName to the value supplied by the caller' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith { return $script:mockInFlight }
+            $result = Get-IISCurrentRequest -ComputerName 'WEB01'
+            $result.ComputerName | Should -Be 'WEB01'
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+    }
+
+    # == Context 2 ==============================================================
+    # Status = NoRequests: IIS healthy but no request in-flight.
+    # ===========================================================================
+    Context 'Status = NoRequests: IIS healthy but no request in-flight' {
+
+        It 'Should return Status NoRequests with null Url and null ProcessId' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith { return $script:mockNoRequests }
+            $result = Get-IISCurrentRequest -ComputerName 'WEB01'
+            $result.Status    | Should -Be 'NoRequests'
+            $result.Url       | Should -BeNullOrEmpty
+            $result.ProcessId | Should -BeNullOrEmpty
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+    }
+
+    # == Context 3 ==============================================================
+    # Status = IISNotInstalled: W3SVC service absent on target machine.
+    # ===========================================================================
+    Context 'Status = IISNotInstalled: W3SVC service absent on target' {
+
+        It 'Should return Status IISNotInstalled with ErrorMessage mentioning W3SVC' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith { return $script:mockIISNotInstalled }
+            $result = Get-IISCurrentRequest -ComputerName 'WEB01'
+            $result.Status       | Should -Be 'IISNotInstalled'
+            $result.ErrorMessage | Should -Match 'W3SVC'
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+    }
+
+    # == Context 4 ==============================================================
+    # Status = AppcmdMissing: appcmd.exe binary not found on target.
+    # ===========================================================================
+    Context 'Status = AppcmdMissing: appcmd.exe not found on target' {
+
+        It 'Should return Status AppcmdMissing with ErrorMessage mentioning appcmd.exe' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith { return $script:mockAppcmdMissing }
+            $result = Get-IISCurrentRequest -ComputerName 'WEB01'
+            $result.Status       | Should -Be 'AppcmdMissing'
+            $result.ErrorMessage | Should -Match 'appcmd\.exe'
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should have null ProcessId, Url and PipelineState when AppcmdMissing' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith { return $script:mockAppcmdMissing }
+            $result = Get-IISCurrentRequest -ComputerName 'WEB01'
+            $result.ProcessId     | Should -BeNullOrEmpty
+            $result.Url           | Should -BeNullOrEmpty
+            $result.PipelineState | Should -BeNullOrEmpty
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+    }
+
+    # == Context 5 ==============================================================
+    # Status = Failed: exception from the scriptblock or Invoke-RemoteOrLocal.
+    # ===========================================================================
+    Context 'Status = Failed: exception thrown during data collection' {
+
+        It 'Should return Status Failed with non-empty ErrorMessage when Invoke-RemoteOrLocal throws' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith { throw 'WinRM connection refused' }
+            $result = Get-IISCurrentRequest -ComputerName 'WEB01' -ErrorAction SilentlyContinue
+            $result.Status       | Should -Be 'Failed'
+            $result.ErrorMessage | Should -Not -BeNullOrEmpty
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should return Status Failed from scriptblock appcmd execution error' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith { return $script:mockFailed }
+            $result = Get-IISCurrentRequest -ComputerName 'WEB01'
+            $result.Status       | Should -Be 'Failed'
+            $result.ErrorMessage | Should -Not -BeNullOrEmpty
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+    }
+
+    # == Context 6 ==============================================================
+    # ShouldProcess: function is read-only; -WhatIf is not a declared parameter.
+    # ===========================================================================
+    Context 'ShouldProcess: read-only function -- -WhatIf parameter is not declared' {
+
+        It 'Should throw when called with -WhatIf because SupportsShouldProcess is not declared' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith { return @() }
+            { Get-IISCurrentRequest -WhatIf -ErrorAction Stop } | Should -Throw
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 0 -Exactly
+        }
+    }
+
+    # == Context 7 ==============================================================
+    # Pipeline by property name: ComputerName / DNSHostName / CN alias binding.
+    # ===========================================================================
+    Context 'Pipeline by property name (ComputerName / DNSHostName / CN aliases)' {
+
+        It 'Should fan-out across two pipeline objects bound by ComputerName property' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith { return $script:mockInFlight }
+            $pipeObjects = @(
+                [PSCustomObject]@{ ComputerName = 'WEB01' }
+                [PSCustomObject]@{ ComputerName = 'WEB02' }
+            )
+            $results = $pipeObjects | Get-IISCurrentRequest
+            @($results).Count | Should -Be 2
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 2 -Exactly
+        }
+
+        It 'Should bind pipeline object via DNSHostName alias and emit ComputerName correctly' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith { return $script:mockInFlight }
+            $pipeObj = [PSCustomObject]@{ DNSHostName = 'WEB03' }
+            $result  = $pipeObj | Get-IISCurrentRequest
+            $result              | Should -Not -BeNullOrEmpty
+            $result.ComputerName | Should -Be 'WEB03'
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should bind pipeline object via CN alias and emit ComputerName correctly' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith { return $script:mockInFlight }
+            $pipeObj = [PSCustomObject]@{ CN = 'WEB04' }
+            $result  = $pipeObj | Get-IISCurrentRequest
+            $result              | Should -Not -BeNullOrEmpty
+            $result.ComputerName | Should -Be 'WEB04'
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+    }
+
+    # == Context 8 ==============================================================
+    # Credential propagation: PSCredential must reach Invoke-RemoteOrLocal.
+    # ===========================================================================
+    Context 'Credential propagation: PSCredential forwarded to Invoke-RemoteOrLocal' {
+
+        It 'Should forward Credential to Invoke-RemoteOrLocal and return InFlight results' {
+            $securePass          = ConvertTo-SecureString -String 'P@ssw0rd!' -AsPlainText -Force
+            $cred                = [System.Management.Automation.PSCredential]::new('DOMAIN\svcweb', $securePass)
+            $script:capturedCred = $null
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith {
+                $script:capturedCred = $Credential
+                return $script:mockInFlight
+            }
+            $result = Get-IISCurrentRequest -ComputerName 'WEB01' -Credential $cred
+            $result.Status                | Should -Be 'InFlight'
+            $script:capturedCred          | Should -Not -BeNullOrEmpty
+            $script:capturedCred.UserName | Should -Be 'DOMAIN\svcweb'
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+    }
+
+    # == Context 9 ==============================================================
+    # ComputerName fan-out: multiple machine names queried in sequence.
+    # ===========================================================================
+    Context 'ComputerName fan-out: multiple machines queried in sequence' {
+
+        It 'Should return one result row per machine with correct ComputerName labels' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith { return $script:mockInFlight }
+            $results = Get-IISCurrentRequest -ComputerName 'WEB01', 'WEB02'
+            @($results).Count        | Should -Be 2
+            $results[0].ComputerName | Should -Be 'WEB01'
+            $results[1].ComputerName | Should -Be 'WEB02'
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 2 -Exactly
+        }
+    }
+
+    # == Context 10 =============================================================
+    # Error isolation: failure on one machine must not suppress other results.
+    # ===========================================================================
+    Context 'Error isolation: failed machine does not suppress results from healthy machine' {
+
+        It 'Should return Failed row for first machine and InFlight for second' {
+            $script:isolationCallCount = 0
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith {
+                $script:isolationCallCount++
+                if ($script:isolationCallCount -eq 1) { throw 'WinRM connection refused' }
+                return $script:mockInFlight
+            }
+            $results = Get-IISCurrentRequest -ComputerName 'FAIL01', 'WEB02' -ErrorAction SilentlyContinue
+            @($results).Count        | Should -Be 2
+            $results[0].Status       | Should -Be 'Failed'
+            $results[0].ComputerName | Should -Be 'FAIL01'
+            $results[1].Status       | Should -Be 'InFlight'
+            $results[1].ComputerName | Should -Be 'WEB02'
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 2 -Exactly
+        }
+    }
+
+    # == Context 11 =============================================================
+    # BOM/CRLF sentinel: test file must be UTF-8 with BOM and CRLF line endings.
+    # ===========================================================================
+    Context 'BOM/CRLF sentinel: test file encoding compliance' {
+
+        It 'Should have UTF-8 BOM as first three bytes (EF BB BF)' {
+            $filePath = Join-Path -Path $PSScriptRoot -ChildPath 'Get-IISCurrentRequest.Tests.ps1'
+            $bytes = [System.IO.File]::ReadAllBytes($filePath)
+            $bytes[0] | Should -Be 0xEF
+            $bytes[1] | Should -Be 0xBB
+            $bytes[2] | Should -Be 0xBF
+        }
+
+        It 'Should use CRLF line endings throughout the test file' {
+            $filePath = Join-Path -Path $PSScriptRoot -ChildPath 'Get-IISCurrentRequest.Tests.ps1'
+            $raw = [System.IO.File]::ReadAllText($filePath)
+            $raw | Should -Match "`r`n"
+        }
+    }
+
+    # == Context 12 =============================================================
+    # Timestamp property: must match yyyy-MM-dd HH:mm:ss pattern in every row.
+    # ===========================================================================
+    Context 'Timestamp property matches yyyy-MM-dd HH:mm:ss format' {
+
+        It 'Should produce Timestamp matching yyyy-MM-dd HH:mm:ss pattern for InFlight row' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith { return $script:mockInFlight }
+            $result = Get-IISCurrentRequest -ComputerName 'WEB01'
+            $result.Timestamp | Should -Match "\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}"
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should produce Timestamp matching yyyy-MM-dd HH:mm:ss pattern for NoRequests row' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith { return $script:mockNoRequests }
+            $result = Get-IISCurrentRequest -ComputerName 'WEB01'
+            $result.Timestamp | Should -Match "\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}"
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+    }
+
+    # == Context 13 =============================================================
+    # AppPoolName filter: filter array forwarded as ArgumentList[0].
+    # ===========================================================================
+    Context 'AppPoolName filter: array forwarded as ArgumentList[0] to Invoke-RemoteOrLocal' {
+
+        It 'Should pass AppPoolName patterns as first element of ArgumentList' {
+            $script:capturedPoolFilter = $null
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith {
+                $script:capturedPoolFilter = $ArgumentList[0]
+                return @()
+            }
+            Get-IISCurrentRequest -ComputerName 'WEB01' -AppPoolName 'API*', 'DefaultAppPool'
+            $script:capturedPoolFilter | Should -Contain 'API*'
+            $script:capturedPoolFilter | Should -Contain 'DefaultAppPool'
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+    }
+
+    # == Context 14 =============================================================
+    # SiteName filter: filter array forwarded as ArgumentList[1].
+    # ===========================================================================
+    Context 'SiteName filter: array forwarded as ArgumentList[1] to Invoke-RemoteOrLocal' {
+
+        It 'Should pass SiteName patterns as second element of ArgumentList' {
+            $script:capturedSiteFilter = $null
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith {
+                $script:capturedSiteFilter = $ArgumentList[1]
+                return @()
+            }
+            Get-IISCurrentRequest -ComputerName 'WEB01' -SiteName 'Default Web Site', 'api.contoso.com'
+            $script:capturedSiteFilter | Should -Contain 'Default Web Site'
+            $script:capturedSiteFilter | Should -Contain 'api.contoso.com'
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+    }
+
+    # == Context 15 =============================================================
+    # MinElapsedMs filter: threshold forwarded as ArgumentList[2].
+    # ===========================================================================
+    Context 'MinElapsedMs filter: threshold forwarded as ArgumentList[2] to Invoke-RemoteOrLocal' {
+
+        It 'Should pass MinElapsedMs as third element of ArgumentList' {
+            $script:capturedMinElapsed = $null
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith {
+                $script:capturedMinElapsed = $ArgumentList[2]
+                return @()
+            }
+            Get-IISCurrentRequest -ComputerName 'WEB01' -MinElapsedMs 5000
+            $script:capturedMinElapsed | Should -Be 5000
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should return two result rows when multiple requests are in-flight' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith { return $script:mockMultiRequest }
+            $results = Get-IISCurrentRequest -ComputerName 'WEB01'
+            @($results).Count | Should -Be 2
+            $results | ForEach-Object { $_.Status | Should -Be 'InFlight' }
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+    }
+
+    # == Context 16 =============================================================
+    # PipelineState enum: valid values pass through; unrecognised -> Unknown.
+    # ===========================================================================
+    Context 'PipelineState enum: valid values pass through unmodified' {
+
+        It 'Should carry a recognised PipelineState for an InFlight request' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith { return $script:mockInFlight }
+            $result = Get-IISCurrentRequest -ComputerName 'WEB01'
+            $validStates = @(
+                'BeginRequest', 'AuthenticateRequest', 'AuthorizeRequest',
+                'ResolveRequestCache', 'MapRequestHandler', 'AcquireRequestState',
+                'PreExecuteRequestHandler', 'ExecuteRequestHandler',
+                'ReleaseRequestState', 'UpdateRequestCache', 'LogRequest',
+                'EndRequest', 'SendResponse', 'Unknown'
+            )
+            $result.PipelineState | Should -BeIn $validStates
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should normalise an unrecognised PipelineState value to Unknown' {
+            $script:mockUnknownState = @(
+                @{
+                    ProcessId       = 999
+                    AppPoolName     = 'TestPool'
+                    SiteName        = 'TestSite'
+                    Url             = 'http://test.local/ping'
+                    Verb            = 'GET'
+                    ClientIPAddress = '127.0.0.1'
+                    TimeElapsed     = [System.TimeSpan]::FromMilliseconds(100)
+                    TimeElapsedMs   = [long]100
+                    PipelineState   = 'Unknown'
+                    Status          = 'InFlight'
+                    ErrorMessage    = $null
+                    Timestamp       = (Get-Date -Format 'yyyy-MM-dd HH:mm:ss')
+                }
+            )
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith { return $script:mockUnknownState }
+            $result = Get-IISCurrentRequest -ComputerName 'WEB01'
+            $result.PipelineState | Should -Be 'Unknown'
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+    }
+}

--- a/en-US/about_PSWinOps.help.txt
+++ b/en-US/about_PSWinOps.help.txt
@@ -84,11 +84,13 @@ FUNCTION DOMAINS
       Get-ServiceHealth
       Get-WSUSHealth
 
-  iis (3 functions)
+  iis (4 functions)
     Functions for managing IIS sites, HTTPS bindings,
-    log file analysis, and worker process monitoring
-    across local or remote servers.
+    log file analysis, worker process monitoring, and
+    real-time in-flight request inspection across local
+    or remote servers.
 
+      Get-IISCurrentRequest
       Get-IISParsedLog
       Get-IISWorkerProcess
       Set-IISBindingCertificate
@@ -284,7 +286,7 @@ REMOTE EXECUTION PATTERN
     in the pipeline continue to be processed.
 
 PSWINOPS TYPE REGISTRY
-    The following 89 PSTypeName values are defined by the
+    The following 90 PSTypeName values are defined by the
     module. Each corresponds to the output of one or more
     public functions.
 
@@ -330,6 +332,7 @@ PSWINOPS TYPE REGISTRY
       PSWinOps.FileServerHealth
       PSWinOps.HyperVHostHealth
       PSWinOps.IISBindingCertificateResult
+      PSWinOps.IISCurrentRequest
       PSWinOps.IISHealth
       PSWinOps.IISLogEntry
       PSWinOps.IISWorkerProcess


### PR DESCRIPTION
## Summary
Enumerates every request actively being processed by IIS worker processes on one or more target servers, joining each entry with the owning application pool, the served site, the absolute URL, HTTP verb, client IP, elapsed time and pipeline state. Provides real-time visibility on stuck or long-running requests — diagnostic data that the IISAdministration module does not expose. Implementation parses `appcmd.exe list requests /xml` inside a remoting-aware scriptblock dispatched through `Invoke-RemoteOrLocal`.

## Files touched
- `Public/iis/Get-IISCurrentRequest.ps1` — implementation
- `Tests/Public/iis/Get-IISCurrentRequest.Tests.ps1` — Pester v5 suite
- `PSWinOps.psd1` — FunctionsToExport, ModuleVersion (0.1.3 → 0.1.4), ReleaseNotes
- `PSWinOps.Format.ps1xml` — new `<View>` for `PSWinOps.IISCurrentRequest`
- `en-US/about_PSWinOps.help.txt` — iis counter 3 → 4, new PSTypeName entry

## Conformance checklist (auto-audited by fn-quality-gate)
- [x] UTF-8 BOM + CRLF on all new files
- [x] Approved PowerShell verb (`Get`)
- [x] `FunctionsToExport` alphabetically sorted (case-insensitive), `Get-IISCurrentRequest` present exactly once
- [x] `PSTypeName` `PSWinOps.IISCurrentRequest` consistent across `.ps1` / `Format.ps1xml` / help
- [x] PSScriptAnalyzer clean (0 errors / 0 warnings on changed paths, `-Severity Error,Warning` matching CI policy)
- [x] No `Write-Host`, no `ToString('o')` introduced in the diff
- [x] `Test-ModuleManifest` succeeds (version `0.1.4`, 112 exported functions)
- [x] `PSWinOps.Format.ps1xml` validates as XML and contains a `<View>` whose `<ViewSelectedBy>/<TypeName>` is `PSWinOps.IISCurrentRequest`
- [ ] Pester suite — **deferred to Windows CI**: module hard-requires Windows (PSEdition guard in `PSWinOps.psm1`), cannot run in the Linux quality-gate sandbox. Validated by the `test (Public/iis)` required check on `windows-latest`.

## Auto-merge
✅ Armed via `gh pr merge --auto --squash --delete-branch`. Will merge automatically once all required Windows CI checks are green (`validate`, `lint`, `test (Public/iis)` and the rest of the matrix configured on `main`). Any failure is picked up by `pswinops-fn-ci-watcher`, which loops back through `pswinops-fn-author MODE=fix` (max 3 iterations).
