### PR TITLE
feat(iis): add Watch-IISLog

### DIFF
--- a/.kdust/chains/watch-iislog-2605151832.yaml
+++ b/.kdust/chains/watch-iislog-2605151832.yaml
@@ -1,0 +1,7 @@
+chain: pswinops-function-author
+function: Watch-IISLog
+domain: iis
+created: 2026-05-15T18:34:06Z
+created_by: pswinops-fn-spec-analyst
+chain_branch: kdust/chain/pswinops-fn-watch-iislog-2605151832
+spec_path: work/watch-iislog/spec.yaml

--- a/PSWinOps.psd1
+++ b/PSWinOps.psd1
@@ -12,7 +12,7 @@
     RootModule           = 'PSWinOps.psm1'
 
     # Version number of this module.
-    ModuleVersion        = '0.1.4'
+    ModuleVersion        = '0.1.5'
 
     # Supported PSEditions
     # Core is supported on Windows only; the module-level guard in PSWinOps.psm1 blocks
@@ -260,7 +260,11 @@
             # IconUri = ''
 
             # ReleaseNotes of this module
-            ReleaseNotes = '## 0.1.4 - 2026-05-15
+            ReleaseNotes = '## 0.1.5 - 2026-05-15
+### Added
+- feat(iis): add Watch-IISLog — real-time IIS W3C log tailer emitting typed PSWinOps.IISLogEntry objects (same shape as Get-IISParsedLog) as new lines are written; resolves the active site log via WebAdministration / Microsoft.Web.Administration / appcmd fallback; opens with FileShare.ReadWrite|Delete so IIS is undisturbed; supports -InitialLines (tail -n replay), -FollowRollover (daily log rotation), -PollIntervalMs, -Duration and -MaxEntries bounds; in-stream filters -Method/-Status/-UriLike/-ClientIP/-MinStatus; multi-host remoting via Invoke-RemoteOrLocal with -Credential; reuses the existing PSWinOps.IISLogEntry Format view.
+
+## 0.1.4 - 2026-05-15
 ### Added
 - feat(iis): add Get-IISCurrentRequest — list HTTP requests currently executing in IIS (typed equivalent of `appcmd list requests`) with per-request ComputerName, ProcessId, AppPoolName, SiteName, Url, Verb, ClientIPAddress, TimeElapsed/TimeElapsedMs, PipelineState; multi-host remoting via Invoke-RemoteOrLocal; -AppPoolName / -SiteName wildcards and -MinElapsedMs threshold filters; standard PSWinOps Status enum (InFlight/NoRequests/IISNotInstalled/AppcmdMissing/Failed) + ErrorMessage + Timestamp tail.
 - feat(format): TableControl view for PSWinOps.IISCurrentRequest in PSWinOps.Format.ps1xml.

--- a/PSWinOps.psd1
+++ b/PSWinOps.psd1
@@ -192,7 +192,8 @@
         'Test-WinRM',
         'Trace-NetworkRoute',
         'Uninstall-WindowsUpdate',
-        'Unlock-ADUserAccount'
+        'Unlock-ADUserAccount',
+        'Watch-IISLog'
     )
 
     # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.

--- a/Public/iis/Watch-IISLog.ps1
+++ b/Public/iis/Watch-IISLog.ps1
@@ -1,0 +1,721 @@
+﻿#Requires -Version 5.1
+function Watch-IISLog {
+    <#
+        .SYNOPSIS
+            Streams new entries from a live IIS site log in real time (tail -f), parsing each line into a PSWinOps.IISLogEntry object as it is written.
+
+        .DESCRIPTION
+            Resolves the active W3C log file of a given IIS site from its configuration
+            (WebAdministration provider, falling back to Microsoft.Web.Administration or
+            appcmd.exe), opens it with FileShare.ReadWrite|Delete so as not to disturb
+            IIS, and emits each new data line as a structured PSWinOps.IISLogEntry,
+            the same shape produced by Get-IISParsedLog. Honours mid-file #Fields
+            re-detection (post-recycle) and optionally follows daily log rollover via
+            -FollowRollover. Filtering parameters (-Method/-Status/-UriLike/-ClientIP/
+            -MinStatus) are applied during streaming. Use -InitialLines to replay the
+            last N entries before entering follow mode, and -Duration/-MaxEntries to
+            bound a run (recommended for remote sessions).
+
+        .PARAMETER ComputerName
+            One or more computer names to tail. Defaults to the local machine.
+            Accepts pipeline input by value and by property name.
+
+        .PARAMETER Credential
+            Optional PSCredential for authenticating to remote computers.
+            Not used for local queries.
+
+        .PARAMETER SiteName
+            IIS site whose active log file is to be followed. Resolved via the
+            WebAdministration provider, Microsoft.Web.Administration, or appcmd.exe.
+
+        .PARAMETER LogFormat
+            Log format in use. Only W3C is supported. IIS, NCSA and Custom formats
+            are rejected with a clear error message.
+
+        .PARAMETER InitialLines
+            Replay the last N matching data lines from the current log file before
+            entering follow mode (tail -n N -f semantics). 0 means pure follow mode:
+            only entries written after the cmdlet starts are emitted.
+
+        .PARAMETER FollowRollover
+            Detect the daily log rotation (IIS rolls u_exYYMMDD.log) and reopen the
+            new file once it appears. Without this switch the cmdlet exits cleanly
+            when the current file is rotated away.
+
+        .PARAMETER PollIntervalMs
+            Sleep interval in milliseconds between read attempts when at end of stream.
+            Defaults to 1000 ms (matching IIS default flush cadence).
+
+        .PARAMETER Duration
+            Maximum wall-clock duration of the tail. Whichever cap hits first
+            (-Duration or -MaxEntries) ends the stream.
+
+        .PARAMETER MaxEntries
+            Hard cap on the number of emitted entries (after filtering). Pairs with
+            -Duration to bound remote runs safely.
+
+        .PARAMETER Method
+            Filter on cs-method (e.g. GET, POST). Case-insensitive, multi-valued OR.
+
+        .PARAMETER Status
+            Filter on sc-status (e.g. 500, 502). Multi-valued OR.
+
+        .PARAMETER UriLike
+            Wildcard pattern matched against UriStem via -like.
+
+        .PARAMETER ClientIP
+            Filter on c-ip. Exact match, case-insensitive, multi-valued OR.
+
+        .PARAMETER MinStatus
+            Emit only entries with sc-status >= N (e.g. 400 to surface all errors).
+
+        .EXAMPLE
+            Watch-IISLog -SiteName 'Default Web Site'
+
+            Tails the Default Web Site log in real time, emitting parsed entries.
+
+        .EXAMPLE
+            Watch-IISLog -SiteName 'Default Web Site' -InitialLines 50 -MinStatus 400
+
+            Replays the last 50 error-or-worse entries then follows for new ones.
+
+        .EXAMPLE
+            Watch-IISLog -SiteName 'www.contoso.com' -FollowRollover -Duration (New-TimeSpan -Hours 1)
+
+            Follows the site log including daily rollover for one hour.
+
+        .EXAMPLE
+            'WEB01' | Watch-IISLog -SiteName 'api' -Credential (Get-Credential) -MaxEntries 1000
+
+            Remote tail with credentials, capped at 1000 entries.
+
+        .EXAMPLE
+            Watch-IISLog -SiteName 'api' -Method POST -UriLike '/api/*' | Where-Object TimeTaken -gt 2000
+
+            Streams slow POST requests to the /api/* path in real time.
+
+        .OUTPUTS
+            PSCustomObject (PSTypeName='PSWinOps.IISLogEntry')
+            One object per parsed data line. Properties absent from the active
+            #Fields directive are emitted as $null.
+
+        .NOTES
+            Author: Franck SALLET
+            Version: 1.0.0
+            Last Modified: 2026-05-15
+            Requires: PowerShell 5.1+ / Windows only
+            Requires: Web-Server (IIS) role
+            Requires: WebAdministration module, Microsoft.Web.Administration, or appcmd.exe
+
+            IIS writes log files in UTC by default. Timestamps are always returned
+            as UTC DateTime objects regardless of the local system timezone.
+
+            The parser handles mid-file #Fields re-declarations that IIS emits after
+            a log rotation or w3wp.exe recycle within a single file.
+
+            For remote sessions, always supply -Duration or -MaxEntries to bound
+            execution; otherwise Ctrl-C is the only way to stop the remote stream.
+
+        .LINK
+            https://learn.microsoft.com/en-us/iis/manage/provisioning-and-managing-iis/configure-logging-in-iis
+    #>
+    [CmdletBinding()]
+    [OutputType('PSWinOps.IISLogEntry')]
+    param(
+        [Parameter(Mandatory = $false, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [ValidateNotNullOrEmpty()]
+        [Alias('CN', 'Name', 'DNSHostName')]
+        [string[]]$ComputerName = $env:COMPUTERNAME,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateNotNull()]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential,
+
+        [Parameter(Mandatory = $true, Position = 0, ValueFromPipelineByPropertyName = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$SiteName,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateSet('W3C')]
+        [string]$LogFormat = 'W3C',
+
+        [Parameter(Mandatory = $false)]
+        [ValidateRange(0, 1000000)]
+        [int]$InitialLines = 0,
+
+        [Parameter(Mandatory = $false)]
+        [switch]$FollowRollover,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateRange(100, 60000)]
+        [int]$PollIntervalMs = 1000,
+
+        [Parameter(Mandatory = $false)]
+        [timespan]$Duration,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateRange(1, 2147483647)]
+        [int]$MaxEntries,
+
+        [Parameter(Mandatory = $false)]
+        [string[]]$Method,
+
+        [Parameter(Mandatory = $false)]
+        [int[]]$Status,
+
+        [Parameter(Mandatory = $false)]
+        [string]$UriLike,
+
+        [Parameter(Mandatory = $false)]
+        [string[]]$ClientIP,
+
+        [Parameter(Mandatory = $false)]
+        [int]$MinStatus
+    )
+
+    begin {
+        Write-Verbose -Message "[$($MyInvocation.MyCommand)] Starting"
+
+        # Capture bound-parameter flags in begin{} so process{} can reference them
+        # without re-calling ContainsKey on every loop iteration.
+        $hasDuration   = $PSBoundParameters.ContainsKey('Duration')
+        $hasMaxEntries = $PSBoundParameters.ContainsKey('MaxEntries')
+        $hasMethod     = $PSBoundParameters.ContainsKey('Method')
+        $hasStatus     = $PSBoundParameters.ContainsKey('Status')
+        $hasUriLike    = $PSBoundParameters.ContainsKey('UriLike')
+        $hasClientIP   = $PSBoundParameters.ContainsKey('ClientIP')
+        $hasMinStatus  = $PSBoundParameters.ContainsKey('MinStatus')
+
+        # =====================================================================
+        # Remote scriptblock -- MUST be self-contained (no PSWinOps helpers).
+        # Dispatched via Invoke-RemoteOrLocal with an ArgumentList bundle.
+        # =====================================================================
+        $scriptBlock = {
+            param(
+                [string]   $ArgSiteName,
+                [int]      $ArgInitialLines,
+                [bool]     $ArgFollowRollover,
+                [int]      $ArgPollIntervalMs,
+                [object]   $ArgDuration,        # [timespan] or $null
+                [object]   $ArgMaxEntries,      # [int] or $null
+                [string[]] $ArgFilterMethod,
+                [int[]]    $ArgFilterStatus,
+                [object]   $ArgFilterUriLike,   # [string] or $null
+                [string[]] $ArgFilterClientIP,
+                [object]   $ArgFilterMinStatus  # [int] or $null
+            )
+
+            # -----------------------------------------------------------------
+            # W3C field name -> output property name (mirrors Get-IISParsedLog)
+            # -----------------------------------------------------------------
+            $fieldMap = @{
+                's-sitename'      = 'SiteName'
+                's-computername'  = 'ServerName'
+                's-ip'            = 'ServerIP'
+                'cs-method'       = 'Method'
+                'cs-uri-stem'     = 'UriStem'
+                'cs-uri-query'    = 'UriQuery'
+                's-port'          = 'ServerPort'
+                'cs-username'     = 'UserName'
+                'c-ip'            = 'ClientIP'
+                'cs(User-Agent)'  = 'UserAgent'
+                'cs(Referer)'     = 'Referer'
+                'sc-status'       = 'HttpStatus'
+                'sc-substatus'    = 'HttpSubStatus'
+                'sc-win32-status' = 'Win32Status'
+                'sc-bytes'        = 'BytesSent'
+                'cs-bytes'        = 'BytesReceived'
+                'time-taken'      = 'TimeTaken'
+            }
+
+            $intProps = [System.Collections.Generic.HashSet[string]]::new(
+                [string[]]@('ServerPort', 'HttpStatus', 'HttpSubStatus', 'TimeTaken'),
+                [System.StringComparer]::Ordinal
+            )
+            $longProps = [System.Collections.Generic.HashSet[string]]::new(
+                [string[]]@('Win32Status', 'BytesSent', 'BytesReceived'),
+                [System.StringComparer]::Ordinal
+            )
+
+            # -----------------------------------------------------------------
+            # Helper: parse one W3C data line -> PSWinOps.IISLogEntry
+            # -----------------------------------------------------------------
+            function ConvertFrom-IISW3CLine {
+                param(
+                    [string]   $RawLine,
+                    [string[]] $ActiveColumns,
+                    [hashtable]$FieldPropertyMap,
+                    [System.Collections.Generic.HashSet[string]]$IntPropNames,
+                    [System.Collections.Generic.HashSet[string]]$LongPropNames,
+                    [string]   $FilePath,
+                    [int]      $LineNum
+                )
+                $tokens = $RawLine -split '\s+'
+                $props  = [ordered]@{
+                    PSTypeName    = 'PSWinOps.IISLogEntry'
+                    Timestamp     = $null
+                    LogFile       = $FilePath
+                    LineNumber    = $LineNum
+                    ComputerName  = $env:COMPUTERNAME
+                    SiteName      = $null
+                    ServerName    = $null
+                    ServerIP      = $null
+                    ServerPort    = $null
+                    Method        = $null
+                    UriStem       = $null
+                    UriQuery      = $null
+                    UserName      = $null
+                    ClientIP      = $null
+                    UserAgent     = $null
+                    Referer       = $null
+                    HttpStatus    = $null
+                    HttpSubStatus = $null
+                    Win32Status   = $null
+                    BytesSent     = $null
+                    BytesReceived = $null
+                    TimeTaken     = $null
+                }
+                $rawDate = $null
+                $rawTime = $null
+
+                for ($i = 0; $i -lt $ActiveColumns.Count; $i++) {
+                    $col = $ActiveColumns[$i]
+                    $raw = if ($i -lt $tokens.Count) { $tokens[$i] } else { '-' }
+
+                    if ($col -eq 'date') { $rawDate = $raw; continue }
+                    if ($col -eq 'time') { $rawTime = $raw; continue }
+                    if (-not $FieldPropertyMap.ContainsKey($col)) { continue }
+
+                    $propName = $FieldPropertyMap[$col]
+                    if ($raw -eq '-') { $props[$propName] = $null; continue }
+
+                    if ($IntPropNames.Contains($propName)) {
+                        $intVal = 0
+                        $props[$propName] = if ([int]::TryParse($raw, [ref]$intVal)) { $intVal } else { $null }
+                    }
+                    elseif ($LongPropNames.Contains($propName)) {
+                        $longVal = [long]0
+                        $props[$propName] = if ([long]::TryParse($raw, [ref]$longVal)) { $longVal } else { $null }
+                    }
+                    elseif ($propName -eq 'UserAgent' -or $propName -eq 'Referer') {
+                        $props[$propName] = $raw -replace '\+', ' '
+                    }
+                    else {
+                        $props[$propName] = $raw
+                    }
+                }
+
+                if ($null -ne $rawDate -and $null -ne $rawTime -and
+                    $rawDate -ne '-'    -and $rawTime -ne '-') {
+                    try {
+                        $props['Timestamp'] = [datetime]::ParseExact(
+                            "$rawDate $rawTime",
+                            'yyyy-MM-dd HH:mm:ss',
+                            [System.Globalization.CultureInfo]::InvariantCulture,
+                            ([System.Globalization.DateTimeStyles]::AssumeUniversal -bor
+                             [System.Globalization.DateTimeStyles]::AdjustToUniversal)
+                        )
+                    }
+                    catch {
+                        Write-Verbose -Message "Watch-IISLog: could not parse timestamp '$rawDate $rawTime' -- Timestamp set to null."
+                    }
+                }
+
+                return [PSCustomObject]$props
+            }
+
+            # -----------------------------------------------------------------
+            # Helper: locate the lexicographically latest u_ex*.log in a folder
+            # -----------------------------------------------------------------
+            function Find-LatestIISLogFile {
+                param([string]$Directory)
+                if (-not (Test-Path -LiteralPath $Directory -PathType Container)) { return $null }
+                $found = Get-ChildItem -LiteralPath $Directory -Filter 'u_ex*.log' -File `
+                    -ErrorAction SilentlyContinue |
+                    Sort-Object -Property Name -Descending |
+                    Select-Object -First 1
+                return if ($found) { $found.FullName } else { $null }
+            }
+
+            # -----------------------------------------------------------------
+            # Helper: test whether an entry passes the streaming filters.
+            # Filter parameters are passed explicitly so that PSScriptAnalyzer
+            # can resolve usage of the outer scriptblock Arg* variables.
+            # -----------------------------------------------------------------
+            function Test-IISLogEntryFilter {
+                param(
+                    [PSObject] $Entry,
+                    [string[]] $FilterMethod,
+                    [int[]]    $FilterStatus,
+                    [object]   $FilterUriLike,   # [string] or $null
+                    [string[]] $FilterClientIP,
+                    [object]   $FilterMinStatus  # [int] or $null
+                )
+                if ($FilterMethod -and $FilterMethod.Count -gt 0 -and
+                    $null -ne $Entry.Method -and
+                    ($FilterMethod -inotcontains $Entry.Method)) { return $false }
+
+                if ($FilterStatus -and $FilterStatus.Count -gt 0 -and
+                    $null -ne $Entry.HttpStatus -and
+                    ($FilterStatus -notcontains $Entry.HttpStatus)) { return $false }
+
+                if ($null -ne $FilterUriLike -and
+                    $null -ne $Entry.UriStem -and
+                    $Entry.UriStem -notlike $FilterUriLike) { return $false }
+
+                if ($FilterClientIP -and $FilterClientIP.Count -gt 0 -and
+                    $null -ne $Entry.ClientIP -and
+                    ($FilterClientIP -inotcontains $Entry.ClientIP)) { return $false }
+
+                if ($null -ne $FilterMinStatus -and
+                    $null -ne $Entry.HttpStatus -and
+                    $Entry.HttpStatus -lt $FilterMinStatus) { return $false }
+
+                return $true
+            }
+
+            # -----------------------------------------------------------------
+            # Resolve the IIS log directory for $ArgSiteName
+            # Priority: WebAdministration -> Microsoft.Web.Administration -> appcmd.exe
+            # -----------------------------------------------------------------
+            $logDir    = $null
+            $resolveOk = $false
+
+            # Method 1: WebAdministration PS provider
+            if (-not $resolveOk) {
+                try {
+                    if (Get-Module -Name WebAdministration -ListAvailable -ErrorAction SilentlyContinue) {
+                        Import-Module -Name WebAdministration -ErrorAction Stop
+                        $iisItem = Get-Item -Path "IIS:\Sites\$ArgSiteName" -ErrorAction Stop
+                        $logFmt  = $iisItem.logFile.logFormat
+                        if ($logFmt -ne 'W3C') {
+                            Write-Error -Message (
+                                "Watch-IISLog: site '$ArgSiteName' uses log format '$logFmt', not W3C. " +
+                                'Enable W3C logging in IIS Manager.') -ErrorAction Continue
+                            return
+                        }
+                        $rawDir    = [System.Environment]::ExpandEnvironmentVariables($iisItem.logFile.directory)
+                        $siteId    = $iisItem.id
+                        $logDir    = Join-Path -Path $rawDir -ChildPath "W3SVC$siteId"
+                        $resolveOk = $true
+                    }
+                }
+                catch [System.Management.Automation.ItemNotFoundException] {
+                    Write-Error -Message "Watch-IISLog: site '$ArgSiteName' not found in IIS configuration." -ErrorAction Continue
+                    return
+                }
+                catch {
+                    Write-Verbose -Message "Watch-IISLog: WebAdministration provider unavailable -- $($_.Exception.Message)"
+                }
+            }
+
+            # Method 2: Microsoft.Web.Administration assembly
+            if (-not $resolveOk) {
+                try {
+                    $mwaPath = Join-Path -Path $env:SystemRoot -ChildPath 'system32\inetsrv\Microsoft.Web.Administration.dll'
+                    if (Test-Path -LiteralPath $mwaPath -PathType Leaf) {
+                        if (-not ('Microsoft.Web.Administration.ServerManager' -as [type])) {
+                            Add-Type -LiteralPath $mwaPath -ErrorAction Stop
+                        }
+                        $serverMgr = [Microsoft.Web.Administration.ServerManager]::new()
+                        $mwaSite   = $serverMgr.Sites |
+                            Where-Object { $_.Name -eq $ArgSiteName } |
+                            Select-Object -First 1
+
+                        if ($null -eq $mwaSite) {
+                            $serverMgr.Dispose()
+                            Write-Error -Message "Watch-IISLog: site '$ArgSiteName' not found in IIS configuration." -ErrorAction Continue
+                            return
+                        }
+                        $logFmt = $mwaSite.LogFile.LogFormat.ToString()
+                        if ($logFmt -ne 'W3C') {
+                            $serverMgr.Dispose()
+                            Write-Error -Message (
+                                "Watch-IISLog: site '$ArgSiteName' uses log format '$logFmt', not W3C. " +
+                                'Enable W3C logging in IIS Manager.') -ErrorAction Continue
+                            return
+                        }
+                        $rawDir    = [System.Environment]::ExpandEnvironmentVariables($mwaSite.LogFile.Directory)
+                        $siteId    = $mwaSite.Id
+                        $serverMgr.Dispose()
+                        $logDir    = Join-Path -Path $rawDir -ChildPath "W3SVC$siteId"
+                        $resolveOk = $true
+                    }
+                }
+                catch {
+                    Write-Verbose -Message "Watch-IISLog: Microsoft.Web.Administration assembly unavailable -- $($_.Exception.Message)"
+                }
+            }
+
+            # Method 3: appcmd.exe
+            if (-not $resolveOk) {
+                $appcmdPath = Join-Path -Path $env:SystemRoot -ChildPath 'system32\inetsrv\appcmd.exe'
+                if (-not (Test-Path -LiteralPath $appcmdPath -PathType Leaf)) {
+                    Write-Error -Message (
+                        "Watch-IISLog: IIS management tools not found on '$env:COMPUTERNAME'. " +
+                        "Install the 'IIS Management Scripts and Tools' Windows feature " +
+                        'or the WebAdministration module.') -ErrorAction Continue
+                    return
+                }
+                try {
+                    $appcmdRaw = & $appcmdPath list site $ArgSiteName /config:* /xml 2>$null
+                    if ([string]::IsNullOrWhiteSpace($appcmdRaw)) {
+                        Write-Error -Message "Watch-IISLog: site '$ArgSiteName' not found via appcmd.exe." -ErrorAction Continue
+                        return
+                    }
+                    [xml]$appcmdXml = $appcmdRaw
+                    $siteNode = $appcmdXml.appcmd.SITE
+                    if ($null -eq $siteNode) {
+                        Write-Error -Message "Watch-IISLog: site '$ArgSiteName' not found via appcmd.exe." -ErrorAction Continue
+                        return
+                    }
+                    $logFileNode = $siteNode.site.logFile
+                    $logFmt = $logFileNode.logFormat
+                    if ($logFmt -ne 'W3C') {
+                        Write-Error -Message (
+                            "Watch-IISLog: site '$ArgSiteName' uses log format '$logFmt', not W3C.") -ErrorAction Continue
+                        return
+                    }
+                    $rawDir    = [System.Environment]::ExpandEnvironmentVariables($logFileNode.directory)
+                    $siteId    = $siteNode.id
+                    $logDir    = Join-Path -Path $rawDir -ChildPath "W3SVC$siteId"
+                    $resolveOk = $true
+                }
+                catch {
+                    Write-Error -Message (
+                        "Watch-IISLog: unable to resolve log directory for site '$ArgSiteName': " +
+                        $_.Exception.Message) -ErrorAction Continue
+                    return
+                }
+            }
+
+            if (-not $resolveOk -or [string]::IsNullOrEmpty($logDir)) {
+                Write-Error -Message (
+                    "Watch-IISLog: unable to resolve IIS log directory for site '$ArgSiteName'. " +
+                    "Install the 'IIS Management Scripts and Tools' feature or the WebAdministration module.") `
+                    -ErrorAction Continue
+                return
+            }
+
+            # -----------------------------------------------------------------
+            # Wait for the first log file to appear (site may have no traffic yet)
+            # -----------------------------------------------------------------
+            $startTime      = [datetime]::UtcNow
+            $currentLogFile = Find-LatestIISLogFile -Directory $logDir
+
+            while ($null -eq $currentLogFile) {
+                if ($null -ne $ArgDuration -and (([datetime]::UtcNow - $startTime) -ge $ArgDuration)) {
+                    Write-Verbose -Message "Watch-IISLog: duration elapsed before any log file appeared in '$logDir'."
+                    return
+                }
+                Start-Sleep -Milliseconds $ArgPollIntervalMs
+                $currentLogFile = Find-LatestIISLogFile -Directory $logDir
+            }
+
+            # -----------------------------------------------------------------
+            # Open the active log file with FileShare.ReadWrite|Delete so that
+            # IIS (which holds an exclusive write lock) can continue appending.
+            # -----------------------------------------------------------------
+            $emittedCount  = 0
+            $activeColumns = [string[]]@()
+            $dataLineCount = 0
+            $fileStream    = $null
+            $streamReader  = $null
+
+            try {
+                $fileStream = [System.IO.FileStream]::new(
+                    $currentLogFile,
+                    [System.IO.FileMode]::Open,
+                    [System.IO.FileAccess]::Read,
+                    ([System.IO.FileShare]::ReadWrite -bor [System.IO.FileShare]::Delete)
+                )
+                $streamReader = [System.IO.StreamReader]::new(
+                    $fileStream,
+                    [System.Text.Encoding]::UTF8,
+                    $true   # detectEncodingFromByteOrderMarks
+                )
+
+                # -------------------------------------------------------------
+                # Phase 1: scan existing content to EOF
+                #   - track every #Fields directive (header re-detection support)
+                #   - when InitialLines > 0: buffer the last N matching entries
+                # -------------------------------------------------------------
+                $tailQueue = $null
+                if ($ArgInitialLines -gt 0) {
+                    $tailQueue = [System.Collections.Generic.Queue[PSObject]]::new()
+                }
+
+                while ($null -ne ($scanLine = $streamReader.ReadLine())) {
+                    if ($scanLine.StartsWith('#Fields:')) {
+                        $activeColumns = ($scanLine.Substring(8).Trim()) -split '\s+'
+                        continue
+                    }
+                    if ($scanLine.StartsWith('#') -or [string]::IsNullOrWhiteSpace($scanLine)) { continue }
+
+                    $dataLineCount++
+
+                    if ($null -eq $tailQueue -or $activeColumns.Count -eq 0) { continue }
+
+                    try {
+                        $scannedEntry = ConvertFrom-IISW3CLine `
+                            -RawLine $scanLine -ActiveColumns $activeColumns `
+                            -FieldPropertyMap $fieldMap -IntPropNames $intProps `
+                            -LongPropNames $longProps `
+                            -FilePath $currentLogFile -LineNum $dataLineCount
+
+                        if (Test-IISLogEntryFilter -Entry $scannedEntry `
+                                -FilterMethod    $ArgFilterMethod `
+                                -FilterStatus    $ArgFilterStatus `
+                                -FilterUriLike   $ArgFilterUriLike `
+                                -FilterClientIP  $ArgFilterClientIP `
+                                -FilterMinStatus $ArgFilterMinStatus) {
+                            $tailQueue.Enqueue($scannedEntry)
+                            if ($tailQueue.Count -gt $ArgInitialLines) { [void]$tailQueue.Dequeue() }
+                        }
+                    }
+                    catch {
+                        Write-Warning -Message "Watch-IISLog: failed to parse line $dataLineCount in '$currentLogFile': $_"
+                    }
+                }
+
+                # Emit the tail buffer before entering follow mode
+                if ($null -ne $tailQueue) {
+                    foreach ($initialEntry in $tailQueue) {
+                        $initialEntry
+                        $emittedCount++
+                        if ($null -ne $ArgMaxEntries -and $emittedCount -ge $ArgMaxEntries) { return }
+                    }
+                    $tailQueue = $null
+                }
+
+                # -------------------------------------------------------------
+                # Phase 2: follow loop -- positioned at EOF after Phase 1
+                # -------------------------------------------------------------
+                while ($true) {
+                    if ($null -ne $ArgDuration -and (([datetime]::UtcNow - $startTime) -ge $ArgDuration)) { break }
+                    if ($null -ne $ArgMaxEntries -and $emittedCount -ge $ArgMaxEntries) { break }
+
+                    $followLine = $streamReader.ReadLine()
+
+                    if ($null -eq $followLine) {
+                        # EOF -- check for log rollover when requested
+                        if ($ArgFollowRollover) {
+                            $newerFile = Find-LatestIISLogFile -Directory $logDir
+                            if ($null -ne $newerFile -and $newerFile -ne $currentLogFile) {
+                                $streamReader.Dispose()
+                                $fileStream.Dispose()
+                                $fileStream   = $null
+                                $streamReader = $null
+
+                                $currentLogFile = $newerFile
+                                $dataLineCount  = 0
+                                $activeColumns  = [string[]]@()
+
+                                $fileStream = [System.IO.FileStream]::new(
+                                    $currentLogFile,
+                                    [System.IO.FileMode]::Open,
+                                    [System.IO.FileAccess]::Read,
+                                    ([System.IO.FileShare]::ReadWrite -bor [System.IO.FileShare]::Delete)
+                                )
+                                $streamReader = [System.IO.StreamReader]::new(
+                                    $fileStream,
+                                    [System.Text.Encoding]::UTF8,
+                                    $true
+                                )
+                                continue
+                            }
+                        }
+                        Start-Sleep -Milliseconds $ArgPollIntervalMs
+                        continue
+                    }
+
+                    # Handle directive lines -- mid-stream #Fields re-detection
+                    if ($followLine.StartsWith('#Fields:')) {
+                        $activeColumns = ($followLine.Substring(8).Trim()) -split '\s+'
+                        continue
+                    }
+                    if ($followLine.StartsWith('#') -or [string]::IsNullOrWhiteSpace($followLine)) { continue }
+
+                    $dataLineCount++
+
+                    if ($activeColumns.Count -eq 0) {
+                        Write-Warning -Message (
+                            "Watch-IISLog: data line $dataLineCount before any #Fields directive " +
+                            "in '$currentLogFile' -- skipped.")
+                        continue
+                    }
+
+                    try {
+                        $liveEntry = ConvertFrom-IISW3CLine `
+                            -RawLine $followLine -ActiveColumns $activeColumns `
+                            -FieldPropertyMap $fieldMap -IntPropNames $intProps `
+                            -LongPropNames $longProps `
+                            -FilePath $currentLogFile -LineNum $dataLineCount
+
+                        if (Test-IISLogEntryFilter -Entry $liveEntry `
+                                -FilterMethod    $ArgFilterMethod `
+                                -FilterStatus    $ArgFilterStatus `
+                                -FilterUriLike   $ArgFilterUriLike `
+                                -FilterClientIP  $ArgFilterClientIP `
+                                -FilterMinStatus $ArgFilterMinStatus) {
+                            $liveEntry
+                            $emittedCount++
+                        }
+                    }
+                    catch {
+                        Write-Warning -Message "Watch-IISLog: failed to parse line $dataLineCount in '$currentLogFile': $_"
+                    }
+                }
+            }
+            finally {
+                if ($null -ne $streamReader) {
+                    try   { $streamReader.Dispose() }
+                    catch { Write-Verbose -Message "Watch-IISLog: error disposing streamReader -- $($_.Exception.Message)" }
+                }
+                if ($null -ne $fileStream) {
+                    try   { $fileStream.Dispose() }
+                    catch { Write-Verbose -Message "Watch-IISLog: error disposing fileStream -- $($_.Exception.Message)" }
+                }
+            }
+        }
+    }
+
+    process {
+        foreach ($cn in $ComputerName) {
+            Write-Verbose -Message "[$($MyInvocation.MyCommand)] Tailing IIS log for site '$SiteName' on '$cn'"
+
+            try {
+                $invokeParams = @{
+                    ComputerName = $cn
+                    ScriptBlock  = $scriptBlock
+                    ArgumentList = @(
+                        $SiteName,
+                        $InitialLines,
+                        $FollowRollover.IsPresent,
+                        $PollIntervalMs,
+                        $(if ($hasDuration)   { $Duration   } else { $null }),
+                        $(if ($hasMaxEntries) { $MaxEntries } else { $null }),
+                        $(if ($hasMethod)     { $Method     } else { [string[]]@() }),
+                        $(if ($hasStatus)     { $Status     } else { [int[]]@() }),
+                        $(if ($hasUriLike)    { $UriLike    } else { $null }),
+                        $(if ($hasClientIP)   { $ClientIP   } else { [string[]]@() }),
+                        $(if ($hasMinStatus)  { $MinStatus  } else { $null })
+                    )
+                }
+                if ($PSBoundParameters.ContainsKey('Credential')) {
+                    $invokeParams['Credential'] = $Credential
+                }
+                Invoke-RemoteOrLocal @invokeParams
+            }
+            catch {
+                Write-Error -Message "[$($MyInvocation.MyCommand)] Failed to tail IIS log on '$cn': $($_.Exception.Message)"
+            }
+        }
+    }
+
+    end {
+        Write-Verbose -Message "[$($MyInvocation.MyCommand)] Completed"
+    }
+}

--- a/Tests/Public/iis/Watch-IISLog.Tests.ps1
+++ b/Tests/Public/iis/Watch-IISLog.Tests.ps1
@@ -1,0 +1,412 @@
+﻿#Requires -Version 5.1
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSUseDeclaredVarsMoreThanAssignments', '',
+    Justification = 'Script-scoped variables are assigned in mocks and assertions across separate scopes'
+)]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSAvoidUsingConvertToSecureStringWithPlainText', '',
+    Justification = 'Test fixture only -- not a real credential'
+)]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSAvoidUsingComputerNameHardcoded', '',
+    Justification = 'Fake target names used exclusively in test fixtures -- no real machines are contacted'
+)]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSReviewUnusedParameter', '',
+    Justification = 'Stub parameters are declared to satisfy the Pester mock engine (PR #42) but have no body'
+)]
+param()
+
+BeforeAll {
+    $script:modulePath = Split-Path -Path (Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent) -Parent
+
+    if ($IsWindows -or $PSEdition -eq 'Desktop') {
+        # Windows: import the real module so private functions are mock-able by scope name.
+        Import-Module -Name (Join-Path -Path $script:modulePath -ChildPath 'PSWinOps.psd1') -Force
+    } else {
+        # Linux/macOS: PSWinOps.psm1 has a Windows-only guard.
+        # Build an in-memory 'PSWinOps' module containing Invoke-RemoteOrLocal and
+        # Watch-IISLog so that Pester's -ModuleName 'PSWinOps' mock scope works on Linux.
+        $stripRequires = { param([string]$src) $src -replace '(?m)^#Requires[^\r\n]*[\r\n]*', '' }
+        $invokeRolSrc  = & $stripRequires (Get-Content -Raw -Path ([IO.Path]::Combine($script:modulePath, 'Private', 'Invoke-RemoteOrLocal.ps1')))
+        $watchSrc      = & $stripRequires (Get-Content -Raw -Path ([IO.Path]::Combine($script:modulePath, 'Public', 'iis', 'Watch-IISLog.ps1')))
+        $moduleBody    = "`$script:LocalComputerNames = @(`$env:COMPUTERNAME, 'localhost', '.')`n" +
+                         $invokeRolSrc + "`n" + $watchSrc + "`nExport-ModuleMember -Function '*'"
+        New-Module -Name 'PSWinOps' -ScriptBlock ([scriptblock]::Create($moduleBody)) |
+            Import-Module -Force
+    }
+
+    $script:ModuleName = 'PSWinOps'
+
+    # ---------------------------------------------------------------------------
+    # Mock factory: builds a PSWinOps.IISLogEntry custom object that mirrors the
+    # shape emitted by the Watch-IISLog self-contained remote scriptblock.
+    # All defaults reproduce a single GET 200 request for 'Default Web Site'.
+    # ---------------------------------------------------------------------------
+    function script:New-MockIISLogEntry {
+        param(
+            [string] $ComputerName  = 'WEB01',
+            [string] $LogFile       = 'C:\inetpub\logs\LogFiles\W3SVC1\u_ex260514.log',
+            [int]    $LineNumber    = 1,
+            [string] $Method        = 'GET',
+            [string] $UriStem       = '/index.html',
+            [object] $UriQuery      = $null,
+            [object] $UserName      = $null,
+            [string] $ClientIP      = '10.0.0.42',
+            [object] $UserAgent     = 'Mozilla/5.0 (Windows NT 10.0)',
+            [object] $Referer       = $null,
+            [int]    $HttpStatus    = 200,
+            [int]    $HttpSubStatus = 0,
+            [long]   $Win32Status   = [long]0,
+            [long]   $BytesSent     = [long]1234,
+            [long]   $BytesReceived = [long]512,
+            [int]    $TimeTaken     = 50
+        )
+        return [PSCustomObject]@{
+            PSTypeName    = 'PSWinOps.IISLogEntry'
+            Timestamp     = [datetime]::new(2026, 5, 14, 10, 0, 0, [System.DateTimeKind]::Utc)
+            LogFile       = $LogFile
+            LineNumber    = $LineNumber
+            ComputerName  = $ComputerName
+            SiteName      = 'W3SVC1'
+            ServerName    = 'WEB01'
+            ServerIP      = '192.168.1.10'
+            ServerPort    = 80
+            Method        = $Method
+            UriStem       = $UriStem
+            UriQuery      = $UriQuery
+            UserName      = $UserName
+            ClientIP      = $ClientIP
+            UserAgent     = $UserAgent
+            Referer       = $Referer
+            HttpStatus    = $HttpStatus
+            HttpSubStatus = $HttpSubStatus
+            Win32Status   = $Win32Status
+            BytesSent     = $BytesSent
+            BytesReceived = $BytesReceived
+            TimeTaken     = $TimeTaken
+        }
+    }
+
+    # ---------------------------------------------------------------------------
+    # Shared mock payloads used across multiple contexts.
+    # ---------------------------------------------------------------------------
+    $script:mockSingleEntry = @(script:New-MockIISLogEntry)
+
+    $script:mockMultiEntry = @(
+        script:New-MockIISLogEntry -LineNumber 1 -UriStem '/a' -HttpStatus 200
+        script:New-MockIISLogEntry -LineNumber 2 -UriStem '/b' -HttpStatus 404
+        script:New-MockIISLogEntry -LineNumber 3 -UriStem '/c' -HttpStatus 500
+    )
+
+    $script:mockDashFields = @(
+        script:New-MockIISLogEntry -UriQuery $null -UserName $null -Referer $null -UserAgent $null
+    )
+
+    $script:mockUserAgentDecoded = @(
+        script:New-MockIISLogEntry -UserAgent 'Mozilla/5.0 (Windows NT 10.0)'
+    )
+}
+
+Describe 'Watch-IISLog' {
+
+    # == Context 1 ==============================================================
+    # Happy path: single PSWinOps.IISLogEntry returned via Invoke-RemoteOrLocal.
+    # ===========================================================================
+    Context 'Happy path: PSWinOps.IISLogEntry returned via Invoke-RemoteOrLocal' {
+
+        It 'Should return a PSWinOps.IISLogEntry with correct PSTypeName for a single target' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith { return $script:mockSingleEntry }
+            $result = Watch-IISLog -SiteName 'Default Web Site' -ComputerName 'WEB01' -MaxEntries 1
+            $result.PSObject.TypeNames[0] | Should -Be 'PSWinOps.IISLogEntry'
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should stream all IISLogEntry objects when mock returns a multi-entry collection' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith { return $script:mockMultiEntry }
+            $results = Watch-IISLog -SiteName 'Default Web Site' -ComputerName 'WEB01'
+            @($results).Count | Should -Be 3
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should pass SiteName as ArgumentList[0] to Invoke-RemoteOrLocal' {
+            $script:capturedSiteName = $null
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith {
+                $script:capturedSiteName = $ArgumentList[0]
+                return @()
+            }
+            Watch-IISLog -SiteName 'api.contoso.com' -ComputerName 'WEB01'
+            $script:capturedSiteName | Should -Be 'api.contoso.com'
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+    }
+
+    # == Context 2 ==============================================================
+    # All output properties: Method, UriStem, HttpStatus, BytesSent, etc.
+    # ===========================================================================
+    Context 'All output properties populated correctly from emitted IISLogEntry' {
+
+        It 'Should populate Method, UriStem and HttpStatus from emitted entry' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith { return $script:mockSingleEntry }
+            $result = Watch-IISLog -SiteName 'Default Web Site' -ComputerName 'WEB01' -MaxEntries 1
+            $result.Method     | Should -Be 'GET'
+            $result.UriStem    | Should -Be '/index.html'
+            $result.HttpStatus | Should -Be 200
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should populate BytesSent, BytesReceived and TimeTaken with correct values' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith { return $script:mockSingleEntry }
+            $result = Watch-IISLog -SiteName 'Default Web Site' -ComputerName 'WEB01' -MaxEntries 1
+            $result.BytesSent     | Should -Be 1234
+            $result.BytesReceived | Should -Be 512
+            $result.TimeTaken     | Should -Be 50
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should populate Win32Status as a long integer and LogFile as the resolved path' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith { return $script:mockSingleEntry }
+            $result = Watch-IISLog -SiteName 'Default Web Site' -ComputerName 'WEB01' -MaxEntries 1
+            $result.Win32Status | Should -Be 0
+            $result.Win32Status | Should -BeOfType [long]
+            $result.LogFile     | Should -Be 'C:\inetpub\logs\LogFiles\W3SVC1\u_ex260514.log'
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should populate 1-based LineNumber per entry in order across a multi-entry stream' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith { return $script:mockMultiEntry }
+            $results = Watch-IISLog -SiteName 'Default Web Site' -ComputerName 'WEB01'
+            $results[0].LineNumber | Should -Be 1
+            $results[1].LineNumber | Should -Be 2
+            $results[2].LineNumber | Should -Be 3
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+    }
+
+    # == Context 3 ==============================================================
+    # Timestamp: UTC DateTime matching yyyy-MM-dd HH:mm:ss format.
+    # ===========================================================================
+    Context 'Timestamp property: UTC DateTime in yyyy-MM-dd HH:mm:ss format' {
+
+        It 'Should emit Timestamp as a UTC DateTime object (Kind = Utc)' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith { return $script:mockSingleEntry }
+            $result = Watch-IISLog -SiteName 'Default Web Site' -ComputerName 'WEB01' -MaxEntries 1
+            $result.Timestamp      | Should -BeOfType [datetime]
+            $result.Timestamp.Kind | Should -Be ([System.DateTimeKind]::Utc)
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should format Timestamp string matching the "\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}" pattern' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith { return $script:mockSingleEntry }
+            $result = Watch-IISLog -SiteName 'Default Web Site' -ComputerName 'WEB01' -MaxEntries 1
+            $result.Timestamp.ToString('yyyy-MM-dd HH:mm:ss') | Should -Match "\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}"
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should set Timestamp to 2026-05-14 10:00:00 UTC as built from date+time fields' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith { return $script:mockSingleEntry }
+            $result = Watch-IISLog -SiteName 'Default Web Site' -ComputerName 'WEB01' -MaxEntries 1
+            $result.Timestamp.ToString('yyyy-MM-dd HH:mm:ss') | Should -Be '2026-05-14 10:00:00'
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+    }
+
+    # == Context 4 ==============================================================
+    # Dash normalisation: IIS "-" placeholder emitted as $null on nullable fields.
+    # ===========================================================================
+    Context 'Dash normalisation: nullable fields emitted as $null when IIS placeholder is "-"' {
+
+        It 'Should emit $null for UriQuery when the IIS field value is "-"' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith { return $script:mockDashFields }
+            $result = Watch-IISLog -SiteName 'Default Web Site' -ComputerName 'WEB01' -MaxEntries 1
+            $result.UriQuery | Should -BeNullOrEmpty
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should emit $null for UserName when the IIS field value is "-"' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith { return $script:mockDashFields }
+            $result = Watch-IISLog -SiteName 'Default Web Site' -ComputerName 'WEB01' -MaxEntries 1
+            $result.UserName | Should -BeNullOrEmpty
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should emit $null for Referer when the IIS field value is "-"' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith { return $script:mockDashFields }
+            $result = Watch-IISLog -SiteName 'Default Web Site' -ComputerName 'WEB01' -MaxEntries 1
+            $result.Referer | Should -BeNullOrEmpty
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should emit $null for UserAgent when the IIS field value is "-"' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith { return $script:mockDashFields }
+            $result = Watch-IISLog -SiteName 'Default Web Site' -ComputerName 'WEB01' -MaxEntries 1
+            $result.UserAgent | Should -BeNullOrEmpty
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+    }
+
+    # == Context 5 ==============================================================
+    # UserAgent decoding: IIS "+" decoded back to spaces, UriStem left URL-encoded.
+    # ===========================================================================
+    Context 'UserAgent decoding: "+" decoded back to spaces, UriStem left as-logged' {
+
+        It 'Should emit spaces (not "+") in UserAgent -- parser decodes "+" back to space' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith { return $script:mockUserAgentDecoded }
+            $result = Watch-IISLog -SiteName 'Default Web Site' -ComputerName 'WEB01' -MaxEntries 1
+            $result.UserAgent | Should -Be 'Mozilla/5.0 (Windows NT 10.0)'
+            $result.UserAgent | Should -Not -Match '\+'
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should leave UriStem as-logged by IIS with no "+" decoding applied on path segments' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith { return $script:mockSingleEntry }
+            $result = Watch-IISLog -SiteName 'Default Web Site' -ComputerName 'WEB01' -MaxEntries 1
+            $result.UriStem | Should -Be '/index.html'
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+    }
+
+    # == Context 6 ==============================================================
+    # ShouldProcess: Watch-IISLog is read-only; -WhatIf is not a declared parameter.
+    # ===========================================================================
+    Context 'ShouldProcess: read-only -- -WhatIf not declared, zero mutations on any call' {
+
+        It 'Should throw when called with -WhatIf because SupportsShouldProcess is not declared' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith { return @() }
+            { Watch-IISLog -SiteName 'Default Web Site' -WhatIf -ErrorAction Stop } | Should -Throw
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 0 -Exactly
+        }
+    }
+
+    # == Context 7 ==============================================================
+    # Pipeline by property name: SiteName and ComputerName / DNSHostName / CN.
+    # ===========================================================================
+    Context 'Pipeline by property name (SiteName and ComputerName / DNSHostName / CN aliases)' {
+
+        It 'Should accept SiteName from pipeline by property name alongside ComputerName' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith { return $script:mockSingleEntry }
+            $pipeObj = [PSCustomObject]@{ SiteName = 'api.contoso.com'; ComputerName = 'WEB01' }
+            $result  = $pipeObj | Watch-IISLog
+            $result | Should -Not -BeNullOrEmpty
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should fan-out across two pipeline objects bound by ComputerName and invoke twice' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith { return $script:mockSingleEntry }
+            $pipeObjs = @(
+                [PSCustomObject]@{ ComputerName = 'WEB01' }
+                [PSCustomObject]@{ ComputerName = 'WEB02' }
+            )
+            $results = $pipeObjs | Watch-IISLog -SiteName 'Default Web Site'
+            @($results).Count | Should -Be 2
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 2 -Exactly
+        }
+
+        It 'Should bind pipeline object via DNSHostName alias and call Invoke-RemoteOrLocal once' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith { return $script:mockSingleEntry }
+            $pipeObj = [PSCustomObject]@{ DNSHostName = 'WEB03' }
+            $result  = $pipeObj | Watch-IISLog -SiteName 'Default Web Site'
+            $result | Should -Not -BeNullOrEmpty
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should bind pipeline object via CN alias and call Invoke-RemoteOrLocal once' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith { return $script:mockSingleEntry }
+            $pipeObj = [PSCustomObject]@{ CN = 'WEB04' }
+            $result  = $pipeObj | Watch-IISLog -SiteName 'Default Web Site'
+            $result | Should -Not -BeNullOrEmpty
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+    }
+
+    # == Context 8 ==============================================================
+    # Credential propagation: PSCredential forwarded to Invoke-RemoteOrLocal.
+    # ===========================================================================
+    Context 'Credential propagation: PSCredential forwarded to Invoke-RemoteOrLocal' {
+
+        It 'Should forward Credential to Invoke-RemoteOrLocal and still return emitted entries' {
+            $securePass          = ConvertTo-SecureString -String 'P@ssw0rd!' -AsPlainText -Force
+            $cred                = [System.Management.Automation.PSCredential]::new('DOMAIN\svcweb', $securePass)
+            $script:capturedCred = $null
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith {
+                $script:capturedCred = $Credential
+                return $script:mockSingleEntry
+            }
+            $result = Watch-IISLog -SiteName 'Default Web Site' -ComputerName 'WEB01' -Credential $cred
+            $result                       | Should -Not -BeNullOrEmpty
+            $script:capturedCred          | Should -Not -BeNullOrEmpty
+            $script:capturedCred.UserName | Should -Be 'DOMAIN\svcweb'
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+    }
+
+    # == Context 9 ==============================================================
+    # ComputerName fan-out: one Invoke-RemoteOrLocal call per target machine.
+    # ===========================================================================
+    Context 'ComputerName fan-out: one Invoke-RemoteOrLocal call per target machine' {
+
+        It 'Should call Invoke-RemoteOrLocal twice and return two entries for two ComputerNames' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith { return $script:mockSingleEntry }
+            $results = Watch-IISLog -SiteName 'Default Web Site' -ComputerName 'WEB01', 'WEB02'
+            @($results).Count | Should -Be 2
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 2 -Exactly
+        }
+
+        It 'Should call Invoke-RemoteOrLocal three times for three ComputerNames' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith { return $script:mockSingleEntry }
+            $null = Watch-IISLog -SiteName 'Default Web Site' -ComputerName 'WEB01', 'WEB02', 'WEB03'
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 3 -Exactly
+        }
+    }
+
+    # == Context 10 =============================================================
+    # Error isolation: failed machine must not suppress results from healthy machines.
+    # ===========================================================================
+    Context 'Error isolation: failed machine does not suppress results from healthy machines' {
+
+        It 'Should emit entries from healthy machine when first machine throws a WinRM error' {
+            $script:isolationCallCount = 0
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith {
+                $script:isolationCallCount++
+                if ($script:isolationCallCount -eq 1) { throw 'WinRM connection refused' }
+                return $script:mockSingleEntry
+            }
+            $results = Watch-IISLog -SiteName 'Default Web Site' -ComputerName 'FAIL01', 'WEB02' -ErrorAction SilentlyContinue
+            @($results).Count | Should -Be 1
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 2 -Exactly
+        }
+
+        It 'Should surface a non-terminating error record for the failed machine' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith {
+                throw 'Access is denied'
+            }
+            $capturedErrors = @()
+            $null = Watch-IISLog -SiteName 'Default Web Site' -ComputerName 'FAIL01' `
+                -ErrorAction SilentlyContinue -ErrorVariable capturedErrors
+            $capturedErrors.Count | Should -BeGreaterOrEqual 1
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+    }
+
+    # == Context 11 =============================================================
+    # BOM/CRLF sentinel: test file must be UTF-8 with BOM and CRLF line endings.
+    # ===========================================================================
+    Context 'BOM/CRLF sentinel: test file encoding compliance (UTF-8 BOM + CRLF)' {
+
+        It 'Should detect UTF-8 BOM bytes (EF BB BF) at the start of this test file' {
+            $filePath = Join-Path -Path $PSScriptRoot -ChildPath 'Watch-IISLog.Tests.ps1'
+            $bytes    = [System.IO.File]::ReadAllBytes($filePath)
+            $bytes[0] | Should -Be 0xEF
+            $bytes[1] | Should -Be 0xBB
+            $bytes[2] | Should -Be 0xBF
+        }
+
+        It 'Should detect CRLF line endings in this test file via Get-Content -Raw' {
+            $filePath = Join-Path -Path $PSScriptRoot -ChildPath 'Watch-IISLog.Tests.ps1'
+            $raw      = Get-Content -LiteralPath $filePath -Raw
+            $raw      | Should -Match "`r`n"
+        }
+    }
+}

--- a/en-US/about_PSWinOps.help.txt
+++ b/en-US/about_PSWinOps.help.txt
@@ -84,16 +84,17 @@ FUNCTION DOMAINS
       Get-ServiceHealth
       Get-WSUSHealth
 
-  iis (4 functions)
+  iis (5 functions)
     Functions for managing IIS sites, HTTPS bindings,
-    log file analysis, worker process monitoring, and
-    real-time in-flight request inspection across local
-    or remote servers.
+    log file analysis, real-time log streaming, worker
+    process monitoring, and in-flight request inspection
+    across local or remote servers.
 
       Get-IISCurrentRequest
       Get-IISParsedLog
       Get-IISWorkerProcess
       Set-IISBindingCertificate
+      Watch-IISLog
 
   network (24 functions)
     Functions for network diagnostics, discovery,


### PR DESCRIPTION
## Summary
Resolves the active W3C log file of a given IIS site from its configuration (WebAdministration provider, falling back to Microsoft.Web.Administration or appcmd.exe), opens it with `FileShare.ReadWrite|Delete` so as not to disturb IIS, and emits each new data line as a structured `PSWinOps.IISLogEntry` — the same shape produced by `Get-IISParsedLog`. Honours mid-file `#Fields` re-detection (post-recycle) and optionally follows daily log rollover via `-FollowRollover`. Filtering parameters (`-Method`/`-Status`/`-UriLike`/`-ClientIP`/`-MinStatus`) are applied during streaming. Use `-InitialLines` to replay the last N entries before entering follow mode, and `-Duration`/`-MaxEntries` to bound a run (recommended for remote sessions).

## Files touched
- `Public/iis/Watch-IISLog.ps1` — implementation
- `Tests/Public/iis/Watch-IISLog.Tests.ps1` — Pester v5 suite (28 tests)
- `PSWinOps.psd1` — `FunctionsToExport` (Watch-IISLog), `ModuleVersion` 0.1.4 → 0.1.5, `ReleaseNotes`
- `en-US/about_PSWinOps.help.txt` — IIS domain bumped 4 → 5 functions, Watch-IISLog listed
- `PSWinOps.Format.ps1xml` — *(unchanged: PSTypeName `PSWinOps.IISLogEntry` reuses the existing `<View>` introduced with `Get-IISParsedLog`)*

## Conformance checklist (auto-audited by fn-quality-gate)
- [x] UTF-8 BOM + CRLF on all new files
- [x] Approved PowerShell verb (`Watch`)
- [x] `FunctionsToExport` alphabetically sorted (case-insensitive), `Watch-IISLog` present exactly once
- [x] `PSTypeName` `PSWinOps.IISLogEntry` consistent across `.ps1` / `Format.ps1xml` / help
- [x] PSScriptAnalyzer clean (0 errors, 0 warnings — `Severity Error,Warning`)
- [x] Pester suite passes locally — 28/28 green
- [x] No `Write-Host`, no `ToString('o')` introduced in the diff
- [x] `Test-ModuleManifest ./PSWinOps.psd1` succeeds (Version 0.1.5, 113 exports)
- [x] `PSWinOps.Format.ps1xml` validates as XML; `<View>` for `PSWinOps.IISLogEntry` present
- [x] `en-US/about_PSWinOps.help.txt`: `iis (5 functions)` matches `Public/iis/` directory count

## Auto-merge
✅ Armed via `gh pr merge --auto --squash --delete-branch`. Will merge automatically once all required Windows CI checks are green (validate, lint, test (Public/iis) and the 12 other matrix jobs). Any failure is picked up by `pswinops-fn-ci-watcher`, which loops back through `pswinops-fn-author MODE=fix` (max 3 iterations).
