### PR TITLE
feat(iis): add Get-IISCertificateBinding

### DIFF
--- a/.kdust/chains/get-iiscertificatebinding-2605161338.yaml
+++ b/.kdust/chains/get-iiscertificatebinding-2605161338.yaml
@@ -1,0 +1,7 @@
+chain: pswinops-function-author
+function: Get-IISCertificateBinding
+domain: iis
+created: 2026-05-16T13:39:59Z
+created_by: pswinops-fn-spec-analyst
+chain_branch: kdust/chain/pswinops-fn-get-iiscertificatebinding-2605161338
+spec_path: work/get-iiscertificatebinding/spec.yaml

--- a/PSWinOps.Format.ps1xml
+++ b/PSWinOps.Format.ps1xml
@@ -7071,5 +7071,84 @@
         </TableRowEntries>
       </TableControl>
     </View>
+
+    <!-- ============================================================ -->
+    <!-- PSWinOps.IISCertificateBinding                               -->
+    <!-- Used by: Get-IISCertificateBinding                           -->
+    <!-- ============================================================ -->
+    <View>
+      <Name>PSWinOps.IISCertificateBinding</Name>
+      <ViewSelectedBy>
+        <TypeName>PSWinOps.IISCertificateBinding</TypeName>
+      </ViewSelectedBy>
+      <TableControl>
+        <AutoSize />
+        <TableHeaders>
+          <TableColumnHeader>
+            <Label>ComputerName</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>SiteName</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Binding</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>HostHeader</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Thumbprint</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>NotAfter</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>DaysLeft</Label>
+            <Alignment>Right</Alignment>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>SNI</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Status</Label>
+          </TableColumnHeader>
+        </TableHeaders>
+        <TableRowEntries>
+          <TableRowEntry>
+            <TableColumnItems>
+              <TableColumnItem>
+                <PropertyName>ComputerName</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>SiteName</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>BindingInformation</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>HostHeader</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>Thumbprint</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <ScriptBlock>
+                  if ($_.NotAfter) { $_.NotAfter.ToString('yyyy-MM-dd') } else { '' }
+                </ScriptBlock>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>DaysUntilExpiration</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>SniEnabled</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>Status</PropertyName>
+              </TableColumnItem>
+            </TableColumnItems>
+          </TableRowEntry>
+        </TableRowEntries>
+      </TableControl>
+    </View>
   </ViewDefinitions>
 </Configuration>

--- a/PSWinOps.psd1
+++ b/PSWinOps.psd1
@@ -123,6 +123,7 @@
         'Get-ExchangeServerHealth',
         'Get-FileServerHealth',
         'Get-HyperVHostHealth',
+        'Get-IISCertificateBinding',
         'Get-IISCurrentRequest',
         'Get-IISFailedRequestTrace',
         'Get-IISHealth',

--- a/PSWinOps.psd1
+++ b/PSWinOps.psd1
@@ -12,7 +12,7 @@
     RootModule           = 'PSWinOps.psm1'
 
     # Version number of this module.
-    ModuleVersion        = '0.1.6'
+    ModuleVersion        = '0.1.7'
 
     # Supported PSEditions
     # Core is supported on Windows only; the module-level guard in PSWinOps.psm1 blocks
@@ -262,7 +262,12 @@
             # IconUri = ''
 
             # ReleaseNotes of this module
-            ReleaseNotes = '## 0.1.6 - 2026-05-15
+            ReleaseNotes = '## 0.1.7 - 2026-05-16
+### Added
+- feat(iis): add Get-IISCertificateBinding — read-only inventory of every IIS HTTPS binding joined to the X509 certificate it actually presents; emits typed PSWinOps.IISCertificateBinding objects with SiteName, BindingInformation (ip:port:hostheader), Protocol, SslFlags (SNI/CCS), Thumbprint, Subject, SubjectAlternativeName, Issuer, NotBefore/NotAfter, DaysUntilExpiration, Expired, CertificateStore and HasPrivateKey; multi-host execution via Invoke-RemoteOrLocal with -Credential; -SiteName/-HostHeader (-like) and -Thumbprint/-Port filters, plus -ExpiringInDays and -IncludeExpired for renewal audits; graceful WebAdministration → IISAdministration → appcmd fallback; pipes cleanly into Set-IISBindingCertificate for rotation workflows.
+- feat(format): TableControl view for PSWinOps.IISCertificateBinding in PSWinOps.Format.ps1xml.
+
+## 0.1.6 - 2026-05-15
 ### Added
 - feat(iis): add Get-IISFailedRequestTrace — parse IIS Failed Request Tracing (FREB) fr######.xml files into typed PSWinOps.IISFailedRequestTrace objects; auto-resolves the FREB folder per site via WebAdministration / IISAdministration / appcmd fallback; surfaces <failedRequest> root attributes (URL, verb, statusCode/subStatus split, timeTaken, appPool, worker PID, failureReason) plus the first ERROR/WARNING event (module, notification, message) without a full DOM load; supports multi-host execution via Invoke-RemoteOrLocal, per-site -Path override, -After/-Before/-StatusCode/-FailureReason filters, -Tail for the most recent N traces, and -IncludeEvents to attach the full event timeline; standard PSWinOps Status enum (Parsed/NoTraces/SiteNotFound/FolderNotFound/IISNotInstalled/Failed).
 - feat(format): TableControl view for PSWinOps.IISFailedRequestTrace in PSWinOps.Format.ps1xml.

--- a/Public/iis/Get-IISCertificateBinding.ps1
+++ b/Public/iis/Get-IISCertificateBinding.ps1
@@ -1,0 +1,675 @@
+﻿#Requires -Version 5.1
+function Get-IISCertificateBinding {
+    <#
+        .SYNOPSIS
+            Inventories every IIS HTTPS binding joined to the X509 certificate it actually presents.
+
+        .DESCRIPTION
+            Enumerates all https bindings on one or more IIS hosts and joins each binding
+            to the X509 certificate it points at, surfacing site, ip:port:hostheader,
+            SNI/CCS flags, thumbprint, subject, SAN, issuer, validity window, days until
+            expiration, certificate store of record and presence of the private key.
+            Provides the read-only typed counterpart of Set-IISBindingCertificate that
+            IISAdministration does not expose in a single cmdlet. Falls back gracefully
+            from WebAdministration to IISAdministration to appcmd, and pipes cleanly into
+            Set-IISBindingCertificate for rotation workflows.
+
+        .PARAMETER ComputerName
+            One or more computer names to query. Defaults to the local machine.
+            Accepts pipeline input by value and by property name.
+
+        .PARAMETER Credential
+            Optional PSCredential for authenticating to remote computers.
+            Not used for local queries.
+
+        .PARAMETER SiteName
+            Filter to one or more site names. Supports -like wildcards. Defaults to all
+            https-bound sites.
+
+        .PARAMETER Thumbprint
+            Filter to one or more certificate thumbprints (40 hex characters, uppercased
+            internally). Useful to track a specific certificate across multiple bindings.
+
+        .PARAMETER HostHeader
+            Filter on the host header part of the binding. Supports -like wildcards.
+
+        .PARAMETER Port
+            Filter to specific TCP ports. Defaults to all https ports (typically 443).
+
+        .PARAMETER ExpiringInDays
+            Returns only certificates with DaysUntilExpiration less than or equal to this
+            value. Includes already-expired certificates (negative DaysUntilExpiration).
+
+        .PARAMETER IncludeExpired
+            When used alone, returns only rows where Expired is $true. Implied when
+            -ExpiringInDays is used.
+
+        .EXAMPLE
+            Get-IISCertificateBinding
+
+            Inventories all https bindings and their certificates on the local machine.
+
+        .EXAMPLE
+            'WEB01','WEB02','WEB03' | Get-IISCertificateBinding -Credential (Get-Credential)
+
+            Audits certificate bindings across a web farm using alternate credentials.
+
+        .EXAMPLE
+            Get-IISCertificateBinding -ComputerName WEB01 -ExpiringInDays 30
+
+            Returns bindings whose certificate expires within the next 30 days.
+
+        .EXAMPLE
+            Get-IISCertificateBinding -SiteName 'www*' -HostHeader '*.contoso.com'
+
+            Filters by site name wildcard and host header wildcard.
+
+        .EXAMPLE
+            Get-IISCertificateBinding -ComputerName WEB01 -ExpiringInDays 15 | Set-IISBindingCertificate -Thumbprint $newTp -Confirm:$false
+
+            Pipes expiring bindings directly into the rotation cmdlet.
+
+        .EXAMPLE
+            Get-IISCertificateBinding | Where-Object Status -eq 'CertNotFound'
+
+            Surfaces orphan bindings whose certificate has been removed from the store.
+
+        .OUTPUTS
+            PSCustomObject (PSTypeName='PSWinOps.IISCertificateBinding')
+
+        .NOTES
+            Author: Franck SALLET
+            Version: 1.0.0
+            Last Modified: 2026-05-16
+            Requires: PowerShell 5.1+ / Windows only
+            Requires: Web-Server (IIS) role
+            Optional: Module WebAdministration or IISAdministration (falls back to appcmd)
+
+        .LINK
+            https://github.com/k9fr4n/PSWinOps
+
+        .LINK
+            https://learn.microsoft.com/en-us/iis/manage/configuring-security/how-to-set-up-ssl-on-iis
+    #>
+    [CmdletBinding()]
+    [OutputType('PSWinOps.IISCertificateBinding')]
+    param(
+        [Parameter(Mandatory = $false, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [ValidateNotNullOrEmpty()]
+        [Alias('CN', 'Name', 'DNSHostName')]
+        [string[]]$ComputerName = $env:COMPUTERNAME,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateNotNull()]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential,
+
+        [Parameter(Mandatory = $false, ValueFromPipelineByPropertyName = $true)]
+        [string[]]$SiteName,
+
+        [Parameter(Mandatory = $false, ValueFromPipelineByPropertyName = $true)]
+        [ValidatePattern('^[A-Fa-f0-9]{40}$')]
+        [string[]]$Thumbprint,
+
+        [Parameter(Mandatory = $false)]
+        [string[]]$HostHeader,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateRange(1, 65535)]
+        [int[]]$Port,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateRange(0, 3650)]
+        [int]$ExpiringInDays,
+
+        [Parameter(Mandatory = $false)]
+        [switch]$IncludeExpired
+    )
+
+    begin {
+        Write-Verbose -Message "[$($MyInvocation.MyCommand)] Starting"
+
+        $scriptBlock = {
+            param(
+                [string[]]$FilterSiteName,
+                [string[]]$FilterThumbprint,
+                [string[]]$FilterHostHeader,
+                [int[]]$FilterPort,
+                [object]$FilterExpiringInDays,
+                [bool]$FilterIncludeExpired
+            )
+
+            $results = [System.Collections.Generic.List[hashtable]]::new()
+
+            $tsNow = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
+
+            # ── 1. Verify W3SVC / IIS installed ───────────────────────────────
+            try {
+                $null = Get-Service -Name 'W3SVC' -ErrorAction Stop
+            }
+            catch {
+                $results.Add(@{
+                    ComputerName            = $env:COMPUTERNAME
+                    SiteName                = $null; SiteId = $null; SiteState = $null
+                    BindingInformation      = $null; IPAddress = $null; Port = $null; HostHeader = $null
+                    Protocol                = $null; SslFlags = $null; SniEnabled = $null; CentralCertStore = $null
+                    Thumbprint              = $null; CertStoreLocation = $null; CertStoreName = $null
+                    Subject                 = $null; SubjectCN = $null; Issuer = $null; SerialNumber = $null
+                    NotBefore               = $null; NotAfter = $null; DaysUntilExpiration = $null; Expired = $null
+                    SubjectAlternativeNames = @()
+                    SignatureAlgorithm      = $null; KeyAlgorithm = $null; KeySize = $null
+                    HasPrivateKey           = $null; FriendlyName = $null
+                    Status                  = 'IISNotInstalled'
+                    ErrorMessage            = "W3SVC service not found: $($_.Exception.Message)"
+                    Timestamp               = $tsNow
+                })
+                return $results
+            }
+
+            # ── 2. Detect IIS module chain ─────────────────────────────────────
+            $iisModule = $null
+            if (Get-Module -Name 'WebAdministration' -ListAvailable -ErrorAction SilentlyContinue) {
+                $iisModule = 'WebAdministration'
+            }
+            elseif (Get-Module -Name 'IISAdministration' -ListAvailable -ErrorAction SilentlyContinue) {
+                $iisModule = 'IISAdministration'
+            }
+
+            # ── 3. Collect raw binding descriptors ────────────────────────────
+            $bindingRows = [System.Collections.Generic.List[hashtable]]::new()
+
+            if ($iisModule -eq 'WebAdministration') {
+                try {
+                    Import-Module -Name 'WebAdministration' -ErrorAction Stop
+
+                    $allSites = @(Get-Website -ErrorAction Stop)
+                    if ($FilterSiteName) {
+                        $allSites = @($allSites | Where-Object {
+                            $sn = $_.Name
+                            $null -ne ($FilterSiteName | Where-Object { $sn -like $_ })
+                        })
+                    }
+
+                    foreach ($site in $allSites) {
+                        $httpsBindings = @(Get-WebBinding -Name $site.Name -Protocol 'https' -ErrorAction SilentlyContinue)
+                        if ($httpsBindings.Count -eq 0) {
+                            if ($FilterSiteName) {
+                                $bindingRows.Add(@{
+                                    SiteNameVal    = $site.Name
+                                    SiteIdVal      = [int]$site.Id
+                                    SiteStateVal   = $site.State
+                                    BindingInfoVal = ''
+                                    SslFlagsVal    = 0
+                                    ThumbprintVal  = $null
+                                    StoreNameVal   = $null
+                                    StatusVal      = 'BindingNotFound'
+                                    ErrorVal       = "No https bindings on site '$($site.Name)'."
+                                })
+                            }
+                            continue
+                        }
+                        foreach ($b in $httpsBindings) {
+                            $sslHash  = $b.certificateHash
+                            $sslStore = if ($b.certificateStoreName) { $b.certificateStoreName } else { 'My' }
+                            $bindingRows.Add(@{
+                                SiteNameVal    = $site.Name
+                                SiteIdVal      = [int]$site.Id
+                                SiteStateVal   = $site.State
+                                BindingInfoVal = $b.bindingInformation
+                                SslFlagsVal    = [int]$b.sslFlags
+                                ThumbprintVal  = $sslHash
+                                StoreNameVal   = $sslStore
+                                StatusVal      = if ($sslHash) { 'Resolved' } else { 'CertNotFound' }
+                                ErrorVal       = if (-not $sslHash) { 'Binding has no certificateHash (unbound https listener).' } else { $null }
+                            })
+                        }
+                    }
+                }
+                catch {
+                    $results.Add(@{
+                        ComputerName            = $env:COMPUTERNAME
+                        SiteName                = $null; SiteId = $null; SiteState = $null
+                        BindingInformation      = $null; IPAddress = $null; Port = $null; HostHeader = $null
+                        Protocol                = $null; SslFlags = $null; SniEnabled = $null; CentralCertStore = $null
+                        Thumbprint              = $null; CertStoreLocation = $null; CertStoreName = $null
+                        Subject                 = $null; SubjectCN = $null; Issuer = $null; SerialNumber = $null
+                        NotBefore               = $null; NotAfter = $null; DaysUntilExpiration = $null; Expired = $null
+                        SubjectAlternativeNames = @()
+                        SignatureAlgorithm      = $null; KeyAlgorithm = $null; KeySize = $null
+                        HasPrivateKey           = $null; FriendlyName = $null
+                        Status                  = 'Failed'
+                        ErrorMessage            = "WebAdministration error: $($_.Exception.Message)"
+                        Timestamp               = $tsNow
+                    })
+                    return $results
+                }
+            }
+            elseif ($iisModule -eq 'IISAdministration') {
+                try {
+                    Import-Module -Name 'IISAdministration' -ErrorAction Stop
+                    $mgr = [Microsoft.Web.Administration.ServerManager]::OpenRemote('localhost')
+                    $allSites = @($mgr.Sites)
+                    if ($FilterSiteName) {
+                        $allSites = @($allSites | Where-Object {
+                            $sn = $_.Name
+                            $null -ne ($FilterSiteName | Where-Object { $sn -like $_ })
+                        })
+                    }
+                    foreach ($site in $allSites) {
+                        $httpsBindings = @($site.Bindings | Where-Object { $_.Protocol -eq 'https' })
+                        if ($httpsBindings.Count -eq 0) {
+                            if ($FilterSiteName) {
+                                $bindingRows.Add(@{
+                                    SiteNameVal    = $site.Name
+                                    SiteIdVal      = [long]$site.Id
+                                    SiteStateVal   = $site.State.ToString()
+                                    BindingInfoVal = ''
+                                    SslFlagsVal    = 0
+                                    ThumbprintVal  = $null
+                                    StoreNameVal   = $null
+                                    StatusVal      = 'BindingNotFound'
+                                    ErrorVal       = "No https bindings on site '$($site.Name)'."
+                                })
+                            }
+                            continue
+                        }
+                        foreach ($b in $httpsBindings) {
+                            $rawHash  = [System.BitConverter]::ToString($b.CertificateHash) -replace '-', ''
+                            $sslStore = if ($b.CertificateStoreName) { $b.CertificateStoreName } else { 'My' }
+                            $bindingRows.Add(@{
+                                SiteNameVal    = $site.Name
+                                SiteIdVal      = [long]$site.Id
+                                SiteStateVal   = $site.State.ToString()
+                                BindingInfoVal = $b.BindingInformation
+                                SslFlagsVal    = [int]$b.SslFlags
+                                ThumbprintVal  = $rawHash
+                                StoreNameVal   = $sslStore
+                                StatusVal      = if ($rawHash) { 'Resolved' } else { 'CertNotFound' }
+                                ErrorVal       = if (-not $rawHash) { 'Binding has no certificate hash (unbound https listener).' } else { $null }
+                            })
+                        }
+                    }
+                    $mgr.Dispose()
+                }
+                catch {
+                    $results.Add(@{
+                        ComputerName            = $env:COMPUTERNAME
+                        SiteName                = $null; SiteId = $null; SiteState = $null
+                        BindingInformation      = $null; IPAddress = $null; Port = $null; HostHeader = $null
+                        Protocol                = $null; SslFlags = $null; SniEnabled = $null; CentralCertStore = $null
+                        Thumbprint              = $null; CertStoreLocation = $null; CertStoreName = $null
+                        Subject                 = $null; SubjectCN = $null; Issuer = $null; SerialNumber = $null
+                        NotBefore               = $null; NotAfter = $null; DaysUntilExpiration = $null; Expired = $null
+                        SubjectAlternativeNames = @()
+                        SignatureAlgorithm      = $null; KeyAlgorithm = $null; KeySize = $null
+                        HasPrivateKey           = $null; FriendlyName = $null
+                        Status                  = 'Failed'
+                        ErrorMessage            = "IISAdministration error: $($_.Exception.Message)"
+                        Timestamp               = $tsNow
+                    })
+                    return $results
+                }
+            }
+            else {
+                # appcmd fallback
+                $appcmdExe = Join-Path -Path $env:windir -ChildPath 'system32\inetsrv\appcmd.exe'
+                if (-not (Test-Path -LiteralPath $appcmdExe -PathType Leaf)) {
+                    $results.Add(@{
+                        ComputerName            = $env:COMPUTERNAME
+                        SiteName                = $null; SiteId = $null; SiteState = $null
+                        BindingInformation      = $null; IPAddress = $null; Port = $null; HostHeader = $null
+                        Protocol                = $null; SslFlags = $null; SniEnabled = $null; CentralCertStore = $null
+                        Thumbprint              = $null; CertStoreLocation = $null; CertStoreName = $null
+                        Subject                 = $null; SubjectCN = $null; Issuer = $null; SerialNumber = $null
+                        NotBefore               = $null; NotAfter = $null; DaysUntilExpiration = $null; Expired = $null
+                        SubjectAlternativeNames = @()
+                        SignatureAlgorithm      = $null; KeyAlgorithm = $null; KeySize = $null
+                        HasPrivateKey           = $null; FriendlyName = $null
+                        Status                  = 'IISNotInstalled'
+                        ErrorMessage            = 'Neither WebAdministration nor IISAdministration module is available, and appcmd.exe was not found.'
+                        Timestamp               = $tsNow
+                    })
+                    return $results
+                }
+                try {
+                    [xml]$sitesXml = & $appcmdExe list sites /config:* /xml 2>$null
+                    foreach ($siteNode in $sitesXml.appcmd.SITE) {
+                        $siteName  = $siteNode.'SITE.NAME'
+                        $siteId    = [int]$siteNode.site.id
+                        $siteState = $siteNode.'SITE.STATE'
+
+                        if ($FilterSiteName) {
+                            $matched = $FilterSiteName | Where-Object { $siteName -like $_ }
+                            if (-not $matched) { continue }
+                        }
+
+                        $httpsNodes = @($siteNode.site.bindings.binding | Where-Object { $_.protocol -eq 'https' })
+                        if ($httpsNodes.Count -eq 0) {
+                            if ($FilterSiteName) {
+                                $bindingRows.Add(@{
+                                    SiteNameVal    = $siteName
+                                    SiteIdVal      = $siteId
+                                    SiteStateVal   = $siteState
+                                    BindingInfoVal = ''
+                                    SslFlagsVal    = 0
+                                    ThumbprintVal  = $null
+                                    StoreNameVal   = $null
+                                    StatusVal      = 'BindingNotFound'
+                                    ErrorVal       = "No https bindings on site '$siteName'."
+                                })
+                            }
+                            continue
+                        }
+                        foreach ($bn in $httpsNodes) {
+                            $sslHash  = $bn.certificateHash
+                            $sslStore = if ($bn.certificateStoreName) { $bn.certificateStoreName } else { 'My' }
+                            $sslFlags = if ($bn.sslFlags) { [int]$bn.sslFlags } else { 0 }
+                            $bindingRows.Add(@{
+                                SiteNameVal    = $siteName
+                                SiteIdVal      = $siteId
+                                SiteStateVal   = $siteState
+                                BindingInfoVal = $bn.bindingInformation
+                                SslFlagsVal    = $sslFlags
+                                ThumbprintVal  = $sslHash
+                                StoreNameVal   = $sslStore
+                                StatusVal      = if ($sslHash) { 'Resolved' } else { 'CertNotFound' }
+                                ErrorVal       = if (-not $sslHash) { 'Binding has no certificateHash (unbound https listener).' } else { $null }
+                            })
+                        }
+                    }
+                }
+                catch {
+                    $results.Add(@{
+                        ComputerName            = $env:COMPUTERNAME
+                        SiteName                = $null; SiteId = $null; SiteState = $null
+                        BindingInformation      = $null; IPAddress = $null; Port = $null; HostHeader = $null
+                        Protocol                = $null; SslFlags = $null; SniEnabled = $null; CentralCertStore = $null
+                        Thumbprint              = $null; CertStoreLocation = $null; CertStoreName = $null
+                        Subject                 = $null; SubjectCN = $null; Issuer = $null; SerialNumber = $null
+                        NotBefore               = $null; NotAfter = $null; DaysUntilExpiration = $null; Expired = $null
+                        SubjectAlternativeNames = @()
+                        SignatureAlgorithm      = $null; KeyAlgorithm = $null; KeySize = $null
+                        HasPrivateKey           = $null; FriendlyName = $null
+                        Status                  = 'Failed'
+                        ErrorMessage            = "appcmd fallback error: $($_.Exception.Message)"
+                        Timestamp               = $tsNow
+                    })
+                    return $results
+                }
+            }
+
+            # ── 4. No bindings at all ──────────────────────────────────────────
+            if ($bindingRows.Count -eq 0) {
+                $results.Add(@{
+                    ComputerName            = $env:COMPUTERNAME
+                    SiteName                = $null; SiteId = $null; SiteState = $null
+                    BindingInformation      = $null; IPAddress = $null; Port = $null; HostHeader = $null
+                    Protocol                = $null; SslFlags = $null; SniEnabled = $null; CentralCertStore = $null
+                    Thumbprint              = $null; CertStoreLocation = $null; CertStoreName = $null
+                    Subject                 = $null; SubjectCN = $null; Issuer = $null; SerialNumber = $null
+                    NotBefore               = $null; NotAfter = $null; DaysUntilExpiration = $null; Expired = $null
+                    SubjectAlternativeNames = @()
+                    SignatureAlgorithm      = $null; KeyAlgorithm = $null; KeySize = $null
+                    HasPrivateKey           = $null; FriendlyName = $null
+                    Status                  = 'BindingNotFound'
+                    ErrorMessage            = 'No https bindings found on this host.'
+                    Timestamp               = $tsNow
+                })
+                return $results
+            }
+
+            # ── 5. Build full rows: parse binding + resolve cert + filter ──────
+            foreach ($br in $bindingRows) {
+                # Parse BindingInformation: ip:port:hostheader
+                # Last colon-segment = hostheader, second-to-last = port,
+                # everything before second-to-last joined = IP (safe for IPv6).
+                $bindInfo  = $br.BindingInfoVal
+                $bParts    = $bindInfo -split ':'
+                $hostHeader = ''
+                $portVal    = 0
+                $ipAddress  = '*'
+                if ($bParts.Count -ge 2) {
+                    $hostHeader = $bParts[-1]
+                    $portVal    = [int]$bParts[-2]
+                    $ipRaw      = ($bParts[0..($bParts.Count - 3)]) -join ':'
+                    $ipAddress  = if ([string]::IsNullOrEmpty($ipRaw)) { '*' } else { $ipRaw }
+                }
+
+                # HostHeader filter
+                if ($FilterHostHeader) {
+                    $hh      = $hostHeader
+                    $matched = $FilterHostHeader | Where-Object { $hh -like $_ }
+                    if (-not $matched) { continue }
+                }
+
+                # Port filter
+                if ($FilterPort -and ($portVal -notin $FilterPort)) { continue }
+
+                # Thumbprint filter (pre-resolution, fast path)
+                if ($FilterThumbprint) {
+                    $tpRaw   = if ($br.ThumbprintVal) { $br.ThumbprintVal.ToUpper() } else { '' }
+                    $matched = $FilterThumbprint | Where-Object { $tpRaw -eq $_.ToUpper() }
+                    if (-not $matched) { continue }
+                }
+
+                # Resolve X509 certificate
+                $tp           = if ($br.ThumbprintVal) { $br.ThumbprintVal.ToUpper() } else { $null }
+                $storeName    = $br.StoreNameVal
+                $statusVal    = $br.StatusVal
+                $errorVal     = $br.ErrorVal
+
+                $certSubject   = $null; $certSubjectCN = $null
+                $certIssuer    = $null; $certSerial    = $null
+                $certNotBefore = $null; $certNotAfter  = $null
+                $certDays      = $null; $certExpired   = $null
+                $certSAN       = @()
+                $certSigAlg    = $null; $certKeyAlg    = $null
+                $certKeySize   = $null; $certHasPK     = $null
+                $certFriendly  = $null
+
+                if ($statusVal -eq 'Resolved' -and $tp -and $storeName) {
+                    $storePath = "Cert:\LocalMachine\$storeName"
+                    $cert      = $null
+                    try {
+                        $cert = Get-ChildItem -LiteralPath $storePath -ErrorAction Stop |
+                            Where-Object { $_.Thumbprint -eq $tp } |
+                            Select-Object -First 1
+                    }
+                    catch {
+                        Write-Verbose -Message "[Get-IISCertificateBinding] Could not open store '$storePath': $($_.Exception.Message)"
+                    }
+
+                    if ($null -eq $cert) {
+                        $statusVal = 'CertNotFound'
+                        $errorVal  = "Certificate with thumbprint '$tp' not found in '$storePath'."
+                    }
+                    else {
+                        $now           = Get-Date
+                        $certDays      = [int][math]::Floor(($cert.NotAfter - $now).TotalDays)
+                        $certExpired   = ($cert.NotAfter -lt $now)
+                        $certSubject   = $cert.Subject
+                        $certIssuer    = $cert.Issuer
+                        $certSerial    = $cert.SerialNumber.ToUpper()
+                        $certNotBefore = $cert.NotBefore
+                        $certNotAfter  = $cert.NotAfter
+                        $certHasPK     = $cert.HasPrivateKey
+                        $certFriendly  = $cert.FriendlyName
+                        $certSigAlg    = $cert.SignatureAlgorithm.FriendlyName
+
+                        # SubjectCN extraction
+                        $cnMatch = [regex]::Match($cert.Subject, '(?:^|,\s*)CN=([^,]+)')
+                        if ($cnMatch.Success) {
+                            $certSubjectCN = $cnMatch.Groups[1].Value.Trim()
+                        }
+
+                        # KeyAlgorithm and KeySize
+                        try {
+                            $certKeyAlg = $cert.PublicKey.Oid.FriendlyName
+                            $rsaKey     = $cert.GetRSAPublicKey()
+                            if ($null -ne $rsaKey) {
+                                $certKeySize = $rsaKey.KeySize
+                            }
+                            else {
+                                $ecKey = $cert.GetECDsaPublicKey()
+                                if ($null -ne $ecKey) {
+                                    $certKeySize = $ecKey.KeySize
+                                }
+                            }
+                        }
+                        catch {
+                            Write-Verbose -Message "[Get-IISCertificateBinding] Key size resolution failed for '$tp': $($_.Exception.Message)"
+                        }
+
+                        # SAN (OID 2.5.29.17)
+                        $sanExt = $cert.Extensions |
+                            Where-Object { $_.Oid.Value -eq '2.5.29.17' } |
+                            Select-Object -First 1
+                        if ($null -ne $sanExt) {
+                            $sanFormatted = $sanExt.Format($false)
+                            if (-not [string]::IsNullOrWhiteSpace($sanFormatted)) {
+                                $certSAN = @($sanFormatted -split ',\s*' |
+                                    ForEach-Object { $_ -replace '^(DNS Name|IP Address)=', '' } |
+                                    Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+                            }
+                        }
+                    }
+                }
+
+                # ExpiringInDays / IncludeExpired filters
+                if ($null -ne $FilterExpiringInDays) {
+                    if ($null -eq $certDays) { continue }
+                    if ($certDays -gt $FilterExpiringInDays) { continue }
+                }
+                elseif ($FilterIncludeExpired) {
+                    if ($certExpired -ne $true) { continue }
+                }
+
+                $results.Add(@{
+                    ComputerName            = $env:COMPUTERNAME
+                    SiteName                = $br.SiteNameVal
+                    SiteId                  = $br.SiteIdVal
+                    SiteState               = $br.SiteStateVal
+                    BindingInformation      = $bindInfo
+                    IPAddress               = $ipAddress
+                    Port                    = $portVal
+                    HostHeader              = $hostHeader
+                    Protocol                = 'https'
+                    SslFlags                = $br.SslFlagsVal
+                    SniEnabled              = (($br.SslFlagsVal -band 1) -eq 1)
+                    CentralCertStore        = (($br.SslFlagsVal -band 2) -eq 2)
+                    Thumbprint              = $tp
+                    CertStoreLocation       = if ($storeName) { "Cert:\LocalMachine\$storeName" } else { $null }
+                    CertStoreName           = $storeName
+                    Subject                 = $certSubject
+                    SubjectCN               = $certSubjectCN
+                    Issuer                  = $certIssuer
+                    SerialNumber            = $certSerial
+                    NotBefore               = $certNotBefore
+                    NotAfter                = $certNotAfter
+                    DaysUntilExpiration     = $certDays
+                    Expired                 = $certExpired
+                    SubjectAlternativeNames = $certSAN
+                    SignatureAlgorithm      = $certSigAlg
+                    KeyAlgorithm            = $certKeyAlg
+                    KeySize                 = $certKeySize
+                    HasPrivateKey           = $certHasPK
+                    FriendlyName            = $certFriendly
+                    Status                  = $statusVal
+                    ErrorMessage            = $errorVal
+                    Timestamp               = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
+                })
+            }
+
+            # ── 6. No rows survived filters ────────────────────────────────────
+            if ($results.Count -eq 0) {
+                $results.Add(@{
+                    ComputerName            = $env:COMPUTERNAME
+                    SiteName                = $null; SiteId = $null; SiteState = $null
+                    BindingInformation      = $null; IPAddress = $null; Port = $null; HostHeader = $null
+                    Protocol                = $null; SslFlags = $null; SniEnabled = $null; CentralCertStore = $null
+                    Thumbprint              = $null; CertStoreLocation = $null; CertStoreName = $null
+                    Subject                 = $null; SubjectCN = $null; Issuer = $null; SerialNumber = $null
+                    NotBefore               = $null; NotAfter = $null; DaysUntilExpiration = $null; Expired = $null
+                    SubjectAlternativeNames = @()
+                    SignatureAlgorithm      = $null; KeyAlgorithm = $null; KeySize = $null
+                    HasPrivateKey           = $null; FriendlyName = $null
+                    Status                  = 'BindingNotFound'
+                    ErrorMessage            = 'No https bindings matched the specified filters on this host.'
+                    Timestamp               = $tsNow
+                })
+            }
+
+            return $results
+        }
+    }
+
+    process {
+        foreach ($cn in $ComputerName) {
+            $filterDays   = if ($PSBoundParameters.ContainsKey('ExpiringInDays')) { $ExpiringInDays } else { $null }
+            $invokeParams = @{
+                ComputerName = $cn
+                ScriptBlock  = $scriptBlock
+                ArgumentList = @(
+                    $SiteName,
+                    $Thumbprint,
+                    $HostHeader,
+                    $Port,
+                    $filterDays,
+                    $IncludeExpired.IsPresent
+                )
+            }
+            if ($Credential) {
+                $invokeParams['Credential'] = $Credential
+            }
+
+            try {
+                $rawResults = Invoke-RemoteOrLocal @invokeParams
+                foreach ($r in $rawResults) {
+                    [PSCustomObject]([ordered]@{
+                        PSTypeName              = 'PSWinOps.IISCertificateBinding'
+                        ComputerName            = $r.ComputerName
+                        SiteName                = $r.SiteName
+                        SiteId                  = $r.SiteId
+                        SiteState               = $r.SiteState
+                        BindingInformation      = $r.BindingInformation
+                        IPAddress               = $r.IPAddress
+                        Port                    = $r.Port
+                        HostHeader              = $r.HostHeader
+                        Protocol                = $r.Protocol
+                        SslFlags                = $r.SslFlags
+                        SniEnabled              = $r.SniEnabled
+                        CentralCertStore        = $r.CentralCertStore
+                        Thumbprint              = $r.Thumbprint
+                        CertStoreLocation       = $r.CertStoreLocation
+                        CertStoreName           = $r.CertStoreName
+                        Subject                 = $r.Subject
+                        SubjectCN               = $r.SubjectCN
+                        Issuer                  = $r.Issuer
+                        SerialNumber            = $r.SerialNumber
+                        NotBefore               = $r.NotBefore
+                        NotAfter                = $r.NotAfter
+                        DaysUntilExpiration     = $r.DaysUntilExpiration
+                        Expired                 = $r.Expired
+                        SubjectAlternativeNames = $r.SubjectAlternativeNames
+                        SignatureAlgorithm      = $r.SignatureAlgorithm
+                        KeyAlgorithm            = $r.KeyAlgorithm
+                        KeySize                 = $r.KeySize
+                        HasPrivateKey           = $r.HasPrivateKey
+                        FriendlyName            = $r.FriendlyName
+                        Status                  = $r.Status
+                        ErrorMessage            = $r.ErrorMessage
+                        Timestamp               = $r.Timestamp
+                    })
+                }
+            }
+            catch {
+                Write-Error -Message "[$($MyInvocation.MyCommand)] Failed on '$cn': $_"
+            }
+        }
+    }
+
+    end {
+        Write-Verbose -Message "[$($MyInvocation.MyCommand)] Completed"
+    }
+}

--- a/Tests/Public/iis/Get-IISCertificateBinding.Tests.ps1
+++ b/Tests/Public/iis/Get-IISCertificateBinding.Tests.ps1
@@ -1,0 +1,676 @@
+﻿#Requires -Version 5.1
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSUseDeclaredVarsMoreThanAssignments', '',
+    Justification = 'Script-scoped variables are assigned in BeforeAll and referenced across nested It scopes'
+)]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSAvoidUsingConvertToSecureStringWithPlainText', '',
+    Justification = 'Test fixture only — not a real credential'
+)]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSAvoidUsingComputerNameHardcoded', '',
+    Justification = 'Fake target names used exclusively in test fixtures — no real machines are contacted'
+)]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSReviewUnusedParameter', '',
+    Justification = 'Stub parameters are declared to satisfy the Pester mock engine (PR #42) but have no body'
+)]
+param()
+
+BeforeAll {
+    $script:modulePath = Split-Path -Path (Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent) -Parent
+    Import-Module -Name (Join-Path -Path $script:modulePath -ChildPath 'PSWinOps.psd1') -Force
+    $script:testFilePath = $PSCommandPath
+
+    # IIS WebAdministration / IISAdministration stubs — parameters declared explicitly
+    # so the Pester mock engine can match arguments correctly (project convention, see PR #42).
+    if (-not (Get-Command -Name 'Get-Website' -ErrorAction SilentlyContinue)) {
+        function global:Get-Website { param([string]$Name) }
+    }
+    if (-not (Get-Command -Name 'Get-WebBinding' -ErrorAction SilentlyContinue)) {
+        function global:Get-WebBinding { param([string]$Name, [string]$Protocol) }
+    }
+    if (-not (Get-Command -Name 'Get-IISSite' -ErrorAction SilentlyContinue)) {
+        function global:Get-IISSite { param([string]$Name) }
+    }
+    if (-not (Get-Command -Name 'Get-IISServerManager' -ErrorAction SilentlyContinue)) {
+        function global:Get-IISServerManager { param() }
+    }
+
+    $script:ModuleName   = 'PSWinOps'
+    $script:Host1        = 'WEB01'
+    $script:Host2        = 'WEB02'
+    $script:FailHost     = 'FAILHOST'
+    $script:ValidThumb   = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
+    $script:OrphanThumb  = 'BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB'
+    $script:ExpiredThumb = 'CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC'
+
+    # ── Mock payload: Resolved binding with full certificate details ──────────
+    $script:mockResolved = @(
+        @{
+            ComputerName            = 'WEB01'
+            SiteName                = 'Default Web Site'
+            SiteId                  = 1
+            SiteState               = 'Started'
+            BindingInformation      = '*:443:'
+            IPAddress               = '*'
+            Port                    = 443
+            HostHeader              = ''
+            Protocol                = 'https'
+            SslFlags                = 0
+            SniEnabled              = $false
+            CentralCertStore        = $false
+            Thumbprint              = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
+            CertStoreLocation       = 'Cert:\LocalMachine\My'
+            CertStoreName           = 'My'
+            Subject                 = 'CN=web01.contoso.com, O=Contoso, C=US'
+            SubjectCN               = 'web01.contoso.com'
+            Issuer                  = 'CN=Contoso CA, O=Contoso, C=US'
+            SerialNumber            = '01020304'
+            NotBefore               = [datetime]'2025-01-01'
+            NotAfter                = [datetime]'2027-01-01'
+            DaysUntilExpiration     = 230
+            Expired                 = $false
+            SubjectAlternativeNames = @('web01.contoso.com', 'www.contoso.com')
+            SignatureAlgorithm      = 'sha256RSA'
+            KeyAlgorithm            = 'RSA'
+            KeySize                 = 2048
+            HasPrivateKey           = $true
+            FriendlyName            = 'Contoso Web Certificate'
+            Status                  = 'Resolved'
+            ErrorMessage            = $null
+            Timestamp               = '2026-05-16 12:00:00'
+        }
+    )
+
+    # ── Mock payload: SNI binding (SslFlags=1) ────────────────────────────────
+    $script:mockSNI = @(
+        @{
+            ComputerName            = 'WEB01'
+            SiteName                = 'SNISite'
+            SiteId                  = 2
+            SiteState               = 'Started'
+            BindingInformation      = '*:443:sni.contoso.com'
+            IPAddress               = '*'
+            Port                    = 443
+            HostHeader              = 'sni.contoso.com'
+            Protocol                = 'https'
+            SslFlags                = 1
+            SniEnabled              = $true
+            CentralCertStore        = $false
+            Thumbprint              = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
+            CertStoreLocation       = 'Cert:\LocalMachine\My'
+            CertStoreName           = 'My'
+            Subject                 = 'CN=sni.contoso.com'
+            SubjectCN               = 'sni.contoso.com'
+            Issuer                  = 'CN=Contoso CA'
+            SerialNumber            = '0A0B0C0D'
+            NotBefore               = [datetime]'2025-01-01'
+            NotAfter                = [datetime]'2027-01-01'
+            DaysUntilExpiration     = 230
+            Expired                 = $false
+            SubjectAlternativeNames = @('sni.contoso.com')
+            SignatureAlgorithm      = 'sha256RSA'
+            KeyAlgorithm            = 'RSA'
+            KeySize                 = 2048
+            HasPrivateKey           = $true
+            FriendlyName            = ''
+            Status                  = 'Resolved'
+            ErrorMessage            = $null
+            Timestamp               = '2026-05-16 12:00:00'
+        }
+    )
+
+    # ── Mock payload: CertNotFound (orphan binding) ───────────────────────────
+    $script:mockCertNotFound = @(
+        @{
+            ComputerName            = 'WEB01'
+            SiteName                = 'Default Web Site'
+            SiteId                  = 1
+            SiteState               = 'Started'
+            BindingInformation      = '*:443:'
+            IPAddress               = '*'
+            Port                    = 443
+            HostHeader              = ''
+            Protocol                = 'https'
+            SslFlags                = 0
+            SniEnabled              = $false
+            CentralCertStore        = $false
+            Thumbprint              = 'BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB'
+            CertStoreLocation       = 'Cert:\LocalMachine\My'
+            CertStoreName           = 'My'
+            Subject                 = $null
+            SubjectCN               = $null
+            Issuer                  = $null
+            SerialNumber            = $null
+            NotBefore               = $null
+            NotAfter                = $null
+            DaysUntilExpiration     = $null
+            Expired                 = $null
+            SubjectAlternativeNames = @()
+            SignatureAlgorithm      = $null
+            KeyAlgorithm            = $null
+            KeySize                 = $null
+            HasPrivateKey           = $null
+            FriendlyName            = $null
+            Status                  = 'CertNotFound'
+            ErrorMessage            = "Certificate with thumbprint 'BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB' not found in 'Cert:\LocalMachine\My'."
+            Timestamp               = '2026-05-16 12:00:00'
+        }
+    )
+
+    # ── Mock payload: BindingNotFound ─────────────────────────────────────────
+    $script:mockBindingNotFound = @(
+        @{
+            ComputerName            = 'WEB01'
+            SiteName                = $null
+            SiteId                  = $null
+            SiteState               = $null
+            BindingInformation      = $null
+            IPAddress               = $null
+            Port                    = $null
+            HostHeader              = $null
+            Protocol                = $null
+            SslFlags                = $null
+            SniEnabled              = $null
+            CentralCertStore        = $null
+            Thumbprint              = $null
+            CertStoreLocation       = $null
+            CertStoreName           = $null
+            Subject                 = $null
+            SubjectCN               = $null
+            Issuer                  = $null
+            SerialNumber            = $null
+            NotBefore               = $null
+            NotAfter                = $null
+            DaysUntilExpiration     = $null
+            Expired                 = $null
+            SubjectAlternativeNames = @()
+            SignatureAlgorithm      = $null
+            KeyAlgorithm            = $null
+            KeySize                 = $null
+            HasPrivateKey           = $null
+            FriendlyName            = $null
+            Status                  = 'BindingNotFound'
+            ErrorMessage            = 'No https bindings found on this host.'
+            Timestamp               = '2026-05-16 12:00:00'
+        }
+    )
+
+    # ── Mock payload: IISNotInstalled ─────────────────────────────────────────
+    $script:mockIISNotInstalled = @(
+        @{
+            ComputerName            = 'WEB01'
+            SiteName                = $null
+            SiteId                  = $null
+            SiteState               = $null
+            BindingInformation      = $null
+            IPAddress               = $null
+            Port                    = $null
+            HostHeader              = $null
+            Protocol                = $null
+            SslFlags                = $null
+            SniEnabled              = $null
+            CentralCertStore        = $null
+            Thumbprint              = $null
+            CertStoreLocation       = $null
+            CertStoreName           = $null
+            Subject                 = $null
+            SubjectCN               = $null
+            Issuer                  = $null
+            SerialNumber            = $null
+            NotBefore               = $null
+            NotAfter                = $null
+            DaysUntilExpiration     = $null
+            Expired                 = $null
+            SubjectAlternativeNames = @()
+            SignatureAlgorithm      = $null
+            KeyAlgorithm            = $null
+            KeySize                 = $null
+            HasPrivateKey           = $null
+            FriendlyName            = $null
+            Status                  = 'IISNotInstalled'
+            ErrorMessage            = 'W3SVC service not found: Cannot find service'
+            Timestamp               = '2026-05-16 12:00:00'
+        }
+    )
+
+    # ── Mock payload: Failed ──────────────────────────────────────────────────
+    $script:mockFailed = @(
+        @{
+            ComputerName            = 'FAILHOST'
+            SiteName                = $null
+            SiteId                  = $null
+            SiteState               = $null
+            BindingInformation      = $null
+            IPAddress               = $null
+            Port                    = $null
+            HostHeader              = $null
+            Protocol                = $null
+            SslFlags                = $null
+            SniEnabled              = $null
+            CentralCertStore        = $null
+            Thumbprint              = $null
+            CertStoreLocation       = $null
+            CertStoreName           = $null
+            Subject                 = $null
+            SubjectCN               = $null
+            Issuer                  = $null
+            SerialNumber            = $null
+            NotBefore               = $null
+            NotAfter                = $null
+            DaysUntilExpiration     = $null
+            Expired                 = $null
+            SubjectAlternativeNames = @()
+            SignatureAlgorithm      = $null
+            KeyAlgorithm            = $null
+            KeySize                 = $null
+            HasPrivateKey           = $null
+            FriendlyName            = $null
+            Status                  = 'Failed'
+            ErrorMessage            = 'Unexpected error during enumeration'
+            Timestamp               = '2026-05-16 12:00:00'
+        }
+    )
+
+    # ── Mock payload: Expired certificate ─────────────────────────────────────
+    $script:mockExpired = @(
+        @{
+            ComputerName            = 'WEB01'
+            SiteName                = 'LegacySite'
+            SiteId                  = 3
+            SiteState               = 'Started'
+            BindingInformation      = '*:443:'
+            IPAddress               = '*'
+            Port                    = 443
+            HostHeader              = ''
+            Protocol                = 'https'
+            SslFlags                = 0
+            SniEnabled              = $false
+            CentralCertStore        = $false
+            Thumbprint              = 'CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC'
+            CertStoreLocation       = 'Cert:\LocalMachine\My'
+            CertStoreName           = 'My'
+            Subject                 = 'CN=legacy.contoso.com'
+            SubjectCN               = 'legacy.contoso.com'
+            Issuer                  = 'CN=Contoso CA'
+            SerialNumber            = '0D0E0F10'
+            NotBefore               = [datetime]'2020-01-01'
+            NotAfter                = [datetime]'2021-01-01'
+            DaysUntilExpiration     = -1600
+            Expired                 = $true
+            SubjectAlternativeNames = @()
+            SignatureAlgorithm      = 'sha1RSA'
+            KeyAlgorithm            = 'RSA'
+            KeySize                 = 1024
+            HasPrivateKey           = $true
+            FriendlyName            = ''
+            Status                  = 'Resolved'
+            ErrorMessage            = $null
+            Timestamp               = '2026-05-16 12:00:00'
+        }
+    )
+}
+
+Describe 'Get-IISCertificateBinding' {
+
+    # ── Context 1: Happy path ─────────────────────────────────────────────────
+    Context 'Happy path: Resolved binding with full certificate details' {
+
+        It 'Should return Status=Resolved with correct PSTypeName' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName `
+                -MockWith { return $script:mockResolved }
+            $result = Get-IISCertificateBinding -ComputerName $script:Host1
+            $result.Status                | Should -Be 'Resolved'
+            $result.PSObject.TypeNames[0] | Should -Be 'PSWinOps.IISCertificateBinding'
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should populate certificate metadata (Subject, SubjectCN, Thumbprint, KeySize)' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName `
+                -MockWith { return $script:mockResolved }
+            $result = Get-IISCertificateBinding -ComputerName $script:Host1
+            $result.Thumbprint | Should -Be $script:ValidThumb
+            $result.Subject    | Should -Be 'CN=web01.contoso.com, O=Contoso, C=US'
+            $result.SubjectCN  | Should -Be 'web01.contoso.com'
+            $result.Issuer     | Should -Not -BeNullOrEmpty
+            $result.KeySize    | Should -Be 2048
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should populate binding geometry (Port, IPAddress, HostHeader, Protocol)' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName `
+                -MockWith { return $script:mockResolved }
+            $result = Get-IISCertificateBinding -ComputerName $script:Host1
+            $result.Port       | Should -Be 443
+            $result.IPAddress  | Should -Be '*'
+            $result.HostHeader | Should -Be ''
+            $result.Protocol   | Should -Be 'https'
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should set ComputerName on the output row' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName `
+                -MockWith { return $script:mockResolved }
+            $result = Get-IISCertificateBinding -ComputerName $script:Host1
+            $result.ComputerName | Should -Be 'WEB01'
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should report Expired=false and DaysUntilExpiration > 0 for a valid certificate' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName `
+                -MockWith { return $script:mockResolved }
+            $result = Get-IISCertificateBinding -ComputerName $script:Host1
+            $result.Expired             | Should -BeFalse
+            $result.DaysUntilExpiration | Should -BeGreaterThan 0
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should populate SubjectAlternativeNames as a non-empty array' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName `
+                -MockWith { return $script:mockResolved }
+            $result = Get-IISCertificateBinding -ComputerName $script:Host1
+            $result.SubjectAlternativeNames | Should -Contain 'web01.contoso.com'
+            $result.SubjectAlternativeNames | Should -Contain 'www.contoso.com'
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should set Timestamp matching the yyyy-MM-dd HH:mm:ss format pattern' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName `
+                -MockWith { return $script:mockResolved }
+            $result = Get-IISCertificateBinding -ComputerName $script:Host1
+            "$($result.Timestamp)" | Should -Match "^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$"
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should populate CertStoreLocation and CertStoreName for a Resolved binding' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName `
+                -MockWith { return $script:mockResolved }
+            $result = Get-IISCertificateBinding -ComputerName $script:Host1
+            $result.CertStoreLocation | Should -Be 'Cert:\LocalMachine\My'
+            $result.CertStoreName     | Should -Be 'My'
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+    }
+
+    # ── Context 2: Status=CertNotFound ───────────────────────────────────────
+    Context 'Status=CertNotFound: orphan binding whose thumbprint is absent from the cert store' {
+
+        It 'Should return Status=CertNotFound with a non-null ErrorMessage' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName `
+                -MockWith { return $script:mockCertNotFound }
+            $result = Get-IISCertificateBinding -ComputerName $script:Host1
+            $result.Status       | Should -Be 'CertNotFound'
+            $result.ErrorMessage | Should -Not -BeNullOrEmpty
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should leave certificate-derived properties null for a CertNotFound row' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName `
+                -MockWith { return $script:mockCertNotFound }
+            $result = Get-IISCertificateBinding -ComputerName $script:Host1
+            $result.Subject  | Should -BeNullOrEmpty
+            $result.NotAfter | Should -BeNullOrEmpty
+            $result.Expired  | Should -BeNullOrEmpty
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should preserve the orphan Thumbprint for a CertNotFound row' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName `
+                -MockWith { return $script:mockCertNotFound }
+            $result = Get-IISCertificateBinding -ComputerName $script:Host1
+            $result.Thumbprint | Should -Be $script:OrphanThumb
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should still carry a valid PSTypeName for CertNotFound rows' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName `
+                -MockWith { return $script:mockCertNotFound }
+            $result = Get-IISCertificateBinding -ComputerName $script:Host1
+            $result.PSObject.TypeNames[0] | Should -Be 'PSWinOps.IISCertificateBinding'
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+    }
+
+    # ── Context 3: Status=BindingNotFound ────────────────────────────────────
+    Context 'Status=BindingNotFound: host has no https bindings matching the supplied filter' {
+
+        It 'Should return Status=BindingNotFound with a non-null ErrorMessage' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName `
+                -MockWith { return $script:mockBindingNotFound }
+            $result = Get-IISCertificateBinding -ComputerName $script:Host1
+            $result.Status       | Should -Be 'BindingNotFound'
+            $result.ErrorMessage | Should -Not -BeNullOrEmpty
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should return null SiteName and null Thumbprint for a BindingNotFound row' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName `
+                -MockWith { return $script:mockBindingNotFound }
+            $result = Get-IISCertificateBinding -ComputerName $script:Host1
+            $result.SiteName   | Should -BeNullOrEmpty
+            $result.Thumbprint | Should -BeNullOrEmpty
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+    }
+
+    # ── Context 4: Status=IISNotInstalled ────────────────────────────────────
+    Context 'Status=IISNotInstalled: W3SVC service absent on the target host' {
+
+        It 'Should return Status=IISNotInstalled when the W3SVC service is missing' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName `
+                -MockWith { return $script:mockIISNotInstalled }
+            $result = Get-IISCertificateBinding -ComputerName $script:Host1
+            $result.Status | Should -Be 'IISNotInstalled'
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should include W3SVC in the ErrorMessage for an IISNotInstalled row' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName `
+                -MockWith { return $script:mockIISNotInstalled }
+            $result = Get-IISCertificateBinding -ComputerName $script:Host1
+            $result.ErrorMessage | Should -Match 'W3SVC'
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+    }
+
+    # ── Context 5: Status=Failed ──────────────────────────────────────────────
+    Context 'Status=Failed: unhandled exception during binding enumeration' {
+
+        It 'Should return Status=Failed with a populated ErrorMessage' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName `
+                -MockWith { return $script:mockFailed }
+            $result = Get-IISCertificateBinding -ComputerName $script:FailHost
+            $result.Status       | Should -Be 'Failed'
+            $result.ErrorMessage | Should -Not -BeNullOrEmpty
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should set PSTypeName to PSWinOps.IISCertificateBinding even for Failed rows' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName `
+                -MockWith { return $script:mockFailed }
+            $result = Get-IISCertificateBinding -ComputerName $script:FailHost
+            $result.PSObject.TypeNames[0] | Should -Be 'PSWinOps.IISCertificateBinding'
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+    }
+
+    # ── Context 6: Pipeline by property name ─────────────────────────────────
+    Context 'Pipeline by property name: ComputerName aliases and business params accepted from pipe' {
+
+        It 'Should accept ComputerName via pipeline by property name' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName `
+                -MockWith { return $script:mockResolved }
+            $pipeInput = [PSCustomObject]@{ ComputerName = $script:Host1 }
+            $result = $pipeInput | Get-IISCertificateBinding
+            $result | Should -Not -BeNullOrEmpty
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should accept the DNSHostName alias for ComputerName via pipeline by property name' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName `
+                -MockWith { return $script:mockResolved }
+            $pipeInput = [PSCustomObject]@{ DNSHostName = $script:Host1 }
+            $result = $pipeInput | Get-IISCertificateBinding
+            $result | Should -Not -BeNullOrEmpty
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should accept SiteName via pipeline by property name alongside ComputerName' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName `
+                -MockWith { return $script:mockResolved }
+            $pipeInput = [PSCustomObject]@{ ComputerName = $script:Host1; SiteName = 'Default Web Site' }
+            $result = $pipeInput | Get-IISCertificateBinding
+            $result | Should -Not -BeNullOrEmpty
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should accept Thumbprint via pipeline by property name alongside ComputerName' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName `
+                -MockWith { return $script:mockResolved }
+            $pipeInput = [PSCustomObject]@{ ComputerName = $script:Host1; Thumbprint = $script:ValidThumb }
+            $result = $pipeInput | Get-IISCertificateBinding
+            $result | Should -Not -BeNullOrEmpty
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+    }
+
+    # ── Context 7: Credential propagation ────────────────────────────────────
+    Context 'Credential propagation: PSCredential forwarded to Invoke-RemoteOrLocal when supplied' {
+
+        It 'Should call Invoke-RemoteOrLocal exactly once when Credential is provided' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName `
+                -MockWith { return $script:mockResolved }
+            $cred = [System.Management.Automation.PSCredential]::new(
+                'domain\user',
+                (ConvertTo-SecureString -String 'P@ssw0rd!' -AsPlainText -Force)
+            )
+            $result = Get-IISCertificateBinding -ComputerName $script:Host1 -Credential $cred
+            $result | Should -Not -BeNullOrEmpty
+            $result.Status | Should -Be 'Resolved'
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should return valid results when no Credential is provided (local / integrated auth)' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName `
+                -MockWith { return $script:mockResolved }
+            $result = Get-IISCertificateBinding -ComputerName $script:Host1
+            $result.Status | Should -Be 'Resolved'
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+    }
+
+    # ── Context 8: ComputerName fan-out ──────────────────────────────────────
+    Context 'ComputerName fan-out: each host generates exactly one Invoke-RemoteOrLocal call' {
+
+        It 'Should invoke Invoke-RemoteOrLocal once per computer for two hosts' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName `
+                -MockWith { return $script:mockResolved }
+            $null = Get-IISCertificateBinding -ComputerName @($script:Host1, $script:Host2)
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 2 -Exactly
+        }
+
+        It 'Should produce one output row per host when each host returns a single binding' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName `
+                -MockWith { return $script:mockResolved }
+            $results = @(Get-IISCertificateBinding -ComputerName @($script:Host1, $script:Host2))
+            $results.Count | Should -Be 2
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 2 -Exactly
+        }
+
+        It 'Should invoke Invoke-RemoteOrLocal three times for three hosts piped as an array' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName `
+                -MockWith { return $script:mockResolved }
+            $null = @($script:Host1, $script:Host2, $script:FailHost) | Get-IISCertificateBinding
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 3 -Exactly
+        }
+    }
+
+    # ── Context 9: Error isolation per machine ───────────────────────────────
+    Context 'Error isolation: a Failed host does not suppress successful host output' {
+
+        It 'Should return a Resolved row and a Failed row when two hosts have different health' {
+            $script:irlCallIdx = 0
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith {
+                $script:irlCallIdx++
+                if ($script:irlCallIdx -ge 2) { return $script:mockFailed }
+                return $script:mockResolved
+            }
+            $results = @(Get-IISCertificateBinding -ComputerName @($script:Host1, $script:FailHost))
+            $results.Count  | Should -Be 2
+            $results.Status | Should -Contain 'Resolved'
+            $results.Status | Should -Contain 'Failed'
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 2 -Exactly
+        }
+    }
+
+    # ── Context 10: SslFlags bitmask ─────────────────────────────────────────
+    Context 'SslFlags bitmask: SniEnabled and CentralCertStore derived from bit positions' {
+
+        It 'Should set SniEnabled=true when SslFlags bit 0 is set (SslFlags=1)' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName `
+                -MockWith { return $script:mockSNI }
+            $result = Get-IISCertificateBinding -ComputerName $script:Host1
+            $result.SslFlags   | Should -Be 1
+            $result.SniEnabled | Should -BeTrue
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should set SniEnabled=false and CentralCertStore=false when SslFlags=0' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName `
+                -MockWith { return $script:mockResolved }
+            $result = Get-IISCertificateBinding -ComputerName $script:Host1
+            $result.SniEnabled       | Should -BeFalse
+            $result.CentralCertStore | Should -BeFalse
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should populate HostHeader with the SNI hostname from BindingInformation' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName `
+                -MockWith { return $script:mockSNI }
+            $result = Get-IISCertificateBinding -ComputerName $script:Host1
+            $result.HostHeader | Should -Be 'sni.contoso.com'
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+    }
+
+    # ── Context 11: Expired certificate ──────────────────────────────────────
+    Context 'Expired certificate: Expired=true and negative DaysUntilExpiration surface correctly' {
+
+        It 'Should return Expired=true and negative DaysUntilExpiration for a past-due certificate' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName `
+                -MockWith { return $script:mockExpired }
+            $result = Get-IISCertificateBinding -ComputerName $script:Host1 -IncludeExpired
+            $result.Expired             | Should -BeTrue
+            $result.DaysUntilExpiration | Should -BeLessThan 0
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should still report Status=Resolved for an expired but store-present certificate' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName `
+                -MockWith { return $script:mockExpired }
+            $result = Get-IISCertificateBinding -ComputerName $script:Host1 -IncludeExpired
+            $result.Status     | Should -Be 'Resolved'
+            $result.Thumbprint | Should -Be $script:ExpiredThumb
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+    }
+
+    # ── Context 12: BOM and CRLF encoding ────────────────────────────────────
+    Context 'File encoding: UTF-8 BOM and CRLF line endings (project convention)' {
+
+        It 'Should begin with a UTF-8 BOM byte sequence (EF BB BF)' {
+            $bytes = [System.IO.File]::ReadAllBytes($script:testFilePath)
+            $bytes[0] | Should -Be 0xEF
+            $bytes[1] | Should -Be 0xBB
+            $bytes[2] | Should -Be 0xBF
+        }
+
+        It 'Should use CRLF line endings throughout the file' {
+            $raw = [System.IO.File]::ReadAllText($script:testFilePath)
+            $raw | Should -Match "`r`n"
+        }
+    }
+}

--- a/en-US/about_PSWinOps.help.txt
+++ b/en-US/about_PSWinOps.help.txt
@@ -84,12 +84,13 @@ FUNCTION DOMAINS
       Get-ServiceHealth
       Get-WSUSHealth
 
-  iis (6 functions)
+  iis (7 functions)
     Functions for managing IIS sites, HTTPS bindings,
     log file analysis, real-time log streaming, worker
     process monitoring, and in-flight request inspection
     across local or remote servers.
 
+      Get-IISCertificateBinding
       Get-IISCurrentRequest
       Get-IISFailedRequestTrace
       Get-IISParsedLog
@@ -288,7 +289,7 @@ REMOTE EXECUTION PATTERN
     in the pipeline continue to be processed.
 
 PSWINOPS TYPE REGISTRY
-    The following 91 PSTypeName values are defined by the
+    The following 92 PSTypeName values are defined by the
     module. Each corresponds to the output of one or more
     public functions.
 
@@ -334,6 +335,7 @@ PSWINOPS TYPE REGISTRY
       PSWinOps.FileServerHealth
       PSWinOps.HyperVHostHealth
       PSWinOps.IISBindingCertificateResult
+      PSWinOps.IISCertificateBinding
       PSWinOps.IISCurrentRequest
       PSWinOps.IISFailedRequestTrace
       PSWinOps.IISHealth


### PR DESCRIPTION
## Summary
Inventories every IIS HTTPS binding joined to the X509 certificate it actually presents. Read-only typed counterpart of `Set-IISBindingCertificate`: surfaces site, ip:port:hostheader, SNI/CCS flags, thumbprint, subject, SAN, issuer, validity window, days-until-expiration, certificate store of record and presence of the private key. Falls back gracefully from WebAdministration to IISAdministration to appcmd, and pipes cleanly into `Set-IISBindingCertificate` for rotation workflows.

## Files touched
- `Public/iis/Get-IISCertificateBinding.ps1` — implementation
- `Tests/Public/iis/Get-IISCertificateBinding.Tests.ps1` — Pester v5 suite
- `PSWinOps.psd1` — FunctionsToExport, ModuleVersion (0.1.6 → 0.1.7), ReleaseNotes
- `PSWinOps.Format.ps1xml` — new `<View>` for `PSWinOps.IISCertificateBinding`
- `en-US/about_PSWinOps.help.txt` — iis counter bumped (6 → 7)

## Conformance checklist (auto-audited by fn-quality-gate)
- [x] UTF-8 BOM + CRLF on all new files
- [x] Approved PowerShell verb (`Get-`)
- [x] `FunctionsToExport` alphabetically sorted (case-insensitive, repo convention)
- [x] `PSTypeName` `PSWinOps.IISCertificateBinding` consistent across .ps1 / Format.ps1xml / help
- [x] PSScriptAnalyzer clean (0 warnings) on changed paths
- [x] `Test-ModuleManifest` succeeds at 0.1.7
- [x] No `Write-Host`, no `ToString('o')` in diff
- [x] `<View>/<ViewSelectedBy>/<TypeName>` matches the function's emitted PSTypeName
- [x] XML well-formed (`PSWinOps.Format.ps1xml`)

> Pester suite is Windows-only (module guards against non-Windows hosts), so the full test run happens on the GitHub Actions Windows matrix — not locally on the Linux audit host.

## Auto-merge
✅ Armed via `gh pr merge --auto --squash --delete-branch`. Will merge automatically once all required Windows CI checks are green (branch protection on `main` has `strict=true` + the full Pester domain matrix as required contexts). Any failure is picked up by `pswinops-fn-ci-watcher`, which loops back through `pswinops-fn-author MODE=fix` (max 3 iterations).
