### PR TITLE
feat(iis): add Test-IISBindingCertificate

### DIFF
--- a/.kdust/chains/test-iisbindingcertificate-2605161427.yaml
+++ b/.kdust/chains/test-iisbindingcertificate-2605161427.yaml
@@ -1,0 +1,7 @@
+chain: pswinops-function-author
+function: Test-IISBindingCertificate
+domain: iis
+created: 2026-05-16T14:27:21Z
+created_by: pswinops-fn-spec-analyst
+chain_branch: kdust/chain/pswinops-fn-test-iisbindingcertificate-2605161426
+spec_path: work/test-iisbindingcertificate/spec.yaml

--- a/PSWinOps.Format.ps1xml
+++ b/PSWinOps.Format.ps1xml
@@ -7150,5 +7150,94 @@
         </TableRowEntries>
       </TableControl>
     </View>
+
+    <!-- ============================================================ -->
+    <!-- PSWinOps.IISCertificateBindingTestResult                     -->
+    <!-- Used by: Test-IISBindingCertificate                          -->
+    <!-- ============================================================ -->
+    <View>
+      <Name>PSWinOps.IISCertificateBindingTestResult</Name>
+      <ViewSelectedBy>
+        <TypeName>PSWinOps.IISCertificateBindingTestResult</TypeName>
+      </ViewSelectedBy>
+      <TableControl>
+        <AutoSize />
+        <TableHeaders>
+          <TableColumnHeader>
+            <Label>ComputerName</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>SiteName</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Binding</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>HostHeader</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>ExpirationStatus</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>DaysLeft</Label>
+            <Alignment>Right</Alignment>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>ChainValid</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>HostMatch</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>AlgorithmStrength</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>OverallStatus</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Status</Label>
+          </TableColumnHeader>
+        </TableHeaders>
+        <TableRowEntries>
+          <TableRowEntry>
+            <TableColumnItems>
+              <TableColumnItem>
+                <PropertyName>ComputerName</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>SiteName</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>BindingInformation</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>HostHeader</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>ExpirationStatus</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>DaysUntilExpiration</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>ChainValid</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>HostnameMatch</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>AlgorithmStrength</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>OverallStatus</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>Status</PropertyName>
+              </TableColumnItem>
+            </TableColumnItems>
+          </TableRowEntry>
+        </TableRowEntries>
+      </TableControl>
+    </View>
   </ViewDefinitions>
 </Configuration>

--- a/PSWinOps.psd1
+++ b/PSWinOps.psd1
@@ -189,6 +189,7 @@
         'Show-WindowsUpdate',
         'Sync-NTPTime',
         'Test-DNSResolution',
+        'Test-IISBindingCertificate',
         'Test-PortConnectivity',
         'Test-ProxyConnection',
         'Test-WinRM',

--- a/PSWinOps.psd1
+++ b/PSWinOps.psd1
@@ -12,7 +12,7 @@
     RootModule           = 'PSWinOps.psm1'
 
     # Version number of this module.
-    ModuleVersion        = '0.1.7'
+    ModuleVersion        = '0.1.8'
 
     # Supported PSEditions
     # Core is supported on Windows only; the module-level guard in PSWinOps.psm1 blocks
@@ -263,7 +263,12 @@
             # IconUri = ''
 
             # ReleaseNotes of this module
-            ReleaseNotes = '## 0.1.7 - 2026-05-16
+            ReleaseNotes = '## 0.1.8 - 2026-05-16
+### Added
+- feat(iis): add Test-IISBindingCertificate — read-only auditor that validates every IIS HTTPS binding certificate across six independent checks (expiration vs configurable Warning/Critical thresholds, X509Chain.Build() validity, hostname/SAN match against the binding host header, HasPrivateKey, signature/key-algorithm strength, and CertStoreName alignment); emits typed PSWinOps.IISCertificateBindingTestResult rows with per-binding OverallStatus (Pass/Warning/Critical/Fail) plus a Findings array describing every non-Pass condition; supports multi-host execution via Invoke-RemoteOrLocal with -Credential, -WarningDays/-CriticalDays thresholds, -SkipChainValidation for air-gapped hosts, optional -IncludeRevocationCheck (CRL/OCSP), and standard Status enum (Tested/IISNotInstalled/BindingNotFound/CertNotFound/Failed); pipes cleanly from Get-IISCertificateBinding for targeted re-test.
+- feat(format): TableControl view for PSWinOps.IISCertificateBindingTestResult in PSWinOps.Format.ps1xml.
+
+## 0.1.7 - 2026-05-16
 ### Added
 - feat(iis): add Get-IISCertificateBinding — read-only inventory of every IIS HTTPS binding joined to the X509 certificate it actually presents; emits typed PSWinOps.IISCertificateBinding objects with SiteName, BindingInformation (ip:port:hostheader), Protocol, SslFlags (SNI/CCS), Thumbprint, Subject, SubjectAlternativeName, Issuer, NotBefore/NotAfter, DaysUntilExpiration, Expired, CertificateStore and HasPrivateKey; multi-host execution via Invoke-RemoteOrLocal with -Credential; -SiteName/-HostHeader (-like) and -Thumbprint/-Port filters, plus -ExpiringInDays and -IncludeExpired for renewal audits; graceful WebAdministration → IISAdministration → appcmd fallback; pipes cleanly into Set-IISBindingCertificate for rotation workflows.
 - feat(format): TableControl view for PSWinOps.IISCertificateBinding in PSWinOps.Format.ps1xml.

--- a/Public/iis/Test-IISBindingCertificate.ps1
+++ b/Public/iis/Test-IISBindingCertificate.ps1
@@ -1,0 +1,886 @@
+﻿#Requires -Version 5.1
+function Test-IISBindingCertificate {
+    <#
+        .SYNOPSIS
+            Validates each IIS HTTPS binding certificate and emits a per-binding verdict (expiration, chain, hostname, key, store).
+
+        .DESCRIPTION
+            Inspects every https binding on one or more IIS hosts and evaluates the
+            associated X509 certificate across six independent checks: expiration
+            against configurable Warning/Critical thresholds, X509Chain.Build()
+            validity, hostname/SAN match against the binding host header, private
+            key availability, signature/key-algorithm strength, and alignment
+            between the binding's declared CertStoreName and the store where the
+            certificate is actually found. Each check contributes to a per-binding
+            OverallStatus (Pass/Warning/Critical/Fail) and a Findings array
+            describing every non-Pass condition. Complements Get-IISCertificateBinding
+            (inventory) with an actionable verdict that IISAdministration does not
+            expose. Falls back gracefully WebAdministration -> IISAdministration
+            -> appcmd, supports multi-host execution via Invoke-RemoteOrLocal,
+            and pipes cleanly from Get-IISCertificateBinding / Get-IISHealth.
+
+        .PARAMETER ComputerName
+            One or more computer names to query. Defaults to the local machine.
+            Accepts pipeline input by value and by property name.
+
+        .PARAMETER Credential
+            Optional PSCredential for authenticating to remote computers.
+            Not used for local queries.
+
+        .PARAMETER SiteName
+            Filter to one or more IIS site names. Supports -like wildcards.
+            Defaults to all https-bound sites.
+
+        .PARAMETER BindingInformation
+            Filter to specific ip:port:hostheader bindings. Supports -like wildcards.
+            Enables piping rows from Get-IISCertificateBinding for targeted re-tests.
+
+        .PARAMETER HostHeader
+            Filter on the host header part of the binding. Supports -like wildcards.
+
+        .PARAMETER Thumbprint
+            Filter to specific certificate thumbprints (40 hex characters, normalised
+            upper-case internally).
+
+        .PARAMETER WarningDays
+            DaysUntilExpiration threshold below which ExpirationStatus becomes Warning.
+            Must be greater than CriticalDays. Default: 30.
+
+        .PARAMETER CriticalDays
+            DaysUntilExpiration threshold below which ExpirationStatus becomes Critical.
+            Default: 7.
+
+        .PARAMETER MinKeySize
+            Minimum acceptable RSA/DSA key size in bits. ECDSA keys are evaluated
+            against a separate built-in baseline (>=256). Anything below MinKeySize
+            flags AlgorithmStrength=Weak. Default: 2048.
+
+        .PARAMETER SkipChainValidation
+            Skip X509Chain.Build() -- useful on hosts without internet access to
+            CRL/OCSP endpoints; ChainValid will be $null and ChainStatus empty.
+
+        .PARAMETER AllowSelfSigned
+            Do not downgrade OverallStatus when the chain ends in an untrusted root
+            if the certificate is self-signed (Issuer equals Subject).
+
+        .PARAMETER IncludeRevocationCheck
+            Enable X509RevocationMode.Online during chain build (default is NoCheck
+            for speed/offline-friendliness).
+
+        .EXAMPLE
+            Test-IISBindingCertificate
+
+            Audit every HTTPS binding on the local host with default thresholds.
+
+        .EXAMPLE
+            'WEB01','WEB02','WEB03' | Test-IISBindingCertificate -Credential (Get-Credential)
+
+            Audit a web farm using alternate credentials.
+
+        .EXAMPLE
+            Test-IISBindingCertificate -ComputerName WEB01 | Where-Object OverallStatus -ne 'Pass'
+
+            Surface only actionable verdicts.
+
+        .EXAMPLE
+            Test-IISBindingCertificate -ComputerName WEB01 -WarningDays 60 -CriticalDays 14
+
+            Tighten the expiration window for a renewal sweep.
+
+        .EXAMPLE
+            Test-IISBindingCertificate -ComputerName WEB01 -SkipChainValidation
+
+            Skip chain build on an offline / air-gapped host.
+
+        .EXAMPLE
+            Get-IISCertificateBinding -ComputerName WEB01 -SiteName www | Test-IISBindingCertificate
+
+            Re-test a specific binding piped from the inventory cmdlet.
+
+        .EXAMPLE
+            Test-IISBindingCertificate -ComputerName WEB01 -IncludeRevocationCheck
+
+            Enable online revocation (CRL/OCSP) for a compliance run.
+
+        .OUTPUTS
+            PSCustomObject (PSTypeName='PSWinOps.IISCertificateBindingTestResult')
+
+        .NOTES
+            Author: Franck SALLET
+            Version: 1.0.0
+            Last Modified: 2026-05-16
+            Requires: PowerShell 5.1+ / Windows only
+            Requires: Web-Server (IIS) role
+            Optional: Module WebAdministration or IISAdministration (falls back to appcmd)
+
+        .LINK
+            https://github.com/k9fr4n/PSWinOps
+
+        .LINK
+            https://learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.x509certificates.x509chain
+    #>
+    [CmdletBinding()]
+    [OutputType('PSWinOps.IISCertificateBindingTestResult')]
+    param(
+        [Parameter(Mandatory = $false, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [ValidateNotNullOrEmpty()]
+        [Alias('CN', 'Name', 'DNSHostName')]
+        [string[]]$ComputerName = $env:COMPUTERNAME,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateNotNull()]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential,
+
+        [Parameter(Mandatory = $false, ValueFromPipelineByPropertyName = $true)]
+        [string[]]$SiteName,
+
+        [Parameter(Mandatory = $false, ValueFromPipelineByPropertyName = $true)]
+        [string[]]$BindingInformation,
+
+        [Parameter(Mandatory = $false)]
+        [string[]]$HostHeader,
+
+        [Parameter(Mandatory = $false, ValueFromPipelineByPropertyName = $true)]
+        [ValidatePattern('^[A-Fa-f0-9]{40}$')]
+        [string[]]$Thumbprint,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateRange(1, 3650)]
+        [int]$WarningDays = 30,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateRange(0, 3650)]
+        [int]$CriticalDays = 7,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateSet(1024, 2048, 3072, 4096)]
+        [int]$MinKeySize = 2048,
+
+        [Parameter(Mandatory = $false)]
+        [switch]$SkipChainValidation,
+
+        [Parameter(Mandatory = $false)]
+        [switch]$AllowSelfSigned,
+
+        [Parameter(Mandatory = $false)]
+        [switch]$IncludeRevocationCheck
+    )
+
+    begin {
+        Write-Verbose -Message "[$($MyInvocation.MyCommand)] Starting"
+
+        if ($PSBoundParameters.ContainsKey('WarningDays') -and $PSBoundParameters.ContainsKey('CriticalDays')) {
+            if ($WarningDays -le $CriticalDays) {
+                throw [System.ArgumentException]::new(
+                    "WarningDays ($WarningDays) must be greater than CriticalDays ($CriticalDays)."
+                )
+            }
+        }
+
+        $scriptBlock = {
+            param(
+                [string[]]$FilterSiteName,
+                [string[]]$FilterBindingInformation,
+                [string[]]$FilterHostHeader,
+                [string[]]$FilterThumbprint,
+                [int]$PWarningDays,
+                [int]$PCriticalDays,
+                [int]$PMinKeySize,
+                [bool]$PSkipChainValidation,
+                [bool]$PAllowSelfSigned,
+                [bool]$PIncludeRevocationCheck
+            )
+
+            $results = [System.Collections.Generic.List[hashtable]]::new()
+            $tsNow   = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
+            $now     = [datetime]::UtcNow
+
+            # ── 1. Verify W3SVC / IIS installed ───────────────────────────────
+            try {
+                $null = Get-Service -Name 'W3SVC' -ErrorAction Stop
+            }
+            catch {
+                $results.Add(@{
+                    ComputerName           = $env:COMPUTERNAME
+                    SiteName               = $null; BindingInformation = $null; Protocol = $null
+                    Port                   = $null; HostHeader = $null; SslFlags = $null
+                    Thumbprint             = $null; Subject = $null; SubjectAlternativeName = @()
+                    Issuer                 = $null; NotBefore = $null; NotAfter = $null
+                    DaysUntilExpiration    = $null; ExpirationStatus = $null
+                    ChainValid             = $null; ChainStatus = @()
+                    HostnameMatch          = $null; HasPrivateKey = $null
+                    SignatureAlgorithm     = $null; KeyAlgorithm = $null; KeySize = $null
+                    AlgorithmStrength      = $null; CertificateStore = $null; StoreAligned = $null
+                    OverallStatus          = 'Fail'; Findings = @()
+                    Status                 = 'IISNotInstalled'
+                    ErrorMessage           = "W3SVC service not found: $($_.Exception.Message)"
+                    Timestamp              = $tsNow
+                })
+                return $results
+            }
+
+            # ── 2. Detect IIS module chain ─────────────────────────────────────
+            $iisModule = $null
+            if (Get-Module -Name 'WebAdministration' -ListAvailable -ErrorAction SilentlyContinue) {
+                $iisModule = 'WebAdministration'
+            }
+            elseif (Get-Module -Name 'IISAdministration' -ListAvailable -ErrorAction SilentlyContinue) {
+                $iisModule = 'IISAdministration'
+            }
+
+            # ── 3. Collect raw binding descriptors (https only) ────────────────
+            $bindingRows = [System.Collections.Generic.List[hashtable]]::new()
+
+            if ($iisModule -eq 'WebAdministration') {
+                try {
+                    Import-Module -Name 'WebAdministration' -ErrorAction Stop
+                    $allSites = @(Get-Website -ErrorAction Stop)
+
+                    if ($FilterSiteName) {
+                        $allSites = @($allSites | Where-Object {
+                            $sn = $_.Name
+                            $null -ne ($FilterSiteName | Where-Object { $sn -like $_ })
+                        })
+                    }
+
+                    foreach ($site in $allSites) {
+                        $httpsBindings = @(
+                            Get-WebBinding -Name $site.Name -Protocol 'https' -ErrorAction SilentlyContinue
+                        )
+                        foreach ($b in $httpsBindings) {
+                            $rawTp = $b.certificateHash
+                            $tpStr = if ($rawTp) {
+                                ($rawTp -split '(?<=\G.{2})' | Where-Object { $_ -ne '' }) -join ''
+                            }
+                            else { $null }
+                            $bindingRows.Add(@{
+                                SiteNameVal    = $site.Name
+                                BindingInfoVal = $b.bindingInformation
+                                SslFlagsVal    = [int]$b.sslFlags
+                                StoreNameVal   = $b.certificateStoreName
+                                ThumbprintVal  = if ($tpStr) { $tpStr.ToUpperInvariant() } else { $null }
+                            })
+                        }
+                    }
+                }
+                catch {
+                    $results.Add(@{
+                        ComputerName           = $env:COMPUTERNAME
+                        SiteName               = $null; BindingInformation = $null; Protocol = $null
+                        Port                   = $null; HostHeader = $null; SslFlags = $null
+                        Thumbprint             = $null; Subject = $null; SubjectAlternativeName = @()
+                        Issuer                 = $null; NotBefore = $null; NotAfter = $null
+                        DaysUntilExpiration    = $null; ExpirationStatus = $null
+                        ChainValid             = $null; ChainStatus = @()
+                        HostnameMatch          = $null; HasPrivateKey = $null
+                        SignatureAlgorithm     = $null; KeyAlgorithm = $null; KeySize = $null
+                        AlgorithmStrength      = $null; CertificateStore = $null; StoreAligned = $null
+                        OverallStatus          = 'Fail'; Findings = @()
+                        Status                 = 'Failed'
+                        ErrorMessage           = "WebAdministration error: $($_.Exception.Message)"
+                        Timestamp              = $tsNow
+                    })
+                    return $results
+                }
+            }
+            elseif ($iisModule -eq 'IISAdministration') {
+                try {
+                    Import-Module -Name 'IISAdministration' -ErrorAction Stop
+                    $allSites = @(Get-IISSite -ErrorAction Stop)
+
+                    if ($FilterSiteName) {
+                        $allSites = @($allSites | Where-Object {
+                            $sn = $_.Name
+                            $null -ne ($FilterSiteName | Where-Object { $sn -like $_ })
+                        })
+                    }
+
+                    foreach ($site in $allSites) {
+                        foreach ($b in ($site.Bindings | Where-Object { $_.Protocol -eq 'https' })) {
+                            $rawHash = $b.CertificateHash
+                            $tpStr = if ($rawHash -and $rawHash.Count -gt 0) {
+                                ($rawHash | ForEach-Object { $_.ToString('X2') }) -join ''
+                            }
+                            else { $null }
+                            $sslFlagsInt = try { [int]$b.SslFlags } catch { 0 }
+                            $bindingRows.Add(@{
+                                SiteNameVal    = $site.Name
+                                BindingInfoVal = $b.BindingInformation
+                                SslFlagsVal    = $sslFlagsInt
+                                StoreNameVal   = $b.CertificateStoreName
+                                ThumbprintVal  = if ($tpStr) { $tpStr.ToUpperInvariant() } else { $null }
+                            })
+                        }
+                    }
+                }
+                catch {
+                    $results.Add(@{
+                        ComputerName           = $env:COMPUTERNAME
+                        SiteName               = $null; BindingInformation = $null; Protocol = $null
+                        Port                   = $null; HostHeader = $null; SslFlags = $null
+                        Thumbprint             = $null; Subject = $null; SubjectAlternativeName = @()
+                        Issuer                 = $null; NotBefore = $null; NotAfter = $null
+                        DaysUntilExpiration    = $null; ExpirationStatus = $null
+                        ChainValid             = $null; ChainStatus = @()
+                        HostnameMatch          = $null; HasPrivateKey = $null
+                        SignatureAlgorithm     = $null; KeyAlgorithm = $null; KeySize = $null
+                        AlgorithmStrength      = $null; CertificateStore = $null; StoreAligned = $null
+                        OverallStatus          = 'Fail'; Findings = @()
+                        Status                 = 'Failed'
+                        ErrorMessage           = "IISAdministration error: $($_.Exception.Message)"
+                        Timestamp              = $tsNow
+                    })
+                    return $results
+                }
+            }
+            else {
+                # appcmd fallback
+                $appcmdExe = Join-Path -Path $env:windir -ChildPath 'system32\inetsrv\appcmd.exe'
+                if (-not (Test-Path -LiteralPath $appcmdExe -PathType Leaf)) {
+                    $results.Add(@{
+                        ComputerName           = $env:COMPUTERNAME
+                        SiteName               = $null; BindingInformation = $null; Protocol = $null
+                        Port                   = $null; HostHeader = $null; SslFlags = $null
+                        Thumbprint             = $null; Subject = $null; SubjectAlternativeName = @()
+                        Issuer                 = $null; NotBefore = $null; NotAfter = $null
+                        DaysUntilExpiration    = $null; ExpirationStatus = $null
+                        ChainValid             = $null; ChainStatus = @()
+                        HostnameMatch          = $null; HasPrivateKey = $null
+                        SignatureAlgorithm     = $null; KeyAlgorithm = $null; KeySize = $null
+                        AlgorithmStrength      = $null; CertificateStore = $null; StoreAligned = $null
+                        OverallStatus          = 'Fail'; Findings = @()
+                        Status                 = 'IISNotInstalled'
+                        ErrorMessage           = 'Neither WebAdministration nor IISAdministration module is available, and appcmd.exe was not found.'
+                        Timestamp              = $tsNow
+                    })
+                    return $results
+                }
+
+                try {
+                    [xml]$sitesXml = & $appcmdExe list sites /config:* /xml 2>$null
+                    foreach ($siteNode in $sitesXml.appcmd.SITE) {
+                        $siteName = $siteNode.'SITE.NAME'
+                        if ($FilterSiteName) {
+                            $snMatch = $FilterSiteName | Where-Object { $siteName -like $_ }
+                            if (-not $snMatch) { continue }
+                        }
+                        foreach ($bNode in $siteNode.site.bindings.binding) {
+                            if ($bNode.protocol -ne 'https') { continue }
+                            $bindingRows.Add(@{
+                                SiteNameVal    = $siteName
+                                BindingInfoVal = $bNode.bindingInformation
+                                SslFlagsVal    = 0
+                                StoreNameVal   = 'My'
+                                ThumbprintVal  = $null
+                            })
+                        }
+                    }
+                    # Enrich thumbprints via netsh sslcert
+                    $netshOut   = & netsh http show sslcert 2>$null
+                    $netshBlock = ($netshOut -join "`n")
+                    $netshRx    = [regex]'IP:port\s+:\s+(\S+)[\s\S]*?Certificate Hash\s+:\s+([0-9a-fA-F]+)'
+                    foreach ($nm in $netshRx.Matches($netshBlock)) {
+                        $epPort = ($nm.Groups[1].Value -split ':')[-1]
+                        $tpVal  = $nm.Groups[2].Value.ToUpperInvariant()
+                        foreach ($row in $bindingRows) {
+                            $rParts = $row.BindingInfoVal -split ':'
+                            $rPort  = if ($rParts.Count -ge 2) { $rParts[-2] } else { '' }
+                            if ($rPort -eq $epPort -and -not $row.ThumbprintVal) {
+                                $row.ThumbprintVal = $tpVal
+                            }
+                        }
+                    }
+                }
+                catch {
+                    $results.Add(@{
+                        ComputerName           = $env:COMPUTERNAME
+                        SiteName               = $null; BindingInformation = $null; Protocol = $null
+                        Port                   = $null; HostHeader = $null; SslFlags = $null
+                        Thumbprint             = $null; Subject = $null; SubjectAlternativeName = @()
+                        Issuer                 = $null; NotBefore = $null; NotAfter = $null
+                        DaysUntilExpiration    = $null; ExpirationStatus = $null
+                        ChainValid             = $null; ChainStatus = @()
+                        HostnameMatch          = $null; HasPrivateKey = $null
+                        SignatureAlgorithm     = $null; KeyAlgorithm = $null; KeySize = $null
+                        AlgorithmStrength      = $null; CertificateStore = $null; StoreAligned = $null
+                        OverallStatus          = 'Fail'; Findings = @()
+                        Status                 = 'Failed'
+                        ErrorMessage           = "appcmd fallback error: $($_.Exception.Message)"
+                        Timestamp              = $tsNow
+                    })
+                    return $results
+                }
+            }
+
+            # ── 4. No bindings found ───────────────────────────────────────────
+            if ($bindingRows.Count -eq 0) {
+                $results.Add(@{
+                    ComputerName           = $env:COMPUTERNAME
+                    SiteName               = $null; BindingInformation = $null; Protocol = 'https'
+                    Port                   = $null; HostHeader = $null; SslFlags = $null
+                    Thumbprint             = $null; Subject = $null; SubjectAlternativeName = @()
+                    Issuer                 = $null; NotBefore = $null; NotAfter = $null
+                    DaysUntilExpiration    = $null; ExpirationStatus = $null
+                    ChainValid             = $null; ChainStatus = @()
+                    HostnameMatch          = $null; HasPrivateKey = $null
+                    SignatureAlgorithm     = $null; KeyAlgorithm = $null; KeySize = $null
+                    AlgorithmStrength      = $null; CertificateStore = $null; StoreAligned = $null
+                    OverallStatus          = 'Fail'; Findings = @()
+                    Status                 = 'BindingNotFound'
+                    ErrorMessage           = 'No https bindings found on this host.'
+                    Timestamp              = $tsNow
+                })
+                return $results
+            }
+
+            # ── 5. Test each binding ──────────────────────────────────────────
+            foreach ($br in $bindingRows) {
+                $bindInfo = $br.BindingInfoVal
+
+                # Parse BindingInformation: ip:port:hostheader (handles IPv6)
+                $bParts     = $bindInfo -split ':'
+                $bHostHeader = ''
+                $bPort       = 443
+                if ($bParts.Count -ge 2) {
+                    $bHostHeader = $bParts[-1]
+                    $bPort       = [int]$bParts[-2]
+                }
+
+                # Normalise SslFlags
+                $sslFlagsStr = switch ($br.SslFlagsVal) {
+                    0 { 'None' }
+                    1 { 'Sni' }
+                    2 { 'CentralCertStore' }
+                    3 { 'Sni+CentralCertStore' }
+                    default { $br.SslFlagsVal.ToString() }
+                }
+
+                # Apply filters
+                if ($FilterBindingInformation) {
+                    $bim = $bindInfo
+                    $bimMatch = $FilterBindingInformation | Where-Object { $bim -like $_ }
+                    if (-not $bimMatch) { continue }
+                }
+                if ($FilterHostHeader) {
+                    $bhhLocal = $bHostHeader
+                    $bhhMatch = $FilterHostHeader | Where-Object { $bhhLocal -like $_ }
+                    if (-not $bhhMatch) { continue }
+                }
+
+                $thumbprintUp = if ($br.ThumbprintVal) { $br.ThumbprintVal.ToUpperInvariant() } else { '' }
+                if ($FilterThumbprint) {
+                    $tpMatch = $FilterThumbprint | Where-Object { $thumbprintUp -ieq $_ }
+                    if (-not $tpMatch) { continue }
+                }
+
+                $certStoreName = if ($br.StoreNameVal) { $br.StoreNameVal } else { 'My' }
+
+                # ── Find certificate in LocalMachine stores ───────────────────
+                $cert           = $null
+                $actualStore    = $null
+                $storeAligned   = $false
+
+                if ($thumbprintUp) {
+                    foreach ($storeName in @('My', 'WebHosting', 'CA', 'Root')) {
+                        try {
+                            $store = [System.Security.Cryptography.X509Certificates.X509Store]::new(
+                                $storeName,
+                                [System.Security.Cryptography.X509Certificates.StoreLocation]::LocalMachine
+                            )
+                            $store.Open(
+                                [System.Security.Cryptography.X509Certificates.OpenFlags]::ReadOnly
+                            )
+                            $found = $store.Certificates |
+                                Where-Object { $_.Thumbprint -ieq $thumbprintUp } |
+                                Select-Object -First 1
+                            $store.Close()
+                            if ($found) {
+                                $cert         = $found
+                                $actualStore  = "LocalMachine\$storeName"
+                                $storeAligned = ($storeName -ieq $certStoreName)
+                                break
+                            }
+                        }
+                        catch {
+                            Write-Verbose -Message "[$($MyInvocation.MyCommand)] Could not search store '$storeName': $_"
+                        }
+                    }
+                }
+
+                if (-not $cert) {
+                    $results.Add(@{
+                        ComputerName           = $env:COMPUTERNAME
+                        SiteName               = $br.SiteNameVal
+                        BindingInformation     = $bindInfo
+                        Protocol               = 'https'
+                        Port                   = $bPort
+                        HostHeader             = $bHostHeader
+                        SslFlags               = $sslFlagsStr
+                        Thumbprint             = $thumbprintUp
+                        Subject                = $null; SubjectAlternativeName = @()
+                        Issuer                 = $null; NotBefore = $null; NotAfter = $null
+                        DaysUntilExpiration    = $null; ExpirationStatus = $null
+                        ChainValid             = $null; ChainStatus = @()
+                        HostnameMatch          = $null; HasPrivateKey = $null
+                        SignatureAlgorithm     = $null; KeyAlgorithm = $null; KeySize = $null
+                        AlgorithmStrength      = $null; CertificateStore = $null; StoreAligned = $null
+                        OverallStatus          = 'Fail'; Findings = @()
+                        Status                 = 'CertNotFound'
+                        ErrorMessage           = "Certificate with thumbprint '$thumbprintUp' not found in any LocalMachine store."
+                        Timestamp              = $tsNow
+                    })
+                    continue
+                }
+
+                $findings = [System.Collections.Generic.List[string]]::new()
+
+                # ── Check 1 : Expiration ──────────────────────────────────────
+                $notBefore = $cert.NotBefore
+                $notAfter  = $cert.NotAfter
+                $daysLeft  = [int][math]::Floor(($notAfter.ToUniversalTime() - $now).TotalDays)
+
+                $expirationStatus = if ($notAfter.ToUniversalTime() -le $now) {
+                    [void]$findings.Add("Certificate expired on $($notAfter.ToString('yyyy-MM-dd HH:mm:ss'))")
+                    'Expired'
+                }
+                elseif ($notBefore.ToUniversalTime() -gt $now) {
+                    [void]$findings.Add("Certificate not yet valid (NotBefore: $($notBefore.ToString('yyyy-MM-dd HH:mm:ss')))")
+                    'NotYetValid'
+                }
+                elseif ($daysLeft -le $PCriticalDays) {
+                    [void]$findings.Add("Certificate expires in $daysLeft day(s) (Critical threshold: $PCriticalDays)")
+                    'Critical'
+                }
+                elseif ($daysLeft -le $PWarningDays) {
+                    [void]$findings.Add("Certificate expires in $daysLeft day(s) (Warning threshold: $PWarningDays)")
+                    'Warning'
+                }
+                else {
+                    'OK'
+                }
+
+                # ── Check 2 : Chain ───────────────────────────────────────────
+                $chainValid  = $null
+                $chainStatus = @()
+
+                if (-not $PSkipChainValidation) {
+                    try {
+                        $chain = [System.Security.Cryptography.X509Certificates.X509Chain]::new()
+                        $chain.ChainPolicy.RevocationMode = if ($PIncludeRevocationCheck) {
+                            [System.Security.Cryptography.X509Certificates.X509RevocationMode]::Online
+                        }
+                        else {
+                            [System.Security.Cryptography.X509Certificates.X509RevocationMode]::NoCheck
+                        }
+                        $chainValid = $chain.Build($cert)
+
+                        if (-not $chainValid) {
+                            $chainStatus = @(
+                                $chain.ChainStatus | ForEach-Object { $_.Status.ToString() }
+                            )
+                            $isSelfSigned = ($cert.Subject -eq $cert.Issuer)
+                            $onlyUntrustedRoot = (
+                                $chainStatus.Count -gt 0 -and
+                                ($chainStatus | Where-Object { $_ -ne 'UntrustedRoot' }).Count -eq 0
+                            )
+                            if ($PAllowSelfSigned -and $isSelfSigned -and $onlyUntrustedRoot) {
+                                $chainValid  = $true
+                                $chainStatus = @()
+                            }
+                            else {
+                                [void]$findings.Add("Chain build failed: $($chainStatus -join ', ')")
+                            }
+                        }
+                        $chain.Dispose()
+                    }
+                    catch {
+                        $chainValid  = $false
+                        $chainStatus = @("Exception: $($_.Exception.Message)")
+                        [void]$findings.Add("Chain validation threw an exception: $($_.Exception.Message)")
+                    }
+                }
+
+                # ── Check 3 : Hostname match ──────────────────────────────────
+                $hostnameMatch = $true
+                if (-not [string]::IsNullOrEmpty($bHostHeader)) {
+                    $nameToTest = $bHostHeader.ToLowerInvariant()
+
+                    $certNames = [System.Collections.Generic.List[string]]::new()
+                    $cnRegex   = [regex]::Match($cert.Subject, '(?i)CN=([^,]+)')
+                    if ($cnRegex.Success) {
+                        [void]$certNames.Add($cnRegex.Groups[1].Value.Trim())
+                    }
+
+                    $sanExtension = $cert.Extensions |
+                        Where-Object { $_.Oid.FriendlyName -eq 'Subject Alternative Name' }
+                    if ($sanExtension) {
+                        $sanExtension.Format($false) -split ', ' |
+                            Where-Object { $_ -like 'DNS Name=*' } |
+                            ForEach-Object { [void]$certNames.Add(($_ -split '=', 2)[1]) }
+                    }
+
+                    $hostnameMatch = $false
+                    foreach ($certName in $certNames) {
+                        $p = $certName.ToLowerInvariant()
+                        if ($p.StartsWith('*.')) {
+                            $suffix = $p.Substring(1)
+                            if ($nameToTest.EndsWith($suffix)) {
+                                $label = $nameToTest.Substring(0, $nameToTest.Length - $suffix.Length)
+                                if ($label -notmatch '\.') {
+                                    $hostnameMatch = $true
+                                    break
+                                }
+                            }
+                        }
+                        elseif ($nameToTest -eq $p) {
+                            $hostnameMatch = $true
+                            break
+                        }
+                    }
+
+                    if (-not $hostnameMatch) {
+                        [void]$findings.Add(
+                            "Hostname '$bHostHeader' does not match any certificate CN or SAN ($($certNames -join ', '))"
+                        )
+                    }
+                }
+
+                # ── Check 4 : Private key ─────────────────────────────────────
+                $hasPrivateKey = $cert.HasPrivateKey
+                if (-not $hasPrivateKey) {
+                    [void]$findings.Add('Certificate does not have an associated private key in this store')
+                }
+
+                # ── Check 5 : Algorithm strength ──────────────────────────────
+                $sigAlgFriendly = $cert.SignatureAlgorithm.FriendlyName
+                $keyAlgOid      = $cert.PublicKey.Oid.FriendlyName
+
+                $keyAlg = switch ($keyAlgOid) {
+                    'RSA' { 'RSA' }
+                    'ECC' { 'ECDSA' }
+                    'DSA' { 'DSA' }
+                    default { $keyAlgOid }
+                }
+
+                $keySize = 0
+                try {
+                    if ($keyAlg -eq 'ECDSA') {
+                        $ecKey = [System.Security.Cryptography.X509Certificates.ECDsaCertificateExtensions]::GetECDsaPublicKey($cert)
+                        if ($ecKey) { $keySize = $ecKey.KeySize }
+                    }
+                    else {
+                        $keySize = $cert.PublicKey.Key.KeySize
+                    }
+                }
+                catch { $keySize = 0 }
+
+                $sigHash = if ($sigAlgFriendly -imatch 'sha512') { 'SHA512' }
+                elseif ($sigAlgFriendly -imatch 'sha384') { 'SHA384' }
+                elseif ($sigAlgFriendly -imatch 'sha256') { 'SHA256' }
+                elseif ($sigAlgFriendly -imatch 'sha1') { 'SHA1' }
+                elseif ($sigAlgFriendly -imatch 'md5') { 'MD5' }
+                else { 'Unknown' }
+
+                $goodHash = $sigHash -in @('SHA256', 'SHA384', 'SHA512')
+
+                $algStrength = if ($sigHash -in @('MD5', 'SHA1', 'Unknown') -or $keySize -eq 0) {
+                    'Weak'
+                }
+                elseif ($keyAlg -eq 'ECDSA') {
+                    if ($keySize -ge 384 -and $goodHash) { 'Strong' }
+                    elseif ($keySize -ge 256 -and $goodHash) { 'Acceptable' }
+                    else { 'Weak' }
+                }
+                elseif ($keyAlg -in @('RSA', 'DSA')) {
+                    if ($keySize -lt $PMinKeySize) { 'Weak' }
+                    elseif ($keySize -ge 3072 -and $goodHash) { 'Strong' }
+                    elseif ($keySize -ge 2048 -and $goodHash) { 'Acceptable' }
+                    else { 'Weak' }
+                }
+                else { 'Weak' }
+
+                if ($algStrength -eq 'Weak') {
+                    [void]$findings.Add(
+                        "Algorithm strength Weak: $keyAlg $keySize-bit, signature $sigAlgFriendly"
+                    )
+                }
+                elseif ($algStrength -eq 'Acceptable') {
+                    [void]$findings.Add(
+                        "Algorithm strength Acceptable: $keyAlg $keySize-bit (consider upgrading to 3072+)"
+                    )
+                }
+
+                # ── Check 6 : Store alignment ─────────────────────────────────
+                if (-not $storeAligned) {
+                    [void]$findings.Add(
+                        "Store misalignment: binding declares '$certStoreName' but certificate found in '$actualStore'"
+                    )
+                }
+
+                # ── Collect SANs for output ───────────────────────────────────
+                $outSANs     = @()
+                $sanExtOut   = $cert.Extensions |
+                    Where-Object { $_.Oid.FriendlyName -eq 'Subject Alternative Name' }
+                if ($sanExtOut) {
+                    $outSANs = @(
+                        $sanExtOut.Format($false) -split ', ' |
+                            Where-Object { $_ -like 'DNS Name=*' } |
+                            ForEach-Object { ($_ -split '=', 2)[1] }
+                    )
+                }
+
+                # ── Compute OverallStatus ─────────────────────────────────────
+                $isCriticalExp = $expirationStatus -in @('Critical', 'Expired', 'NotYetValid')
+                $chainFail     = ($null -ne $chainValid) -and (-not $chainValid)
+
+                $overallStatus = if (
+                    $isCriticalExp -or
+                    (-not $hostnameMatch) -or
+                    (-not $hasPrivateKey) -or
+                    $chainFail -or
+                    ($algStrength -eq 'Weak') -or
+                    (-not $storeAligned)
+                ) {
+                    'Critical'
+                }
+                elseif ($expirationStatus -eq 'Warning' -or $algStrength -eq 'Acceptable') {
+                    'Warning'
+                }
+                else {
+                    'Pass'
+                }
+
+                $results.Add(@{
+                    ComputerName           = $env:COMPUTERNAME
+                    SiteName               = $br.SiteNameVal
+                    BindingInformation     = $bindInfo
+                    Protocol               = 'https'
+                    Port                   = $bPort
+                    HostHeader             = $bHostHeader
+                    SslFlags               = $sslFlagsStr
+                    Thumbprint             = $thumbprintUp
+                    Subject                = $cert.Subject
+                    SubjectAlternativeName = $outSANs
+                    Issuer                 = $cert.Issuer
+                    NotBefore              = $notBefore
+                    NotAfter               = $notAfter
+                    DaysUntilExpiration    = $daysLeft
+                    ExpirationStatus       = $expirationStatus
+                    ChainValid             = $chainValid
+                    ChainStatus            = $chainStatus
+                    HostnameMatch          = $hostnameMatch
+                    HasPrivateKey          = $hasPrivateKey
+                    SignatureAlgorithm     = $sigAlgFriendly
+                    KeyAlgorithm           = $keyAlg
+                    KeySize                = $keySize
+                    AlgorithmStrength      = $algStrength
+                    CertificateStore       = $actualStore
+                    StoreAligned           = $storeAligned
+                    OverallStatus          = $overallStatus
+                    Findings               = @($findings)
+                    Status                 = 'Tested'
+                    ErrorMessage           = $null
+                    Timestamp              = $tsNow
+                })
+            }
+
+            if ($results.Count -eq 0) {
+                $results.Add(@{
+                    ComputerName           = $env:COMPUTERNAME
+                    SiteName               = $null; BindingInformation = $null; Protocol = 'https'
+                    Port                   = $null; HostHeader = $null; SslFlags = $null
+                    Thumbprint             = $null; Subject = $null; SubjectAlternativeName = @()
+                    Issuer                 = $null; NotBefore = $null; NotAfter = $null
+                    DaysUntilExpiration    = $null; ExpirationStatus = $null
+                    ChainValid             = $null; ChainStatus = @()
+                    HostnameMatch          = $null; HasPrivateKey = $null
+                    SignatureAlgorithm     = $null; KeyAlgorithm = $null; KeySize = $null
+                    AlgorithmStrength      = $null; CertificateStore = $null; StoreAligned = $null
+                    OverallStatus          = 'Fail'; Findings = @()
+                    Status                 = 'BindingNotFound'
+                    ErrorMessage           = 'No https bindings matched the supplied filters on this host.'
+                    Timestamp              = $tsNow
+                })
+            }
+
+            return $results
+        }
+    }
+
+    process {
+        foreach ($cn in $ComputerName) {
+            $tpNorm = if ($Thumbprint) {
+                @($Thumbprint | ForEach-Object { $_.ToUpperInvariant() })
+            }
+            else { $null }
+
+            $invokeParams = @{
+                ComputerName = $cn
+                ScriptBlock  = $scriptBlock
+                ArgumentList = @(
+                    $SiteName,
+                    $BindingInformation,
+                    $HostHeader,
+                    $tpNorm,
+                    $WarningDays,
+                    $CriticalDays,
+                    $MinKeySize,
+                    $SkipChainValidation.IsPresent,
+                    $AllowSelfSigned.IsPresent,
+                    $IncludeRevocationCheck.IsPresent
+                )
+            }
+            if ($Credential) {
+                $invokeParams['Credential'] = $Credential
+            }
+
+            try {
+                $rawResults = Invoke-RemoteOrLocal @invokeParams
+                foreach ($r in $rawResults) {
+                    [PSCustomObject]([ordered]@{
+                        PSTypeName             = 'PSWinOps.IISCertificateBindingTestResult'
+                        ComputerName           = $r.ComputerName
+                        SiteName               = $r.SiteName
+                        BindingInformation     = $r.BindingInformation
+                        Protocol               = $r.Protocol
+                        Port                   = $r.Port
+                        HostHeader             = $r.HostHeader
+                        SslFlags               = $r.SslFlags
+                        Thumbprint             = $r.Thumbprint
+                        Subject                = $r.Subject
+                        SubjectAlternativeName = $r.SubjectAlternativeName
+                        Issuer                 = $r.Issuer
+                        NotBefore              = $r.NotBefore
+                        NotAfter               = $r.NotAfter
+                        DaysUntilExpiration    = $r.DaysUntilExpiration
+                        ExpirationStatus       = $r.ExpirationStatus
+                        ChainValid             = $r.ChainValid
+                        ChainStatus            = $r.ChainStatus
+                        HostnameMatch          = $r.HostnameMatch
+                        HasPrivateKey          = $r.HasPrivateKey
+                        SignatureAlgorithm     = $r.SignatureAlgorithm
+                        KeyAlgorithm           = $r.KeyAlgorithm
+                        KeySize                = $r.KeySize
+                        AlgorithmStrength      = $r.AlgorithmStrength
+                        CertificateStore       = $r.CertificateStore
+                        StoreAligned           = $r.StoreAligned
+                        OverallStatus          = $r.OverallStatus
+                        Findings               = $r.Findings
+                        Status                 = $r.Status
+                        ErrorMessage           = $r.ErrorMessage
+                        Timestamp              = $r.Timestamp
+                    })
+                }
+            }
+            catch {
+                Write-Error -Message "[$($MyInvocation.MyCommand)] Failed on '$cn': $_"
+            }
+        }
+    }
+
+    end {
+        Write-Verbose -Message "[$($MyInvocation.MyCommand)] Completed"
+    }
+}

--- a/Tests/Public/iis/Test-IISBindingCertificate.Tests.ps1
+++ b/Tests/Public/iis/Test-IISBindingCertificate.Tests.ps1
@@ -1,0 +1,890 @@
+﻿#Requires -Version 5.1
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSUseDeclaredVarsMoreThanAssignments', '',
+    Justification = 'Script-scoped variables are assigned in BeforeAll and referenced across nested It scopes'
+)]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSAvoidUsingConvertToSecureStringWithPlainText', '',
+    Justification = 'Test fixture only -- not a real credential'
+)]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSAvoidUsingComputerNameHardcoded', '',
+    Justification = 'Fake target names used exclusively in test fixtures -- no real machines are contacted'
+)]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSReviewUnusedParameter', '',
+    Justification = 'Stub parameters declared to satisfy the Pester mock engine (PR #42) but have no body'
+)]
+param()
+
+BeforeAll {
+    $script:modulePath = Split-Path -Path (Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent) -Parent
+    $script:testFilePath = $PSCommandPath
+
+    # PSWinOps is Windows-only. On Linux/macOS the psm1 guard throws, so we build an
+    # in-memory 'PSWinOps' module containing Invoke-RemoteOrLocal and
+    # Test-IISBindingCertificate so that Pester's -ModuleName 'PSWinOps' mock scope
+    # works on all platforms (same pattern as Watch-IISLog.Tests.ps1).
+    if ($IsWindows -or $PSEdition -eq 'Desktop') {
+        Import-Module -Name (Join-Path -Path $script:modulePath -ChildPath 'PSWinOps.psd1') -Force
+    } else {
+        $stripRequires = { param([string]$src) $src -replace '(?m)^#Requires[^\r\n]*[\r\n]*', '' }
+        $invokeRolSrc  = & $stripRequires (Get-Content -Raw -Path (
+            [IO.Path]::Combine($script:modulePath, 'Private', 'Invoke-RemoteOrLocal.ps1')))
+        $funcSrc       = & $stripRequires (Get-Content -Raw -Path (
+            [IO.Path]::Combine($script:modulePath, 'Public', 'iis', 'Test-IISBindingCertificate.ps1')))
+        $moduleBody    = "`$script:LocalComputerNames = @(`$env:COMPUTERNAME, 'localhost', '.')`r`n" +
+                         $invokeRolSrc + "`r`n" + $funcSrc + "`r`nExport-ModuleMember -Function '*'"
+        New-Module -Name 'PSWinOps' -ScriptBlock ([scriptblock]::Create($moduleBody)) |
+            Import-Module -Force
+    }
+
+    # IIS WebAdministration / IISAdministration stubs -- parameters declared explicitly
+    # so the Pester mock engine can match arguments correctly (project convention, see PR #42).
+    if (-not (Get-Command -Name 'Get-Website' -ErrorAction SilentlyContinue)) {
+        function global:Get-Website { param([string]$Name) }
+    }
+    if (-not (Get-Command -Name 'Get-WebBinding' -ErrorAction SilentlyContinue)) {
+        function global:Get-WebBinding { param([string]$Name, [string]$Protocol) }
+    }
+    if (-not (Get-Command -Name 'Get-IISSite' -ErrorAction SilentlyContinue)) {
+        function global:Get-IISSite { param([string]$Name) }
+    }
+    if (-not (Get-Command -Name 'Get-IISServerManager' -ErrorAction SilentlyContinue)) {
+        function global:Get-IISServerManager { param() }
+    }
+
+    $script:ModuleName  = 'PSWinOps'
+    $script:Host1       = 'WEB01'
+    $script:Host2       = 'WEB02'
+    $script:FailHost    = 'FAILHOST'
+    $script:ValidThumb  = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
+    $script:OrphanThumb = 'BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB'
+
+    # ── Mock: Status=Tested, OverallStatus=Pass (all checks green, Strong algo) ──
+    $script:mockPass = @(
+        @{
+            ComputerName           = 'WEB01'
+            SiteName               = 'Default Web Site'
+            BindingInformation     = '*:443:'
+            Protocol               = 'https'
+            Port                   = 443
+            HostHeader             = ''
+            SslFlags               = 'None'
+            Thumbprint             = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
+            Subject                = 'CN=web01.contoso.com, O=Contoso, C=US'
+            SubjectAlternativeName = @('web01.contoso.com', 'www.contoso.com')
+            Issuer                 = 'CN=Contoso CA, O=Contoso, C=US'
+            NotBefore              = [datetime]'2025-01-01'
+            NotAfter               = [datetime]'2027-01-01'
+            DaysUntilExpiration    = 365
+            ExpirationStatus       = 'OK'
+            ChainValid             = $true
+            ChainStatus            = @()
+            HostnameMatch          = $true
+            HasPrivateKey          = $true
+            SignatureAlgorithm     = 'sha256RSA'
+            KeyAlgorithm           = 'RSA'
+            KeySize                = 4096
+            AlgorithmStrength      = 'Strong'
+            CertificateStore       = 'LocalMachine\My'
+            StoreAligned           = $true
+            OverallStatus          = 'Pass'
+            Findings               = @()
+            Status                 = 'Tested'
+            ErrorMessage           = $null
+            Timestamp              = '2026-05-16 12:00:00'
+        }
+    )
+
+    # ── Mock: Status=Tested, OverallStatus=Warning (ExpirationStatus=Warning) ────
+    $script:mockWarningExpiry = @(
+        @{
+            ComputerName           = 'WEB01'
+            SiteName               = 'WarningSite'
+            BindingInformation     = '*:443:warn.contoso.com'
+            Protocol               = 'https'
+            Port                   = 443
+            HostHeader             = 'warn.contoso.com'
+            SslFlags               = 'Sni'
+            Thumbprint             = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
+            Subject                = 'CN=warn.contoso.com'
+            SubjectAlternativeName = @('warn.contoso.com')
+            Issuer                 = 'CN=Contoso CA'
+            NotBefore              = [datetime]'2025-01-01'
+            NotAfter               = ([datetime]::UtcNow).AddDays(20)
+            DaysUntilExpiration    = 20
+            ExpirationStatus       = 'Warning'
+            ChainValid             = $true
+            ChainStatus            = @()
+            HostnameMatch          = $true
+            HasPrivateKey          = $true
+            SignatureAlgorithm     = 'sha256RSA'
+            KeyAlgorithm           = 'RSA'
+            KeySize                = 4096
+            AlgorithmStrength      = 'Strong'
+            CertificateStore       = 'LocalMachine\My'
+            StoreAligned           = $true
+            OverallStatus          = 'Warning'
+            Findings               = @('Certificate expires in 20 day(s) (Warning threshold: 30)')
+            Status                 = 'Tested'
+            ErrorMessage           = $null
+            Timestamp              = '2026-05-16 12:00:00'
+        }
+    )
+
+    # ── Mock: Status=Tested, OverallStatus=Warning (AlgorithmStrength=Acceptable) ─
+    $script:mockWarningAlgo = @(
+        @{
+            ComputerName           = 'WEB01'
+            SiteName               = 'AlgoSite'
+            BindingInformation     = '*:443:algo.contoso.com'
+            Protocol               = 'https'
+            Port                   = 443
+            HostHeader             = 'algo.contoso.com'
+            SslFlags               = 'Sni'
+            Thumbprint             = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
+            Subject                = 'CN=algo.contoso.com'
+            SubjectAlternativeName = @('algo.contoso.com')
+            Issuer                 = 'CN=Contoso CA'
+            NotBefore              = [datetime]'2025-01-01'
+            NotAfter               = [datetime]'2027-01-01'
+            DaysUntilExpiration    = 365
+            ExpirationStatus       = 'OK'
+            ChainValid             = $true
+            ChainStatus            = @()
+            HostnameMatch          = $true
+            HasPrivateKey          = $true
+            SignatureAlgorithm     = 'sha256RSA'
+            KeyAlgorithm           = 'RSA'
+            KeySize                = 2048
+            AlgorithmStrength      = 'Acceptable'
+            CertificateStore       = 'LocalMachine\My'
+            StoreAligned           = $true
+            OverallStatus          = 'Warning'
+            Findings               = @('Algorithm strength Acceptable: RSA 2048-bit (consider upgrading to 3072+)')
+            Status                 = 'Tested'
+            ErrorMessage           = $null
+            Timestamp              = '2026-05-16 12:00:00'
+        }
+    )
+
+    # ── Mock: Status=Tested, OverallStatus=Critical (ExpirationStatus=Expired) ───
+    $script:mockExpired = @(
+        @{
+            ComputerName           = 'WEB01'
+            SiteName               = 'ExpiredSite'
+            BindingInformation     = '*:443:expired.contoso.com'
+            Protocol               = 'https'
+            Port                   = 443
+            HostHeader             = 'expired.contoso.com'
+            SslFlags               = 'Sni'
+            Thumbprint             = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
+            Subject                = 'CN=expired.contoso.com'
+            SubjectAlternativeName = @('expired.contoso.com')
+            Issuer                 = 'CN=Contoso CA'
+            NotBefore              = [datetime]'2020-01-01'
+            NotAfter               = [datetime]'2021-01-01'
+            DaysUntilExpiration    = -1826
+            ExpirationStatus       = 'Expired'
+            ChainValid             = $true
+            ChainStatus            = @()
+            HostnameMatch          = $true
+            HasPrivateKey          = $true
+            SignatureAlgorithm     = 'sha256RSA'
+            KeyAlgorithm           = 'RSA'
+            KeySize                = 4096
+            AlgorithmStrength      = 'Strong'
+            CertificateStore       = 'LocalMachine\My'
+            StoreAligned           = $true
+            OverallStatus          = 'Critical'
+            Findings               = @('Certificate expired on 2021-01-01 00:00:00')
+            Status                 = 'Tested'
+            ErrorMessage           = $null
+            Timestamp              = '2026-05-16 12:00:00'
+        }
+    )
+
+    # ── Mock: Status=Tested, OverallStatus=Critical (HostnameMatch=$false) ───────
+    $script:mockHostnameMismatch = @(
+        @{
+            ComputerName           = 'WEB01'
+            SiteName               = 'MismatchSite'
+            BindingInformation     = '*:443:other.contoso.com'
+            Protocol               = 'https'
+            Port                   = 443
+            HostHeader             = 'other.contoso.com'
+            SslFlags               = 'Sni'
+            Thumbprint             = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
+            Subject                = 'CN=web01.contoso.com'
+            SubjectAlternativeName = @('web01.contoso.com')
+            Issuer                 = 'CN=Contoso CA'
+            NotBefore              = [datetime]'2025-01-01'
+            NotAfter               = [datetime]'2027-01-01'
+            DaysUntilExpiration    = 365
+            ExpirationStatus       = 'OK'
+            ChainValid             = $true
+            ChainStatus            = @()
+            HostnameMatch          = $false
+            HasPrivateKey          = $true
+            SignatureAlgorithm     = 'sha256RSA'
+            KeyAlgorithm           = 'RSA'
+            KeySize                = 4096
+            AlgorithmStrength      = 'Strong'
+            CertificateStore       = 'LocalMachine\My'
+            StoreAligned           = $true
+            OverallStatus          = 'Critical'
+            Findings               = @("Hostname 'other.contoso.com' does not match any certificate CN or SAN (web01.contoso.com)")
+            Status                 = 'Tested'
+            ErrorMessage           = $null
+            Timestamp              = '2026-05-16 12:00:00'
+        }
+    )
+
+    # ── Mock: Status=Tested, SkipChainValidation active (ChainValid=$null) ───────
+    $script:mockSkipChain = @(
+        @{
+            ComputerName           = 'WEB01'
+            SiteName               = 'OfflineSite'
+            BindingInformation     = '*:443:offline.contoso.com'
+            Protocol               = 'https'
+            Port                   = 443
+            HostHeader             = 'offline.contoso.com'
+            SslFlags               = 'Sni'
+            Thumbprint             = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
+            Subject                = 'CN=offline.contoso.com'
+            SubjectAlternativeName = @('offline.contoso.com')
+            Issuer                 = 'CN=Contoso CA'
+            NotBefore              = [datetime]'2025-01-01'
+            NotAfter               = [datetime]'2027-01-01'
+            DaysUntilExpiration    = 365
+            ExpirationStatus       = 'OK'
+            ChainValid             = $null
+            ChainStatus            = @()
+            HostnameMatch          = $true
+            HasPrivateKey          = $true
+            SignatureAlgorithm     = 'sha256RSA'
+            KeyAlgorithm           = 'RSA'
+            KeySize                = 4096
+            AlgorithmStrength      = 'Strong'
+            CertificateStore       = 'LocalMachine\My'
+            StoreAligned           = $true
+            OverallStatus          = 'Pass'
+            Findings               = @()
+            Status                 = 'Tested'
+            ErrorMessage           = $null
+            Timestamp              = '2026-05-16 12:00:00'
+        }
+    )
+
+    # ── Mock: Status=IISNotInstalled ──────────────────────────────────────────────
+    $script:mockIISNotInstalled = @(
+        @{
+            ComputerName           = 'WEB01'
+            SiteName               = $null
+            BindingInformation     = $null
+            Protocol               = $null
+            Port                   = $null
+            HostHeader             = $null
+            SslFlags               = $null
+            Thumbprint             = $null
+            Subject                = $null
+            SubjectAlternativeName = @()
+            Issuer                 = $null
+            NotBefore              = $null
+            NotAfter               = $null
+            DaysUntilExpiration    = $null
+            ExpirationStatus       = $null
+            ChainValid             = $null
+            ChainStatus            = @()
+            HostnameMatch          = $null
+            HasPrivateKey          = $null
+            SignatureAlgorithm     = $null
+            KeyAlgorithm           = $null
+            KeySize                = $null
+            AlgorithmStrength      = $null
+            CertificateStore       = $null
+            StoreAligned           = $null
+            OverallStatus          = 'Fail'
+            Findings               = @()
+            Status                 = 'IISNotInstalled'
+            ErrorMessage           = 'W3SVC service not found: Cannot find service W3SVC'
+            Timestamp              = '2026-05-16 12:00:00'
+        }
+    )
+
+    # ── Mock: Status=BindingNotFound ──────────────────────────────────────────────
+    $script:mockBindingNotFound = @(
+        @{
+            ComputerName           = 'WEB01'
+            SiteName               = $null
+            BindingInformation     = $null
+            Protocol               = 'https'
+            Port                   = $null
+            HostHeader             = $null
+            SslFlags               = $null
+            Thumbprint             = $null
+            Subject                = $null
+            SubjectAlternativeName = @()
+            Issuer                 = $null
+            NotBefore              = $null
+            NotAfter               = $null
+            DaysUntilExpiration    = $null
+            ExpirationStatus       = $null
+            ChainValid             = $null
+            ChainStatus            = @()
+            HostnameMatch          = $null
+            HasPrivateKey          = $null
+            SignatureAlgorithm     = $null
+            KeyAlgorithm           = $null
+            KeySize                = $null
+            AlgorithmStrength      = $null
+            CertificateStore       = $null
+            StoreAligned           = $null
+            OverallStatus          = 'Fail'
+            Findings               = @()
+            Status                 = 'BindingNotFound'
+            ErrorMessage           = 'No https bindings found on this host.'
+            Timestamp              = '2026-05-16 12:00:00'
+        }
+    )
+
+    # ── Mock: Status=CertNotFound ─────────────────────────────────────────────────
+    $script:mockCertNotFound = @(
+        @{
+            ComputerName           = 'WEB01'
+            SiteName               = 'Default Web Site'
+            BindingInformation     = '*:443:'
+            Protocol               = 'https'
+            Port                   = 443
+            HostHeader             = ''
+            SslFlags               = 'None'
+            Thumbprint             = 'BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB'
+            Subject                = $null
+            SubjectAlternativeName = @()
+            Issuer                 = $null
+            NotBefore              = $null
+            NotAfter               = $null
+            DaysUntilExpiration    = $null
+            ExpirationStatus       = $null
+            ChainValid             = $null
+            ChainStatus            = @()
+            HostnameMatch          = $null
+            HasPrivateKey          = $null
+            SignatureAlgorithm     = $null
+            KeyAlgorithm           = $null
+            KeySize                = $null
+            AlgorithmStrength      = $null
+            CertificateStore       = $null
+            StoreAligned           = $null
+            OverallStatus          = 'Fail'
+            Findings               = @()
+            Status                 = 'CertNotFound'
+            ErrorMessage           = "Certificate with thumbprint 'BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB' not found in any LocalMachine store."
+            Timestamp              = '2026-05-16 12:00:00'
+        }
+    )
+
+    # ── Mock: second host result for fan-out tests ────────────────────────────────
+    $script:mockPassHost2 = @(
+        @{
+            ComputerName           = 'WEB02'
+            SiteName               = 'Default Web Site'
+            BindingInformation     = '*:443:'
+            Protocol               = 'https'
+            Port                   = 443
+            HostHeader             = ''
+            SslFlags               = 'None'
+            Thumbprint             = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
+            Subject                = 'CN=web02.contoso.com'
+            SubjectAlternativeName = @('web02.contoso.com')
+            Issuer                 = 'CN=Contoso CA'
+            NotBefore              = [datetime]'2025-01-01'
+            NotAfter               = [datetime]'2027-01-01'
+            DaysUntilExpiration    = 365
+            ExpirationStatus       = 'OK'
+            ChainValid             = $true
+            ChainStatus            = @()
+            HostnameMatch          = $true
+            HasPrivateKey          = $true
+            SignatureAlgorithm     = 'sha256RSA'
+            KeyAlgorithm           = 'RSA'
+            KeySize                = 4096
+            AlgorithmStrength      = 'Strong'
+            CertificateStore       = 'LocalMachine\My'
+            StoreAligned           = $true
+            OverallStatus          = 'Pass'
+            Findings               = @()
+            Status                 = 'Tested'
+            ErrorMessage           = $null
+            Timestamp              = '2026-05-16 12:00:00'
+        }
+    )
+}
+
+Describe 'Test-IISBindingCertificate' {
+
+    # ─────────────────────────────────────────────────────────────────────────────
+    # Context 1: Happy path -- Status=Tested, OverallStatus=Pass
+    # ─────────────────────────────────────────────────────────────────────────────
+    Context 'Happy path: Status=Tested, OverallStatus=Pass (all checks green)' {
+
+        It 'Should return Status=Tested and OverallStatus=Pass for a fully healthy binding' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName `
+                -MockWith { return $script:mockPass }
+            $result = Test-IISBindingCertificate -ComputerName $script:Host1
+            $result.Status        | Should -Be 'Tested'
+            $result.OverallStatus | Should -Be 'Pass'
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should set PSTypeName to PSWinOps.IISCertificateBindingTestResult' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName `
+                -MockWith { return $script:mockPass }
+            $result = Test-IISBindingCertificate -ComputerName $script:Host1
+            $result.PSObject.TypeNames[0] | Should -Be 'PSWinOps.IISCertificateBindingTestResult'
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should populate certificate metadata (Subject, Thumbprint, Issuer, KeySize)' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName `
+                -MockWith { return $script:mockPass }
+            $result = Test-IISBindingCertificate -ComputerName $script:Host1
+            $result.Thumbprint | Should -Be $script:ValidThumb
+            $result.Subject    | Should -Be 'CN=web01.contoso.com, O=Contoso, C=US'
+            $result.Issuer     | Should -Not -BeNullOrEmpty
+            $result.KeySize    | Should -Be 4096
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should report ChainValid=$true, HostnameMatch=$true, HasPrivateKey=$true, StoreAligned=$true' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName `
+                -MockWith { return $script:mockPass }
+            $result = Test-IISBindingCertificate -ComputerName $script:Host1
+            $result.ChainValid    | Should -BeTrue
+            $result.HostnameMatch | Should -BeTrue
+            $result.HasPrivateKey | Should -BeTrue
+            $result.StoreAligned  | Should -BeTrue
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should have an empty Findings array when OverallStatus=Pass' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName `
+                -MockWith { return $script:mockPass }
+            $result = Test-IISBindingCertificate -ComputerName $script:Host1
+            $result.Findings | Should -BeNullOrEmpty
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should set Timestamp matching the yyyy-MM-dd HH:mm:ss format pattern' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName `
+                -MockWith { return $script:mockPass }
+            $result = Test-IISBindingCertificate -ComputerName $script:Host1
+            "$($result.Timestamp)" | Should -Match "^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$"
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should report AlgorithmStrength=Strong, SignatureAlgorithm=sha256RSA and KeyAlgorithm=RSA' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName `
+                -MockWith { return $script:mockPass }
+            $result = Test-IISBindingCertificate -ComputerName $script:Host1
+            $result.AlgorithmStrength  | Should -Be 'Strong'
+            $result.SignatureAlgorithm | Should -Be 'sha256RSA'
+            $result.KeyAlgorithm       | Should -Be 'RSA'
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should populate SubjectAlternativeName as a non-empty array for a Pass result' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName `
+                -MockWith { return $script:mockPass }
+            $result = Test-IISBindingCertificate -ComputerName $script:Host1
+            $result.SubjectAlternativeName | Should -Contain 'web01.contoso.com'
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+    }
+
+    # ─────────────────────────────────────────────────────────────────────────────
+    # Context 2: OverallStatus=Warning
+    # ─────────────────────────────────────────────────────────────────────────────
+    Context 'OverallStatus=Warning: ExpirationStatus=Warning or AlgorithmStrength=Acceptable' {
+
+        It 'Should return OverallStatus=Warning when ExpirationStatus=Warning' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName `
+                -MockWith { return $script:mockWarningExpiry }
+            $result = Test-IISBindingCertificate -ComputerName $script:Host1
+            $result.OverallStatus    | Should -Be 'Warning'
+            $result.ExpirationStatus | Should -Be 'Warning'
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should retain Status=Tested when only the expiration is in Warning range' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName `
+                -MockWith { return $script:mockWarningExpiry }
+            $result = Test-IISBindingCertificate -ComputerName $script:Host1
+            $result.Status              | Should -Be 'Tested'
+            $result.DaysUntilExpiration | Should -BeLessThan 30
+            $result.DaysUntilExpiration | Should -BeGreaterThan 7
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should include an expiration finding message when ExpirationStatus=Warning' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName `
+                -MockWith { return $script:mockWarningExpiry }
+            $result = Test-IISBindingCertificate -ComputerName $script:Host1
+            $result.Findings | Should -Not -BeNullOrEmpty
+            ($result.Findings -join ' ') | Should -Match "expires in"
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should return OverallStatus=Warning when AlgorithmStrength=Acceptable (2048-bit RSA)' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName `
+                -MockWith { return $script:mockWarningAlgo }
+            $result = Test-IISBindingCertificate -ComputerName $script:Host1
+            $result.OverallStatus     | Should -Be 'Warning'
+            $result.AlgorithmStrength | Should -Be 'Acceptable'
+            $result.KeySize           | Should -Be 2048
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+    }
+
+    # ─────────────────────────────────────────────────────────────────────────────
+    # Context 3: OverallStatus=Critical (expired cert and hostname mismatch)
+    # ─────────────────────────────────────────────────────────────────────────────
+    Context 'OverallStatus=Critical: expired certificate or hostname mismatch' {
+
+        It 'Should return OverallStatus=Critical and ExpirationStatus=Expired for a past-due certificate' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName `
+                -MockWith { return $script:mockExpired }
+            $result = Test-IISBindingCertificate -ComputerName $script:Host1
+            $result.OverallStatus    | Should -Be 'Critical'
+            $result.ExpirationStatus | Should -Be 'Expired'
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should report a negative DaysUntilExpiration for an expired certificate' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName `
+                -MockWith { return $script:mockExpired }
+            $result = Test-IISBindingCertificate -ComputerName $script:Host1
+            $result.DaysUntilExpiration | Should -BeLessThan 0
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should include an expiry finding message for an Expired certificate' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName `
+                -MockWith { return $script:mockExpired }
+            $result = Test-IISBindingCertificate -ComputerName $script:Host1
+            ($result.Findings -join ' ') | Should -Match "expired"
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should set Status=Tested even when the certificate is expired' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName `
+                -MockWith { return $script:mockExpired }
+            $result = Test-IISBindingCertificate -ComputerName $script:Host1
+            $result.Status | Should -Be 'Tested'
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should return OverallStatus=Critical when HostnameMatch=$false (SAN mismatch)' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName `
+                -MockWith { return $script:mockHostnameMismatch }
+            $result = Test-IISBindingCertificate -ComputerName $script:Host1
+            $result.OverallStatus | Should -Be 'Critical'
+            $result.HostnameMatch | Should -BeFalse
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should include a hostname-mismatch finding when HostnameMatch=$false' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName `
+                -MockWith { return $script:mockHostnameMismatch }
+            $result = Test-IISBindingCertificate -ComputerName $script:Host1
+            ($result.Findings -join ' ') | Should -Match "does not match"
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+    }
+
+    # ─────────────────────────────────────────────────────────────────────────────
+    # Context 4: Status=IISNotInstalled
+    # ─────────────────────────────────────────────────────────────────────────────
+    Context 'Status=IISNotInstalled: W3SVC service not found on the target host' {
+
+        It 'Should return Status=IISNotInstalled when W3SVC is absent' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName `
+                -MockWith { return $script:mockIISNotInstalled }
+            $result = Test-IISBindingCertificate -ComputerName $script:Host1
+            $result.Status | Should -Be 'IISNotInstalled'
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should set OverallStatus=Fail and include a non-null ErrorMessage for IISNotInstalled' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName `
+                -MockWith { return $script:mockIISNotInstalled }
+            $result = Test-IISBindingCertificate -ComputerName $script:Host1
+            $result.OverallStatus | Should -Be 'Fail'
+            $result.ErrorMessage  | Should -Not -BeNullOrEmpty
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should carry the PSTypeName even for a Status=IISNotInstalled row' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName `
+                -MockWith { return $script:mockIISNotInstalled }
+            $result = Test-IISBindingCertificate -ComputerName $script:Host1
+            $result.PSObject.TypeNames[0] | Should -Be 'PSWinOps.IISCertificateBindingTestResult'
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+    }
+
+    # ─────────────────────────────────────────────────────────────────────────────
+    # Context 5: Status=BindingNotFound
+    # ─────────────────────────────────────────────────────────────────────────────
+    Context 'Status=BindingNotFound: no https bindings match the supplied filters' {
+
+        It 'Should return Status=BindingNotFound when no https bindings exist on the host' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName `
+                -MockWith { return $script:mockBindingNotFound }
+            $result = Test-IISBindingCertificate -ComputerName $script:Host1
+            $result.Status | Should -Be 'BindingNotFound'
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should set OverallStatus=Fail and a non-null ErrorMessage for BindingNotFound' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName `
+                -MockWith { return $script:mockBindingNotFound }
+            $result = Test-IISBindingCertificate -ComputerName $script:Host1
+            $result.OverallStatus | Should -Be 'Fail'
+            $result.ErrorMessage  | Should -Not -BeNullOrEmpty
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+    }
+
+    # ─────────────────────────────────────────────────────────────────────────────
+    # Context 6: Status=CertNotFound
+    # ─────────────────────────────────────────────────────────────────────────────
+    Context 'Status=CertNotFound: binding thumbprint absent from any LocalMachine store' {
+
+        It 'Should return Status=CertNotFound when the thumbprint is not found in any store' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName `
+                -MockWith { return $script:mockCertNotFound }
+            $result = Test-IISBindingCertificate -ComputerName $script:Host1
+            $result.Status | Should -Be 'CertNotFound'
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should preserve the orphan Thumbprint in the CertNotFound row' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName `
+                -MockWith { return $script:mockCertNotFound }
+            $result = Test-IISBindingCertificate -ComputerName $script:Host1
+            $result.Thumbprint | Should -Be $script:OrphanThumb
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should leave certificate-derived properties null for a CertNotFound row' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName `
+                -MockWith { return $script:mockCertNotFound }
+            $result = Test-IISBindingCertificate -ComputerName $script:Host1
+            $result.OverallStatus | Should -Be 'Fail'
+            $result.Subject       | Should -BeNullOrEmpty
+            $result.NotAfter      | Should -BeNullOrEmpty
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+    }
+
+    # ─────────────────────────────────────────────────────────────────────────────
+    # Context 7: -SkipChainValidation
+    # ─────────────────────────────────────────────────────────────────────────────
+    Context '-SkipChainValidation: ChainValid=$null and ChainStatus empty when chain build is skipped' {
+
+        It 'Should surface ChainValid=$null and empty ChainStatus when -SkipChainValidation is used' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName `
+                -MockWith { return $script:mockSkipChain }
+            $result = Test-IISBindingCertificate -ComputerName $script:Host1 -SkipChainValidation
+            $result.ChainValid  | Should -BeNullOrEmpty
+            $result.ChainStatus | Should -BeNullOrEmpty
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should still produce Status=Tested and OverallStatus=Pass with -SkipChainValidation' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName `
+                -MockWith { return $script:mockSkipChain }
+            $result = Test-IISBindingCertificate -ComputerName $script:Host1 -SkipChainValidation
+            $result.Status        | Should -Be 'Tested'
+            $result.OverallStatus | Should -Be 'Pass'
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+    }
+
+    # ─────────────────────────────────────────────────────────────────────────────
+    # Context 8: Read-only / ShouldProcess semantics
+    # ─────────────────────────────────────────────────────────────────────────────
+    Context 'Read-only semantics: Test-IISBindingCertificate never mutates state (ShouldProcess not implemented)' {
+
+        It 'Should not accept -WhatIf (function is read-only; SupportsShouldProcess is not declared)' {
+            { Test-IISBindingCertificate -ComputerName $script:Host1 -WhatIf } | Should -Throw
+        }
+
+        It 'Should invoke Invoke-RemoteOrLocal exactly once and produce no write side-effects' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName `
+                -MockWith { return $script:mockPass }
+            $result = Test-IISBindingCertificate -ComputerName $script:Host1
+            $result.Status | Should -Be 'Tested'
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+    }
+
+    # ─────────────────────────────────────────────────────────────────────────────
+    # Context 9: Pipeline by property name
+    # ─────────────────────────────────────────────────────────────────────────────
+    Context 'Pipeline by property name: ComputerName, SiteName, BindingInformation and Thumbprint bound from pipe' {
+
+        It 'Should accept ComputerName via pipeline by property name' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName `
+                -MockWith { return $script:mockPass }
+            $pipeInput = [PSCustomObject]@{ ComputerName = $script:Host1 }
+            $result = $pipeInput | Test-IISBindingCertificate
+            $result | Should -Not -BeNullOrEmpty
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should accept the DNSHostName alias for ComputerName via pipeline by property name' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName `
+                -MockWith { return $script:mockPass }
+            $pipeInput = [PSCustomObject]@{ DNSHostName = $script:Host1 }
+            $result = $pipeInput | Test-IISBindingCertificate
+            $result | Should -Not -BeNullOrEmpty
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should accept SiteName via pipeline by property name alongside ComputerName' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName `
+                -MockWith { return $script:mockPass }
+            $pipeInput = [PSCustomObject]@{ ComputerName = $script:Host1; SiteName = 'Default Web Site' }
+            $result = $pipeInput | Test-IISBindingCertificate
+            $result | Should -Not -BeNullOrEmpty
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should accept BindingInformation via pipeline by property name (re-test piped from Get-IISCertificateBinding)' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName `
+                -MockWith { return $script:mockPass }
+            $pipeInput = [PSCustomObject]@{
+                ComputerName       = $script:Host1
+                BindingInformation = '*:443:'
+            }
+            $result = $pipeInput | Test-IISBindingCertificate
+            $result | Should -Not -BeNullOrEmpty
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should accept Thumbprint via pipeline by property name' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName `
+                -MockWith { return $script:mockPass }
+            $pipeInput = [PSCustomObject]@{
+                ComputerName = $script:Host1
+                Thumbprint   = $script:ValidThumb
+            }
+            $result = $pipeInput | Test-IISBindingCertificate
+            $result | Should -Not -BeNullOrEmpty
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+    }
+
+    # ─────────────────────────────────────────────────────────────────────────────
+    # Context 10: Credential propagation
+    # ─────────────────────────────────────────────────────────────────────────────
+    Context 'Credential propagation: PSCredential forwarded to Invoke-RemoteOrLocal when supplied' {
+
+        It 'Should call Invoke-RemoteOrLocal exactly once when a Credential is provided' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName `
+                -MockWith { return $script:mockPass }
+            $cred = [System.Management.Automation.PSCredential]::new(
+                'domain\svcaccount',
+                (ConvertTo-SecureString -String 'P@ssw0rd!' -AsPlainText -Force)
+            )
+            $result = Test-IISBindingCertificate -ComputerName $script:Host1 -Credential $cred
+            $result.Status | Should -Be 'Tested'
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should return valid results when no Credential is supplied (local or integrated auth)' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName `
+                -MockWith { return $script:mockPass }
+            $result = Test-IISBindingCertificate -ComputerName $script:Host1
+            $result.Status | Should -Be 'Tested'
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+    }
+
+    # ─────────────────────────────────────────────────────────────────────────────
+    # Context 11: ComputerName fan-out
+    # ─────────────────────────────────────────────────────────────────────────────
+    Context 'ComputerName fan-out: each host triggers exactly one Invoke-RemoteOrLocal call' {
+
+        It 'Should invoke Invoke-RemoteOrLocal once per computer when two hosts are supplied' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName `
+                -MockWith { return $script:mockPass }
+            $null = Test-IISBindingCertificate -ComputerName @($script:Host1, $script:Host2)
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 2 -Exactly
+        }
+
+        It 'Should produce one output row per host when each host returns a single binding' {
+            $script:fanOutCallIdx = 0
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith {
+                $script:fanOutCallIdx++
+                if ($script:fanOutCallIdx -ge 2) { return $script:mockPassHost2 }
+                return $script:mockPass
+            }
+            $results = @(Test-IISBindingCertificate -ComputerName @($script:Host1, $script:Host2))
+            $results.Count | Should -Be 2
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 2 -Exactly
+        }
+
+        It 'Should invoke Invoke-RemoteOrLocal three times when three hosts are piped in' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName `
+                -MockWith { return $script:mockPass }
+            $null = @($script:Host1, $script:Host2, $script:FailHost) | Test-IISBindingCertificate
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 3 -Exactly
+        }
+    }
+
+    # ─────────────────────────────────────────────────────────────────────────────
+    # Context 12: Error isolation per machine
+    # ─────────────────────────────────────────────────────────────────────────────
+    Context 'Error isolation: an exception from one host does not suppress results from healthy hosts' {
+
+        It 'Should emit a result row from the healthy host when the second host throws' {
+            $script:irlCallIdx = 0
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith {
+                $script:irlCallIdx++
+                if ($script:irlCallIdx -ge 2) { throw 'Simulated WinRM error on FAILHOST' }
+                return $script:mockPass
+            }
+            $results = @(
+                Test-IISBindingCertificate -ComputerName @($script:Host1, $script:FailHost) `
+                    -ErrorAction SilentlyContinue
+            )
+            $results.Count    | Should -BeGreaterOrEqual 1
+            $results[0].Status | Should -Be 'Tested'
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 2 -Exactly
+        }
+    }
+
+    # ─────────────────────────────────────────────────────────────────────────────
+    # Context 13: BOM and CRLF encoding sentinel
+    # ─────────────────────────────────────────────────────────────────────────────
+    Context 'File encoding: UTF-8 BOM and CRLF line endings (project convention)' {
+
+        It 'Should begin with a UTF-8 BOM byte sequence (EF BB BF)' {
+            $bytes = [System.IO.File]::ReadAllBytes($script:testFilePath)
+            $bytes[0] | Should -Be 0xEF
+            $bytes[1] | Should -Be 0xBB
+            $bytes[2] | Should -Be 0xBF
+        }
+
+        It 'Should use CRLF line endings throughout the file' {
+            $raw = [System.IO.File]::ReadAllText($script:testFilePath)
+            $raw | Should -Match "`r`n"
+        }
+    }
+}

--- a/en-US/about_PSWinOps.help.txt
+++ b/en-US/about_PSWinOps.help.txt
@@ -84,11 +84,12 @@ FUNCTION DOMAINS
       Get-ServiceHealth
       Get-WSUSHealth
 
-  iis (7 functions)
+  iis (8 functions)
     Functions for managing IIS sites, HTTPS bindings,
     log file analysis, real-time log streaming, worker
-    process monitoring, and in-flight request inspection
-    across local or remote servers.
+    process monitoring, in-flight request inspection,
+    and certificate binding validation across local or
+    remote servers.
 
       Get-IISCertificateBinding
       Get-IISCurrentRequest
@@ -96,6 +97,7 @@ FUNCTION DOMAINS
       Get-IISParsedLog
       Get-IISWorkerProcess
       Set-IISBindingCertificate
+      Test-IISBindingCertificate
       Watch-IISLog
 
   network (24 functions)
@@ -289,7 +291,7 @@ REMOTE EXECUTION PATTERN
     in the pipeline continue to be processed.
 
 PSWINOPS TYPE REGISTRY
-    The following 92 PSTypeName values are defined by the
+    The following 93 PSTypeName values are defined by the
     module. Each corresponds to the output of one or more
     public functions.
 
@@ -336,6 +338,7 @@ PSWINOPS TYPE REGISTRY
       PSWinOps.HyperVHostHealth
       PSWinOps.IISBindingCertificateResult
       PSWinOps.IISCertificateBinding
+      PSWinOps.IISCertificateBindingTestResult
       PSWinOps.IISCurrentRequest
       PSWinOps.IISFailedRequestTrace
       PSWinOps.IISHealth


### PR DESCRIPTION
## Summary
Inspects every HTTPS binding on one or more IIS hosts and evaluates the associated X509 certificate across six independent checks — expiration against configurable Warning/Critical thresholds, X509Chain.Build() validity, hostname/SAN match against the binding host header, private key availability, signature/key-algorithm strength, and alignment between the binding's declared CertStoreName and the store where the certificate is actually found. Each check contributes to a per-binding OverallStatus (Pass/Warning/Critical/Fail) and a Findings array describing every non-Pass condition. Complements `Get-IISCertificateBinding` (inventory) with an actionable verdict that IISAdministration does not expose.

## Files touched
- `Public/iis/Test-IISBindingCertificate.ps1` — implementation
- `Tests/Public/iis/Test-IISBindingCertificate.Tests.ps1` — Pester v5 suite (43 tests)
- `PSWinOps.psd1` — `FunctionsToExport`, `ModuleVersion` 0.1.7 → 0.1.8, `ReleaseNotes`
- `PSWinOps.Format.ps1xml` — new `<View>` for `PSWinOps.IISCertificateBindingTestResult`
- `en-US/about_PSWinOps.help.txt` — iis counter bumped 7 → 8, type registry updated

## Conformance checklist (auto-audited by fn-quality-gate)
- [x] UTF-8 BOM + CRLF on all new files
- [x] Approved PowerShell verb (`Test-`)
- [x] `FunctionsToExport` alphabetically sorted (case-insensitive), `Test-IISBindingCertificate` present exactly once
- [x] `PSTypeName` consistent across `.ps1` / `Format.ps1xml` / help (`PSWinOps.IISCertificateBindingTestResult`)
- [x] PSScriptAnalyzer clean (0 Error/Warning) on changed paths
- [x] Pester suite passes locally: **43 Passed / 0 Failed**
- [x] No `Write-Host`, no `ToString('o')` introduced in the diff
- [x] `Test-ModuleManifest ./PSWinOps.psd1` succeeds (v0.1.8, 116 exported functions)
- [x] `PSWinOps.Format.ps1xml` validates as XML

## Auto-merge
✅ Armed via `gh pr merge --auto --squash --delete-branch`. Will merge automatically once all 14 required Windows CI checks are green (`validate`, `lint`, `test (Public/*)` matrix). Any failure is picked up by `pswinops-fn-ci-watcher`, which loops back through `pswinops-fn-author MODE=fix` (max 3 iterations).
