### PR TITLE
feat(iis): add Get-IISAppPoolHistory

### DIFF
--- a/.kdust/chains/get-iisapppoolhistory-2605162005.yaml
+++ b/.kdust/chains/get-iisapppoolhistory-2605162005.yaml
@@ -1,0 +1,7 @@
+chain: pswinops-function-author
+function: Get-IISAppPoolHistory
+domain: iis
+created: 2026-05-16T20:08:17Z
+created_by: pswinops-fn-spec-analyst
+chain_branch: kdust/chain/pswinops-fn-get-iisapppoolhistory-2605162005
+spec_path: work/get-iisapppoolhistory/spec.yaml

--- a/PSWinOps.Format.ps1xml
+++ b/PSWinOps.Format.ps1xml
@@ -7239,5 +7239,78 @@
         </TableRowEntries>
       </TableControl>
     </View>
+    <!-- ============================================================ -->
+    <!-- PSWinOps.IISAppPoolHistoryEvent                             -->
+    <!-- Used by: Get-IISAppPoolHistory                              -->
+    <!-- ============================================================ -->
+    <View>
+      <Name>PSWinOps.IISAppPoolHistoryEvent</Name>
+      <ViewSelectedBy>
+        <TypeName>PSWinOps.IISAppPoolHistoryEvent</TypeName>
+      </ViewSelectedBy>
+      <TableControl>
+        <AutoSize />
+        <TableHeaders>
+          <TableColumnHeader>
+            <Label>TimeCreatedLocal</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>ComputerName</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>AppPoolName</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Category</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>EventId</Label>
+            <Alignment>Right</Alignment>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>WorkerPid</Label>
+            <Alignment>Right</Alignment>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>ReasonCode</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>LogName</Label>
+          </TableColumnHeader>
+        </TableHeaders>
+        <TableRowEntries>
+          <TableRowEntry>
+            <TableColumnItems>
+              <TableColumnItem>
+                <ScriptBlock>
+                  if ($_.TimeCreatedLocal) { $_.TimeCreatedLocal.ToString('yyyy-MM-dd HH:mm:ss') } else { '' }
+                </ScriptBlock>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>ComputerName</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>AppPoolName</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>Category</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>EventId</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>WorkerPid</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>ReasonCode</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>LogName</PropertyName>
+              </TableColumnItem>
+            </TableColumnItems>
+          </TableRowEntry>
+        </TableRowEntries>
+      </TableControl>
+    </View>
   </ViewDefinitions>
 </Configuration>

--- a/PSWinOps.psd1
+++ b/PSWinOps.psd1
@@ -12,7 +12,7 @@
     RootModule           = 'PSWinOps.psm1'
 
     # Version number of this module.
-    ModuleVersion        = '0.1.8'
+    ModuleVersion        = '0.1.9'
 
     # Supported PSEditions
     # Core is supported on Windows only; the module-level guard in PSWinOps.psm1 blocks
@@ -123,6 +123,7 @@
         'Get-ExchangeServerHealth',
         'Get-FileServerHealth',
         'Get-HyperVHostHealth',
+        'Get-IISAppPoolHistory',
         'Get-IISCertificateBinding',
         'Get-IISCurrentRequest',
         'Get-IISFailedRequestTrace',
@@ -263,7 +264,12 @@
             # IconUri = ''
 
             # ReleaseNotes of this module
-            ReleaseNotes = '## 0.1.8 - 2026-05-16
+            ReleaseNotes = '## 0.1.9 - 2026-05-16
+### Added
+- feat(iis): add Get-IISAppPoolHistory — reconstructs the lifecycle history (recycles, rapid-fail shutdowns, crashes, start/stop, identity changes, orphaned worker processes) of IIS application pools by mining the System (Microsoft-Windows-WAS), Application (W3SVC-WP) and optionally the IIS-W3SVC-WP/Operational event logs; classifies each event using a static 16-entry EventId map into typed PSWinOps.IISAppPoolHistoryEvent rows enriched with AppPoolName (parsed from InsertionStrings), WorkerPid, normalised ReasonCode, UTC and local timestamps; server-side filtering via Get-WinEvent -FilterHashtable (-After/-Before/-EventId); client-side -AppPoolName wildcard post-filter and -Tail for the most recent N events; multi-host execution via Invoke-RemoteOrLocal with -Credential; -IncludeOperationalLog adds the admin-only channel with Write-Warning+skip when absent.
+- feat(format): TableControl view for PSWinOps.IISAppPoolHistoryEvent in PSWinOps.Format.ps1xml.
+
+## 0.1.8 - 2026-05-16
 ### Added
 - feat(iis): add Test-IISBindingCertificate — read-only auditor that validates every IIS HTTPS binding certificate across six independent checks (expiration vs configurable Warning/Critical thresholds, X509Chain.Build() validity, hostname/SAN match against the binding host header, HasPrivateKey, signature/key-algorithm strength, and CertStoreName alignment); emits typed PSWinOps.IISCertificateBindingTestResult rows with per-binding OverallStatus (Pass/Warning/Critical/Fail) plus a Findings array describing every non-Pass condition; supports multi-host execution via Invoke-RemoteOrLocal with -Credential, -WarningDays/-CriticalDays thresholds, -SkipChainValidation for air-gapped hosts, optional -IncludeRevocationCheck (CRL/OCSP), and standard Status enum (Tested/IISNotInstalled/BindingNotFound/CertNotFound/Failed); pipes cleanly from Get-IISCertificateBinding for targeted re-test.
 - feat(format): TableControl view for PSWinOps.IISCertificateBindingTestResult in PSWinOps.Format.ps1xml.

--- a/Public/iis/Get-IISAppPoolHistory.ps1
+++ b/Public/iis/Get-IISAppPoolHistory.ps1
@@ -1,0 +1,464 @@
+﻿#Requires -Version 5.1
+function Get-IISAppPoolHistory {
+    <#
+        .SYNOPSIS
+            Reconstructs the lifecycle history (recycles, rapid-fail shutdowns, crashes, start/stop, identity changes) of IIS application pools from Windows event logs.
+
+        .DESCRIPTION
+            Mines the System (Microsoft-Windows-WAS), Application (W3SVC-WP, WAS) and
+            optionally the Microsoft-Windows-IIS-W3SVC-WP/Operational event logs on one
+            or more servers, then classifies every relevant entry into a typed event
+            object enriched with the owning application pool, worker PID and a
+            normalised reason code. Provides the operational timeline IISAdministration
+            does not expose, with server-side filtering via Get-WinEvent -FilterHashtable
+            for performance.
+
+        .PARAMETER ComputerName
+            One or more computer names to query. Defaults to the local machine.
+            Accepts pipeline input by value and by property name (aliases: CN, Server,
+            MachineName). Use $env:COMPUTERNAME, localhost, or . for the local machine.
+
+        .PARAMETER Credential
+            Optional PSCredential for authenticating to remote computers.
+            Not used for local queries.
+
+        .PARAMETER AppPoolName
+            Restrict results to events whose parsed application pool name matches one
+            or more patterns. Wildcards accepted via -like. Applied as a post-filter
+            after event parsing because not all event IDs expose the pool name in a
+            single InsertionString slot.
+
+        .PARAMETER After
+            Return only events with TimeCreated on or after this value.
+            Forwarded as StartTime in Get-WinEvent -FilterHashtable for server-side
+            filtering.
+
+        .PARAMETER Before
+            Return only events with TimeCreated on or before this value.
+            Forwarded as EndTime in Get-WinEvent -FilterHashtable for server-side
+            filtering.
+
+        .PARAMETER Category
+            Restrict results to one or more event categories. Valid values:
+            Recycle, RapidFail, Crash, Start, Stop, IdentityChange, ConfigChange,
+            OrphanWP, Other. When combined with -EventId the two ID sets are unioned.
+
+        .PARAMETER EventId
+            Query specific event IDs instead of (or in addition to) the default set
+            derived from -Category. IDs not present in the built-in map are routed to
+            the Operational log channel when -IncludeOperationalLog is also specified.
+
+        .PARAMETER IncludeOperationalLog
+            Also query the Microsoft-Windows-IIS-W3SVC-WP/Operational channel.
+            This admin-only log contains additional ISAPI / FastCGI crash detail.
+            A warning is emitted and the channel is skipped if it is absent or
+            disabled; no terminating error is thrown.
+
+        .PARAMETER MaxEvents
+            Maximum number of events to retrieve per log channel per target machine.
+            Forwarded as -MaxEvents to each Get-WinEvent call. Default: 1000.
+
+        .PARAMETER Tail
+            Keep only the most recent N events (applied after merging all log channels
+            and post-filtering). Results are still returned in chronological order
+            (oldest first).
+
+        .EXAMPLE
+            Get-IISAppPoolHistory -After (Get-Date).AddHours(-24) -Category Recycle,RapidFail
+
+            Returns all recycle and rapid-fail events from the last 24 hours on the
+            local machine.
+
+        .EXAMPLE
+            'WEB01','WEB02' | Get-IISAppPoolHistory -AppPoolName 'api-*' -Tail 20
+
+            Returns the 20 most recent history events for application pools matching
+            'api-*' across two web servers.
+
+        .EXAMPLE
+            Get-IISHealth -ComputerName WEB01 | Get-IISAppPoolHistory -After (Get-Date).AddDays(-7)
+
+            Pipeline from Get-IISHealth to retrieve a week of app pool history.
+
+        .EXAMPLE
+            Get-IISAppPoolHistory -ComputerName WEB01 -Category Crash -IncludeOperationalLog -After (Get-Date).AddDays(-1)
+
+            Includes the admin Operational channel for additional ISAPI / FastCGI crash
+            detail over the last 24 hours.
+
+        .OUTPUTS
+            PSCustomObject (PSTypeName='PSWinOps.IISAppPoolHistoryEvent')
+
+        .NOTES
+            Author: Franck SALLET
+            Version: 1.0.0
+            Last Modified: 2026-05-16
+            Requires: PowerShell 5.1+ / Windows only
+            Requires: Web-Server (IIS) role
+
+        .LINK
+            https://github.com/k9fr4n/PSWinOps
+
+        .LINK
+            https://learn.microsoft.com/en-us/iis/manage/provisioning-and-managing-iis/troubleshooting-application-pool-issues
+    #>
+    [CmdletBinding()]
+    [OutputType('PSWinOps.IISAppPoolHistoryEvent')]
+    param(
+        [Parameter(Mandatory = $false, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [ValidateNotNullOrEmpty()]
+        [Alias('CN', 'Server', 'MachineName')]
+        [string[]]$ComputerName = $env:COMPUTERNAME,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateNotNull()]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential,
+
+        [Parameter(Mandatory = $false, ValueFromPipelineByPropertyName = $true)]
+        [string[]]$AppPoolName,
+
+        [Parameter(Mandatory = $false)]
+        [datetime]$After,
+
+        [Parameter(Mandatory = $false)]
+        [datetime]$Before,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateSet('Recycle', 'RapidFail', 'Crash', 'Start', 'Stop', 'IdentityChange', 'ConfigChange', 'OrphanWP', 'Other')]
+        [string[]]$Category,
+
+        [Parameter(Mandatory = $false)]
+        [int[]]$EventId,
+
+        [Parameter(Mandatory = $false)]
+        [switch]$IncludeOperationalLog,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateRange(1, 2147483647)]
+        [int]$MaxEvents = 1000,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateRange(1, 2147483647)]
+        [int]$Tail
+    )
+
+    begin {
+        Write-Verbose -Message "[$($MyInvocation.MyCommand)] Starting"
+
+        # ── Static event-ID classification table ────────────────────────────
+        # Passed via ArgumentList so the remote scriptblock classifies events
+        # without any top-level module state.
+        $eventIdMap = @{
+            # ── WAS Recycle family (System log) ─────────────────────────────
+            5074 = @{ Category = 'Recycle';        ReasonCode = 'ConfigChange';         Log = 'System';      PoolIdx = 0; PidIdx = -1 }
+            5076 = @{ Category = 'Recycle';        ReasonCode = 'ScheduleTime';         Log = 'System';      PoolIdx = 0; PidIdx = -1 }
+            5077 = @{ Category = 'Recycle';        ReasonCode = 'NumberOfRequests';     Log = 'System';      PoolIdx = 0; PidIdx = -1 }
+            5079 = @{ Category = 'Recycle';        ReasonCode = 'Memory';               Log = 'System';      PoolIdx = 0; PidIdx = -1 }
+            5080 = @{ Category = 'Recycle';        ReasonCode = 'PrivateMemory';        Log = 'System';      PoolIdx = 0; PidIdx = -1 }
+            # ── Rapid-fail protection (System log) ──────────────────────────
+            5117 = @{ Category = 'RapidFail';      ReasonCode = 'RapidFailProtection';  Log = 'System';      PoolIdx = 0; PidIdx = -1 }
+            5021 = @{ Category = 'IdentityChange'; ReasonCode = 'IdentityChange';       Log = 'System';      PoolIdx = 0; PidIdx = -1 }
+            5022 = @{ Category = 'RapidFail';      ReasonCode = 'RapidFailProtection';  Log = 'System';      PoolIdx = 0; PidIdx = -1 }
+            # ── Worker-process crash (Application log) ───────────────────────
+            5009 = @{ Category = 'Crash';          ReasonCode = 'ProcessTerminated';    Log = 'Application'; PoolIdx = 1; PidIdx = 0 }
+            5010 = @{ Category = 'Crash';          ReasonCode = 'ISAPI';                Log = 'Application'; PoolIdx = 1; PidIdx = 0 }
+            5011 = @{ Category = 'Crash';          ReasonCode = 'PingFailure';          Log = 'Application'; PoolIdx = 1; PidIdx = 0 }
+            5013 = @{ Category = 'Crash';          ReasonCode = 'ShutdownTimeLimit';    Log = 'Application'; PoolIdx = 1; PidIdx = 0 }
+            # ── Pool start / stop / orphan (System log) ──────────────────────
+            5057 = @{ Category = 'Start';          ReasonCode = 'PoolStarted';          Log = 'System';      PoolIdx = 0; PidIdx = -1 }
+            5059 = @{ Category = 'Stop';           ReasonCode = 'PoolStopped';          Log = 'System';      PoolIdx = 0; PidIdx = -1 }
+            5168 = @{ Category = 'OrphanWP';       ReasonCode = 'OrphanWorkerProcess';  Log = 'System';      PoolIdx = 0; PidIdx = 1  }
+            5186 = @{ Category = 'Stop';           ReasonCode = 'OnDemandStop';         Log = 'System';      PoolIdx = 0; PidIdx = -1 }
+        }
+
+        # Category -> default EventId set
+        $categoryEventIds = @{
+            Recycle        = @(5074, 5076, 5077, 5079, 5080)
+            RapidFail      = @(5117, 5022)
+            Crash          = @(5009, 5010, 5011, 5013)
+            Start          = @(5057)
+            Stop           = @(5059, 5186)
+            IdentityChange = @(5021)
+            ConfigChange   = @(5074)
+            OrphanWP       = @(5168)
+            Other          = @()
+        }
+
+        $hasCategory = $PSBoundParameters.ContainsKey('Category')
+        $hasEventId  = $PSBoundParameters.ContainsKey('EventId')
+
+        # Resolve which EventIds to query from System / Application logs
+        $resolvedIds = [System.Collections.Generic.HashSet[int]]::new()
+
+        if ($hasCategory) {
+            foreach ($cat in $Category) {
+                foreach ($cid in $categoryEventIds[$cat]) {
+                    $null = $resolvedIds.Add($cid)
+                }
+            }
+        }
+        if ($hasEventId) {
+            foreach ($eid in $EventId) {
+                if ($eventIdMap.ContainsKey($eid)) {
+                    $null = $resolvedIds.Add($eid)
+                }
+            }
+        }
+        # Default: query all known IDs when neither -Category nor -EventId is supplied
+        if ($resolvedIds.Count -eq 0 -and -not $hasCategory -and -not $hasEventId) {
+            foreach ($eid in $eventIdMap.Keys) {
+                $null = $resolvedIds.Add($eid)
+            }
+        }
+
+        # Partition by log channel for server-side filtering
+        $systemIds      = [int[]]@($resolvedIds | Where-Object { $eventIdMap[$_]['Log'] -eq 'System'      })
+        $applicationIds = [int[]]@($resolvedIds | Where-Object { $eventIdMap[$_]['Log'] -eq 'Application' })
+
+        # Operational channel: user-specified IDs not in the static map
+        $operationalQueryIds = [int[]]@(
+            if ($hasEventId) { $EventId | Where-Object { -not $eventIdMap.ContainsKey($_) } }
+        )
+
+        # ── Remote-capable scriptblock ────────────────────────────────────
+        $scriptBlock = {
+            param(
+                [hashtable] $EventIdMap,
+                [int[]]     $SysIds,
+                [int[]]     $AppIds,
+                [int[]]     $OpIds,
+                [string[]]  $FilterAppPool,
+                [datetime]  $FilterAfter,
+                [bool]      $HasAfter,
+                [datetime]  $FilterBefore,
+                [bool]      $HasBefore,
+                [bool]      $IncludeOp,
+                [int]       $MaxEvt,
+                [int]       $TailN
+            )
+
+            $rawEvents = @()
+
+            # ── 1. Query System log ──────────────────────────────────────────
+            if ($SysIds -and $SysIds.Count -gt 0) {
+                $fht = @{ LogName = 'System'; Id = $SysIds }
+                if ($HasAfter)  { $fht['StartTime'] = $FilterAfter  }
+                if ($HasBefore) { $fht['EndTime']   = $FilterBefore }
+                $gwp = @{ FilterHashtable = $fht; ErrorAction = 'Stop' }
+                if ($MaxEvt -gt 0) { $gwp['MaxEvents'] = $MaxEvt }
+                try {
+                    $rawEvents += @(Get-WinEvent @gwp)
+                }
+                catch {
+                    $errMsg = $_.Exception.Message
+                    if ($errMsg -notmatch 'No events were found|There are no more files') {
+                        Write-Warning "[$env:COMPUTERNAME] System log query failed: $errMsg"
+                    }
+                }
+            }
+
+            # ── 2. Query Application log ─────────────────────────────────────
+            if ($AppIds -and $AppIds.Count -gt 0) {
+                $fht = @{ LogName = 'Application'; Id = $AppIds }
+                if ($HasAfter)  { $fht['StartTime'] = $FilterAfter  }
+                if ($HasBefore) { $fht['EndTime']   = $FilterBefore }
+                $gwp = @{ FilterHashtable = $fht; ErrorAction = 'Stop' }
+                if ($MaxEvt -gt 0) { $gwp['MaxEvents'] = $MaxEvt }
+                try {
+                    $rawEvents += @(Get-WinEvent @gwp)
+                }
+                catch {
+                    $errMsg = $_.Exception.Message
+                    if ($errMsg -notmatch 'No events were found|There are no more files') {
+                        Write-Warning "[$env:COMPUTERNAME] Application log query failed: $errMsg"
+                    }
+                }
+            }
+
+            # ── 3. Query Operational log (optional) ──────────────────────────
+            if ($IncludeOp) {
+                $opLog = 'Microsoft-Windows-IIS-W3SVC-WP/Operational'
+                $fht   = @{ LogName = $opLog }
+                if ($OpIds -and $OpIds.Count -gt 0) { $fht['Id'] = $OpIds }
+                if ($HasAfter)  { $fht['StartTime'] = $FilterAfter  }
+                if ($HasBefore) { $fht['EndTime']   = $FilterBefore }
+                $gwp = @{ FilterHashtable = $fht; ErrorAction = 'Stop' }
+                if ($MaxEvt -gt 0) { $gwp['MaxEvents'] = $MaxEvt }
+                try {
+                    $rawEvents += @(Get-WinEvent @gwp)
+                }
+                catch {
+                    $errMsg = $_.Exception.Message
+                    if ($errMsg -match 'channel .* is disabled|not found|does not exist|cannot be opened|The specified channel') {
+                        Write-Warning "[$env:COMPUTERNAME] Operational log '$opLog' is unavailable or disabled. Skipping."
+                    }
+                    elseif ($errMsg -notmatch 'No events were found|There are no more files') {
+                        Write-Warning "[$env:COMPUTERNAME] Operational log query failed: $errMsg"
+                    }
+                }
+            }
+
+            if ($rawEvents.Count -eq 0) { return }
+
+            # ── 4. Parse events into typed rows ──────────────────────────────
+            $parsed = [System.Collections.Generic.List[hashtable]]::new()
+
+            foreach ($evt in $rawEvents) {
+                $id   = [int]$evt.Id
+                $meta = if ($EventIdMap.ContainsKey($id)) { $EventIdMap[$id] } else { $null }
+
+                $poolName  = $null
+                $workerPid = $null
+
+                try {
+                    $props = $evt.Properties
+                    if ($meta) {
+                        $poolIdx = [int]$meta['PoolIdx']
+                        $pidIdx  = [int]$meta['PidIdx']
+
+                        if ($poolIdx -ge 0 -and $props.Count -gt $poolIdx) {
+                            $v = [string]$props[$poolIdx].Value
+                            if (-not [string]::IsNullOrWhiteSpace($v)) { $poolName = $v }
+                        }
+                        if ($pidIdx -ge 0 -and $props.Count -gt $pidIdx) {
+                            $pv = $props[$pidIdx].Value
+                            if ($null -ne $pv) {
+                                $intVal = 0
+                                if ([int]::TryParse($pv.ToString(), [ref]$intVal)) { $workerPid = $intVal }
+                            }
+                        }
+                    }
+                    elseif ($props.Count -gt 0) {
+                        $v = [string]$props[0].Value
+                        if (-not [string]::IsNullOrWhiteSpace($v)) { $poolName = $v }
+                    }
+                }
+                catch { $null = $_ }
+
+                $category   = if ($meta) { [string]$meta['Category'] }  else { 'Other' }
+                $reasonCode = if ($meta) { [string]$meta['ReasonCode'] } else { $null   }
+
+                $reason = $null
+                try {
+                    $msgRaw = $evt.Message
+                    if (-not [string]::IsNullOrWhiteSpace($msgRaw)) {
+                        $reason = ($msgRaw -replace '\r?\n', ' ' -replace '\s{2,}', ' ').Trim()
+                        if ($reason.Length -gt 200) { $reason = $reason.Substring(0, 200) + '...' }
+                    }
+                }
+                catch { $null = $_ }
+
+                $tcUtc   = [datetime]::SpecifyKind($evt.TimeCreated.ToUniversalTime(), [System.DateTimeKind]::Utc)
+                $tcLocal = $evt.TimeCreated
+
+                $parsed.Add(@{
+                    TimeCreated      = $tcUtc
+                    TimeCreatedLocal = $tcLocal
+                    AppPoolName      = $poolName
+                    Category         = $category
+                    EventId          = $id
+                    WorkerPid        = $workerPid
+                    ReasonCode       = $reasonCode
+                    Reason           = $reason
+                    ProviderName     = $evt.ProviderName
+                    LogName          = $evt.LogName
+                    RecordId         = $evt.RecordId
+                    MachineName      = $evt.MachineName
+                })
+            }
+
+            # ── 5. Post-filter: AppPoolName wildcard ─────────────────────────
+            if ($FilterAppPool -and $FilterAppPool.Count -gt 0) {
+                $keep = [System.Collections.Generic.List[hashtable]]::new()
+                foreach ($row in $parsed) {
+                    $pool = $row['AppPoolName']
+                    if ($null -ne $pool) {
+                        foreach ($pat in $FilterAppPool) {
+                            if ($pool -like $pat) { $keep.Add($row); break }
+                        }
+                    }
+                }
+                $parsed = $keep
+            }
+
+            if ($parsed.Count -eq 0) { return }
+
+            # ── 6. Tail: keep most recent N, then output chronologically ──────
+            if ($TailN -gt 0 -and $parsed.Count -gt $TailN) {
+                $sorted = @($parsed | Sort-Object { [datetime]$_['TimeCreated'] } -Descending)
+                $tail   = [System.Collections.Generic.List[hashtable]]::new()
+                for ($i = 0; $i -lt $TailN -and $i -lt $sorted.Count; $i++) {
+                    $tail.Add($sorted[$i])
+                }
+                $parsed = $tail
+            }
+
+            # ── 7. Chronological sort for final output ────────────────────────
+            @($parsed | Sort-Object { [datetime]$_['TimeCreated'] })
+        }
+    }
+
+    process {
+        foreach ($cn in $ComputerName) {
+            Write-Verbose -Message "[$($MyInvocation.MyCommand)] Querying '$cn'"
+
+            try {
+                $invokeParams = @{
+                    ComputerName = $cn
+                    ScriptBlock  = $scriptBlock
+                    ArgumentList = @(
+                        $eventIdMap,
+                        $systemIds,
+                        $applicationIds,
+                        $operationalQueryIds,
+                        $AppPoolName,
+                        $(if ($PSBoundParameters.ContainsKey('After'))  { $After  } else { [datetime]::MinValue }),
+                        $PSBoundParameters.ContainsKey('After'),
+                        $(if ($PSBoundParameters.ContainsKey('Before')) { $Before } else { [datetime]::MaxValue }),
+                        $PSBoundParameters.ContainsKey('Before'),
+                        [bool]$IncludeOperationalLog.IsPresent,
+                        [int]$MaxEvents,
+                        $(if ($PSBoundParameters.ContainsKey('Tail')) { [int]$Tail } else { [int]0 })
+                    )
+                }
+                if ($PSBoundParameters.ContainsKey('Credential')) {
+                    $invokeParams['Credential'] = $Credential
+                }
+
+                $rawResults = Invoke-RemoteOrLocal @invokeParams
+            }
+            catch {
+                Write-Error -Message "[$($MyInvocation.MyCommand)] Failed to query '$cn': $($_.Exception.Message)"
+                continue
+            }
+
+            if ($null -eq $rawResults) { continue }
+
+            foreach ($row in $rawResults) {
+                [PSCustomObject]@{
+                    PSTypeName       = 'PSWinOps.IISAppPoolHistoryEvent'
+                    TimeCreated      = $row['TimeCreated']
+                    TimeCreatedLocal = $row['TimeCreatedLocal']
+                    ComputerName     = $cn
+                    AppPoolName      = $row['AppPoolName']
+                    Category         = $row['Category']
+                    EventId          = $row['EventId']
+                    WorkerPid        = $row['WorkerPid']
+                    ReasonCode       = $row['ReasonCode']
+                    Reason           = $row['Reason']
+                    ProviderName     = $row['ProviderName']
+                    LogName          = $row['LogName']
+                    RecordId         = $row['RecordId']
+                    MachineName      = $row['MachineName']
+                    Timestamp        = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
+                }
+            }
+        }
+    }
+
+    end {
+        Write-Verbose -Message "[$($MyInvocation.MyCommand)] Done"
+    }
+}

--- a/Tests/Public/iis/Get-IISAppPoolHistory.Tests.ps1
+++ b/Tests/Public/iis/Get-IISAppPoolHistory.Tests.ps1
@@ -1,0 +1,733 @@
+﻿#Requires -Version 5.1
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSUseDeclaredVarsMoreThanAssignments', '',
+    Justification = 'Script-scoped variables are assigned in mocks and assertions across separate scopes'
+)]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSAvoidUsingConvertToSecureStringWithPlainText', '',
+    Justification = 'Test fixture only -- not a real credential'
+)]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSAvoidUsingComputerNameHardcoded', '',
+    Justification = 'Fake target names used exclusively in test fixtures -- no real machines are contacted'
+)]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSReviewUnusedParameter', '',
+    Justification = 'Stub parameters are declared to satisfy the Pester mock engine (PR #42) but have no body'
+)]
+param()
+
+BeforeAll {
+    $script:modulePath = Split-Path -Path (Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent) -Parent
+    # PSWinOps is Windows-only. On Linux/macOS the module guard throws, so we
+    # conditionally import here and skip all tests via -Skip on the Describe block.
+    if ($IsWindows -or $PSEdition -eq 'Desktop') {
+        Import-Module -Name (Join-Path -Path $script:modulePath -ChildPath 'PSWinOps.psd1') -Force
+    }
+    $script:ModuleName = 'PSWinOps'
+
+    # Stub for Get-WinEvent -- parameters declared so Pester mock engine matches correctly (PR #42).
+    if (-not (Get-Command -Name 'Get-WinEvent' -ErrorAction SilentlyContinue)) {
+        function global:Get-WinEvent {
+            param(
+                [hashtable]$FilterHashtable,
+                [int]$MaxEvents,
+                [string]$LogName,
+                [string]$ErrorAction
+            )
+        }
+    }
+
+    # ── Reusable base UTC timestamp ────────────────────────────────────────────
+    $script:baseUtc = [datetime]::SpecifyKind(
+        [datetime]::Parse('2026-05-01 10:00:00'),
+        [System.DateTimeKind]::Utc
+    )
+
+    # ── Mock event rows: hashtables mirroring the shape emitted by the scriptblock ──
+
+    $script:mockRecycle5074 = @(
+        @{
+            TimeCreated      = $script:baseUtc
+            TimeCreatedLocal = $script:baseUtc.ToLocalTime()
+            AppPoolName      = 'DefaultAppPool'
+            Category         = 'Recycle'
+            EventId          = 5074
+            WorkerPid        = $null
+            ReasonCode       = 'ConfigChange'
+            Reason           = "Application pool DefaultAppPool was recycled due to configuration change."
+            ProviderName     = 'Microsoft-Windows-WAS'
+            LogName          = 'System'
+            RecordId         = [long]12345
+            MachineName      = 'WEB01.contoso.com'
+        }
+    )
+
+    $script:mockRapidFail5117 = @(
+        @{
+            TimeCreated      = $script:baseUtc
+            TimeCreatedLocal = $script:baseUtc.ToLocalTime()
+            AppPoolName      = 'API-Pool'
+            Category         = 'RapidFail'
+            EventId          = 5117
+            WorkerPid        = $null
+            ReasonCode       = 'RapidFailProtection'
+            Reason           = "Application pool API-Pool was disabled by rapid-fail protection."
+            ProviderName     = 'Microsoft-Windows-WAS'
+            LogName          = 'System'
+            RecordId         = [long]22222
+            MachineName      = 'WEB01.contoso.com'
+        }
+    )
+
+    $script:mockCrash5010 = @(
+        @{
+            TimeCreated      = $script:baseUtc
+            TimeCreatedLocal = $script:baseUtc.ToLocalTime()
+            AppPoolName      = 'crash-pool'
+            Category         = 'Crash'
+            EventId          = 5010
+            WorkerPid        = 4321
+            ReasonCode       = 'ISAPI'
+            Reason           = "Worker process 4321 crash for app pool crash-pool."
+            ProviderName     = 'W3SVC-WP'
+            LogName          = 'Application'
+            RecordId         = [long]99999
+            MachineName      = 'WEB01.contoso.com'
+        }
+    )
+
+    $script:mockStart5057 = @(
+        @{
+            TimeCreated      = $script:baseUtc
+            TimeCreatedLocal = $script:baseUtc.ToLocalTime()
+            AppPoolName      = 'DefaultAppPool'
+            Category         = 'Start'
+            EventId          = 5057
+            WorkerPid        = $null
+            ReasonCode       = 'PoolStarted'
+            Reason           = "Application pool DefaultAppPool was started."
+            ProviderName     = 'Microsoft-Windows-WAS'
+            LogName          = 'System'
+            RecordId         = [long]30001
+            MachineName      = 'WEB01.contoso.com'
+        }
+    )
+
+    $script:mockStop5059 = @(
+        @{
+            TimeCreated      = $script:baseUtc
+            TimeCreatedLocal = $script:baseUtc.ToLocalTime()
+            AppPoolName      = 'DefaultAppPool'
+            Category         = 'Stop'
+            EventId          = 5059
+            WorkerPid        = $null
+            ReasonCode       = 'PoolStopped'
+            Reason           = "Application pool DefaultAppPool was stopped."
+            ProviderName     = 'Microsoft-Windows-WAS'
+            LogName          = 'System'
+            RecordId         = [long]40001
+            MachineName      = 'WEB01.contoso.com'
+        }
+    )
+
+    $script:mockIdentity5021 = @(
+        @{
+            TimeCreated      = $script:baseUtc
+            TimeCreatedLocal = $script:baseUtc.ToLocalTime()
+            AppPoolName      = 'SvcPool'
+            Category         = 'IdentityChange'
+            EventId          = 5021
+            WorkerPid        = $null
+            ReasonCode       = 'IdentityChange'
+            Reason           = "Application pool SvcPool identity changed."
+            ProviderName     = 'Microsoft-Windows-WAS'
+            LogName          = 'System'
+            RecordId         = [long]50001
+            MachineName      = 'WEB01.contoso.com'
+        }
+    )
+
+    $script:mockOrphan5168 = @(
+        @{
+            TimeCreated      = $script:baseUtc
+            TimeCreatedLocal = $script:baseUtc.ToLocalTime()
+            AppPoolName      = 'orphan-pool'
+            Category         = 'OrphanWP'
+            EventId          = 5168
+            WorkerPid        = 7890
+            ReasonCode       = 'OrphanWorkerProcess'
+            Reason           = "Worker process 7890 for orphan-pool was orphaned."
+            ProviderName     = 'Microsoft-Windows-WAS'
+            LogName          = 'System'
+            RecordId         = [long]60001
+            MachineName      = 'WEB01.contoso.com'
+        }
+    )
+
+    # Five events spread over 20 minutes -- used for -Tail and -AppPoolName tests.
+    $script:mockMultiple = @(
+        @{
+            TimeCreated      = $script:baseUtc
+            TimeCreatedLocal = $script:baseUtc.ToLocalTime()
+            AppPoolName      = 'api-prod'
+            Category         = 'Recycle'
+            EventId          = 5074
+            WorkerPid        = $null
+            ReasonCode       = 'ConfigChange'
+            Reason           = 'api-prod recycle'
+            ProviderName     = 'Microsoft-Windows-WAS'
+            LogName          = 'System'
+            RecordId         = [long]1
+            MachineName      = 'WEB01'
+        }
+        @{
+            TimeCreated      = $script:baseUtc.AddMinutes(5)
+            TimeCreatedLocal = $script:baseUtc.AddMinutes(5).ToLocalTime()
+            AppPoolName      = 'api-stage'
+            Category         = 'Recycle'
+            EventId          = 5076
+            WorkerPid        = $null
+            ReasonCode       = 'ScheduleTime'
+            Reason           = 'api-stage schedule recycle'
+            ProviderName     = 'Microsoft-Windows-WAS'
+            LogName          = 'System'
+            RecordId         = [long]2
+            MachineName      = 'WEB01'
+        }
+        @{
+            TimeCreated      = $script:baseUtc.AddMinutes(10)
+            TimeCreatedLocal = $script:baseUtc.AddMinutes(10).ToLocalTime()
+            AppPoolName      = 'web-api'
+            Category         = 'Stop'
+            EventId          = 5059
+            WorkerPid        = $null
+            ReasonCode       = 'PoolStopped'
+            Reason           = 'web-api stop'
+            ProviderName     = 'Microsoft-Windows-WAS'
+            LogName          = 'System'
+            RecordId         = [long]3
+            MachineName      = 'WEB01'
+        }
+        @{
+            TimeCreated      = $script:baseUtc.AddMinutes(15)
+            TimeCreatedLocal = $script:baseUtc.AddMinutes(15).ToLocalTime()
+            AppPoolName      = 'api-prod'
+            Category         = 'Start'
+            EventId          = 5057
+            WorkerPid        = $null
+            ReasonCode       = 'PoolStarted'
+            Reason           = 'api-prod start'
+            ProviderName     = 'Microsoft-Windows-WAS'
+            LogName          = 'System'
+            RecordId         = [long]4
+            MachineName      = 'WEB01'
+        }
+        @{
+            TimeCreated      = $script:baseUtc.AddMinutes(20)
+            TimeCreatedLocal = $script:baseUtc.AddMinutes(20).ToLocalTime()
+            AppPoolName      = 'api-stage'
+            Category         = 'Crash'
+            EventId          = 5010
+            WorkerPid        = 4321
+            ReasonCode       = 'ISAPI'
+            Reason           = 'api-stage crash'
+            ProviderName     = 'W3SVC-WP'
+            LogName          = 'Application'
+            RecordId         = [long]5
+            MachineName      = 'WEB01'
+        }
+    )
+}
+
+Describe 'Get-IISAppPoolHistory' -Skip:(-not ($IsWindows -or $PSEdition -eq 'Desktop')) {
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # Context 1 -- Happy path: all mandatory output properties populated
+    # ─────────────────────────────────────────────────────────────────────────
+    Context 'Happy path: Recycle event returns PSTypeName and all mandatory properties' {
+
+        It 'Should return exactly one object with PSTypeName PSWinOps.IISAppPoolHistoryEvent' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith {
+                return $script:mockRecycle5074
+            }
+            $result = Get-IISAppPoolHistory -ComputerName 'WEB01'
+            @($result).Count              | Should -Be 1
+            $result.PSObject.TypeNames[0] | Should -Be 'PSWinOps.IISAppPoolHistoryEvent'
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should populate all mandatory output properties from the row hashtable' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith {
+                return $script:mockRecycle5074
+            }
+            $result = Get-IISAppPoolHistory -ComputerName 'WEB01'
+            $result.ComputerName | Should -Be 'WEB01'
+            $result.AppPoolName  | Should -Be 'DefaultAppPool'
+            $result.Category     | Should -Be 'Recycle'
+            $result.EventId      | Should -Be 5074
+            $result.ReasonCode   | Should -Be 'ConfigChange'
+            $result.LogName      | Should -Be 'System'
+            $result.RecordId     | Should -Be 12345
+            $result.MachineName  | Should -Be 'WEB01.contoso.com'
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should set TimeCreated and TimeCreatedLocal as datetime objects' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith {
+                return $script:mockRecycle5074
+            }
+            $result = Get-IISAppPoolHistory -ComputerName 'WEB01'
+            $result.TimeCreated      | Should -BeOfType [datetime]
+            $result.TimeCreatedLocal | Should -BeOfType [datetime]
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should set Timestamp string matching yyyy-MM-dd HH:mm:ss format' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith {
+                return $script:mockRecycle5074
+            }
+            $result = Get-IISAppPoolHistory -ComputerName 'WEB01'
+            $result.Timestamp | Should -Match "^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$"
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+    }
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # Context 2 -- EventId to Category mapping: one representative per family
+    # ─────────────────────────────────────────────────────────────────────────
+    Context 'EventId to Category mapping: one representative per event family' {
+
+        It 'Should map EventId 5074 to Recycle / ConfigChange (WAS Recycle family)' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith {
+                return $script:mockRecycle5074
+            }
+            $result = Get-IISAppPoolHistory -ComputerName 'WEB01'
+            $result.Category   | Should -Be 'Recycle'
+            $result.ReasonCode | Should -Be 'ConfigChange'
+            $result.EventId    | Should -Be 5074
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should map EventId 5117 to RapidFail / RapidFailProtection' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith {
+                return $script:mockRapidFail5117
+            }
+            $result = Get-IISAppPoolHistory -ComputerName 'WEB01'
+            $result.Category   | Should -Be 'RapidFail'
+            $result.ReasonCode | Should -Be 'RapidFailProtection'
+            $result.EventId    | Should -Be 5117
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should map EventId 5010 to Crash / ISAPI with WorkerPid from InsertionStrings[0]' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith {
+                return $script:mockCrash5010
+            }
+            $result = Get-IISAppPoolHistory -ComputerName 'WEB01'
+            $result.Category   | Should -Be 'Crash'
+            $result.ReasonCode | Should -Be 'ISAPI'
+            $result.EventId    | Should -Be 5010
+            $result.WorkerPid  | Should -Be 4321
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should map EventId 5057 to Start / PoolStarted' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith {
+                return $script:mockStart5057
+            }
+            $result = Get-IISAppPoolHistory -ComputerName 'WEB01'
+            $result.Category   | Should -Be 'Start'
+            $result.ReasonCode | Should -Be 'PoolStarted'
+            $result.EventId    | Should -Be 5057
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should map EventId 5059 to Stop / PoolStopped' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith {
+                return $script:mockStop5059
+            }
+            $result = Get-IISAppPoolHistory -ComputerName 'WEB01'
+            $result.Category   | Should -Be 'Stop'
+            $result.ReasonCode | Should -Be 'PoolStopped'
+            $result.EventId    | Should -Be 5059
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should map EventId 5021 to IdentityChange / IdentityChange' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith {
+                return $script:mockIdentity5021
+            }
+            $result = Get-IISAppPoolHistory -ComputerName 'WEB01'
+            $result.Category   | Should -Be 'IdentityChange'
+            $result.ReasonCode | Should -Be 'IdentityChange'
+            $result.EventId    | Should -Be 5021
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should map EventId 5168 to OrphanWP / OrphanWorkerProcess with WorkerPid from InsertionStrings[1]' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith {
+                return $script:mockOrphan5168
+            }
+            $result = Get-IISAppPoolHistory -ComputerName 'WEB01'
+            $result.Category   | Should -Be 'OrphanWP'
+            $result.ReasonCode | Should -Be 'OrphanWorkerProcess'
+            $result.EventId    | Should -Be 5168
+            $result.WorkerPid  | Should -Be 7890
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+    }
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # Context 3 -- -After / -Before forwarded via ArgumentList[5..8]
+    # ─────────────────────────────────────────────────────────────────────────
+    Context '-After and -Before forwarded into the ArgumentList for server-side filtering' {
+
+        It 'Should set HasAfter=true and FilterAfter in ArgumentList when -After is specified' {
+            $cutoff = [datetime]::Parse('2026-05-01 08:00:00')
+            $script:capturedAfterArgs = $null
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith {
+                $script:capturedAfterArgs = $ArgumentList
+                return @()
+            }
+            $null = Get-IISAppPoolHistory -ComputerName 'WEB01' -After $cutoff
+            $script:capturedAfterArgs[6] | Should -BeTrue
+            $script:capturedAfterArgs[5] | Should -Be $cutoff
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should set HasBefore=true and FilterBefore in ArgumentList when -Before is specified' {
+            $cutoff = [datetime]::Parse('2026-05-15 23:59:59')
+            $script:capturedBeforeArgs = $null
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith {
+                $script:capturedBeforeArgs = $ArgumentList
+                return @()
+            }
+            $null = Get-IISAppPoolHistory -ComputerName 'WEB01' -Before $cutoff
+            $script:capturedBeforeArgs[8] | Should -BeTrue
+            $script:capturedBeforeArgs[7] | Should -Be $cutoff
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should set HasAfter=false and HasBefore=false when neither is specified' {
+            $script:capturedNoDateArgs = $null
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith {
+                $script:capturedNoDateArgs = $ArgumentList
+                return @()
+            }
+            $null = Get-IISAppPoolHistory -ComputerName 'WEB01'
+            $script:capturedNoDateArgs[6] | Should -BeFalse
+            $script:capturedNoDateArgs[8] | Should -BeFalse
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+    }
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # Context 4 -- -Tail forwarded via ArgumentList[11]; 0 means no limit
+    # ─────────────────────────────────────────────────────────────────────────
+    Context '-Tail value forwarded to ArgumentList[11]; default 0 means no tail applied' {
+
+        It 'Should forward -Tail 3 to ArgumentList[11]' {
+            $script:capturedTailArgs = $null
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith {
+                $script:capturedTailArgs = $ArgumentList
+                return @()
+            }
+            $null = Get-IISAppPoolHistory -ComputerName 'WEB01' -Tail 3
+            $script:capturedTailArgs[11] | Should -Be 3
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should forward TailN=0 when -Tail is not specified and return all events' {
+            $script:capturedTailDefaultArgs = $null
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith {
+                $script:capturedTailDefaultArgs = $ArgumentList
+                return $script:mockMultiple
+            }
+            $results = Get-IISAppPoolHistory -ComputerName 'WEB01'
+            @($results).Count                   | Should -Be 5
+            $script:capturedTailDefaultArgs[11] | Should -Be 0
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+    }
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # Context 5 -- -AppPoolName wildcard filter forwarded via ArgumentList[4]
+    # ─────────────────────────────────────────────────────────────────────────
+    Context '-AppPoolName wildcard: api-* matches api-prod/api-stage; not web-api' {
+
+        It 'Should forward -AppPoolName patterns to ArgumentList[4]' {
+            $script:capturedPoolArgs = $null
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith {
+                $script:capturedPoolArgs = $ArgumentList
+                return @()
+            }
+            $null = Get-IISAppPoolHistory -ComputerName 'WEB01' -AppPoolName 'api-*'
+            $script:capturedPoolArgs[4] | Should -Contain 'api-*'
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should only surface api-* matching rows (4 out of 5) when scriptblock applies the filter' {
+            $apiRows = @($script:mockMultiple | Where-Object { $_['AppPoolName'] -like 'api-*' })
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith {
+                return $apiRows
+            }
+            $results = Get-IISAppPoolHistory -ComputerName 'WEB01' -AppPoolName 'api-*'
+            @($results).Count | Should -Be 4
+            foreach ($r in $results) {
+                $r.AppPoolName | Should -BeLike 'api-*'
+            }
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+    }
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # Context 6 -- -Category resolves to correct EventId set; union with -EventId
+    # ─────────────────────────────────────────────────────────────────────────
+    Context '-Category resolves to correct EventId set; -Category + -EventId unions the two sets' {
+
+        It 'Should populate systemIds with all Recycle IDs and leave applicationIds empty for -Category Recycle' {
+            $script:capturedCatArgs = $null
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith {
+                $script:capturedCatArgs = $ArgumentList
+                return @()
+            }
+            $null = Get-IISAppPoolHistory -ComputerName 'WEB01' -Category Recycle
+            $sysIds = [int[]]$script:capturedCatArgs[1]
+            $appIds = [int[]]$script:capturedCatArgs[2]
+            $sysIds | Should -Contain 5074
+            $sysIds | Should -Contain 5076
+            $sysIds | Should -Contain 5079
+            $sysIds | Should -Contain 5080
+            $appIds | Should -BeNullOrEmpty
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should union -Category Crash Application IDs with -EventId 5057 System ID' {
+            $script:capturedUnionArgs = $null
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith {
+                $script:capturedUnionArgs = $ArgumentList
+                return @()
+            }
+            $null = Get-IISAppPoolHistory -ComputerName 'WEB01' -Category Crash -EventId 5057
+            $appIds = [int[]]$script:capturedUnionArgs[2]
+            $sysIds = [int[]]$script:capturedUnionArgs[1]
+            $appIds | Should -Contain 5009
+            $appIds | Should -Contain 5010
+            $sysIds | Should -Contain 5057
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+    }
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # Context 7 -- -IncludeOperationalLog controls ArgumentList[9]
+    # ─────────────────────────────────────────────────────────────────────────
+    Context '-IncludeOperationalLog: ArgumentList[9] is true when specified, false by default' {
+
+        It 'Should set ArgumentList[9] (IncludeOp) to true when -IncludeOperationalLog is specified' {
+            $script:capturedOpTrueArgs = $null
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith {
+                $script:capturedOpTrueArgs = $ArgumentList
+                return @()
+            }
+            $null = Get-IISAppPoolHistory -ComputerName 'WEB01' -IncludeOperationalLog
+            $script:capturedOpTrueArgs[9] | Should -BeTrue
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should set ArgumentList[9] (IncludeOp) to false when -IncludeOperationalLog is not specified' {
+            $script:capturedOpFalseArgs = $null
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith {
+                $script:capturedOpFalseArgs = $ArgumentList
+                return @()
+            }
+            $null = Get-IISAppPoolHistory -ComputerName 'WEB01'
+            $script:capturedOpFalseArgs[9] | Should -BeFalse
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+    }
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # Context 8 -- Pipeline by property name: ComputerName and AppPoolName
+    # ─────────────────────────────────────────────────────────────────────────
+    Context 'Pipeline by property name: ComputerName and AppPoolName bound from pipeline objects' {
+
+        It 'Should fan-out across two pipeline objects with ComputerName property' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith {
+                return $script:mockRecycle5074
+            }
+            $pipeObjs = @(
+                [PSCustomObject]@{ ComputerName = 'WEB01' }
+                [PSCustomObject]@{ ComputerName = 'WEB02' }
+            )
+            $results = $pipeObjs | Get-IISAppPoolHistory
+            @($results).Count | Should -Be 2
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 2 -Exactly
+        }
+
+        It 'Should bind AppPoolName from pipeline object by property name and forward to ArgumentList[4]' {
+            $script:capturedPipePoolArgs = $null
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith {
+                $script:capturedPipePoolArgs = $ArgumentList
+                return @()
+            }
+            $pipeObj = [PSCustomObject]@{ ComputerName = 'WEB01'; AppPoolName = 'pipe-pool' }
+            $null    = $pipeObj | Get-IISAppPoolHistory
+            $script:capturedPipePoolArgs[4] | Should -Contain 'pipe-pool'
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should bind ComputerName via Server alias from pipeline by property name' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith {
+                return $script:mockRecycle5074
+            }
+            $pipeObj = [PSCustomObject]@{ Server = 'WEB03' }
+            $result  = $pipeObj | Get-IISAppPoolHistory
+            $result              | Should -Not -BeNullOrEmpty
+            $result.ComputerName | Should -Be 'WEB03'
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+    }
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # Context 9 -- Credential propagation
+    # ─────────────────────────────────────────────────────────────────────────
+    Context 'Credential propagation: PSCredential forwarded to Invoke-RemoteOrLocal' {
+
+        It 'Should forward Credential to Invoke-RemoteOrLocal when -Credential is specified' {
+            $securePass          = ConvertTo-SecureString -String 'P@ssw0rd!' -AsPlainText -Force
+            $cred                = [System.Management.Automation.PSCredential]::new('DOMAIN\svcacct', $securePass)
+            $script:capturedCred = $null
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith {
+                $script:capturedCred = $Credential
+                return $script:mockRecycle5074
+            }
+            $result = Get-IISAppPoolHistory -ComputerName 'WEB01' -Credential $cred
+            $result                       | Should -Not -BeNullOrEmpty
+            $script:capturedCred          | Should -Not -BeNullOrEmpty
+            $script:capturedCred.UserName | Should -Be 'DOMAIN\svcacct'
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should not forward Credential when -Credential is omitted (null in mock)' {
+            $script:credNullCount = 0
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith {
+                if ($null -eq $Credential) { $script:credNullCount++ }
+                return @()
+            }
+            $null = Get-IISAppPoolHistory -ComputerName 'WEB01'
+            $script:credNullCount | Should -Be 1
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+    }
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # Context 10 -- ComputerName fan-out
+    # ─────────────────────────────────────────────────────────────────────────
+    Context 'ComputerName fan-out: two machines queried, results labelled correctly' {
+
+        It 'Should call Invoke-RemoteOrLocal twice and label each result row with its ComputerName' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith {
+                return $script:mockRecycle5074
+            }
+            $results = Get-IISAppPoolHistory -ComputerName 'WEB01', 'WEB02'
+            @($results).Count        | Should -Be 2
+            $results[0].ComputerName | Should -Be 'WEB01'
+            $results[1].ComputerName | Should -Be 'WEB02'
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 2 -Exactly
+        }
+    }
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # Context 11 -- Error isolation per machine
+    # ─────────────────────────────────────────────────────────────────────────
+    Context 'Error isolation: failed machine does not suppress results from healthy machine' {
+
+        It 'Should return results from WEB02 even when DEAD01 throws a WinRM error' {
+            $script:isolationCallIndex = 0
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith {
+                $script:isolationCallIndex++
+                if ($script:isolationCallIndex -eq 1) { throw 'WinRM connection refused' }
+                return $script:mockRecycle5074
+            }
+            $results = Get-IISAppPoolHistory -ComputerName 'DEAD01', 'WEB02' -ErrorAction SilentlyContinue
+            @($results).Count        | Should -Be 1
+            $results[0].ComputerName | Should -Be 'WEB02'
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 2 -Exactly
+        }
+    }
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # Context 12 -- Empty result: no synthetic placeholder emitted
+    # ─────────────────────────────────────────────────────────────────────────
+    Context 'Empty result: zero objects emitted when no matching events found' {
+
+        It 'Should emit zero objects when Invoke-RemoteOrLocal returns an empty array' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith {
+                return @()
+            }
+            $results = @(Get-IISAppPoolHistory -ComputerName 'WEB01')
+            $results.Count | Should -Be 0
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should emit zero objects when Invoke-RemoteOrLocal returns null' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith {
+                return $null
+            }
+            $results = @(Get-IISAppPoolHistory -ComputerName 'WEB01')
+            $results.Count | Should -Be 0
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+    }
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # Context 13 -- Missing log channel: Write-Warning, no terminating error
+    # ─────────────────────────────────────────────────────────────────────────
+    Context 'Missing log channel: no terminating error thrown; function returns normally' {
+
+        It 'Should not throw when the Operational log channel is unavailable' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith {
+                Write-Warning 'Operational log channel is unavailable or disabled. Skipping.'
+                return @()
+            }
+            { Get-IISAppPoolHistory -ComputerName 'WEB01' -IncludeOperationalLog } | Should -Not -Throw
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should still return events from other channels when one channel produces a warning' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith {
+                Write-Warning 'Operational log channel is unavailable or disabled. Skipping.'
+                return $script:mockRecycle5074
+            }
+            $results = Get-IISAppPoolHistory -ComputerName 'WEB01' -IncludeOperationalLog
+            @($results).Count | Should -Be 1
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+    }
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # Context 14 -- BOM / CRLF sentinel
+    # ─────────────────────────────────────────────────────────────────────────
+    Context 'BOM and CRLF sentinel: test source file encoding' {
+
+        It 'Test source file starts with UTF-8 BOM bytes (0xEF 0xBB 0xBF)' {
+            $bytes    = [System.IO.File]::ReadAllBytes($PSCommandPath)
+            $bytes[0] | Should -Be 0xEF
+            $bytes[1] | Should -Be 0xBB
+            $bytes[2] | Should -Be 0xBF
+        }
+
+        It 'Test source file uses CRLF line endings' {
+            $raw = [System.IO.File]::ReadAllText($PSCommandPath)
+            $raw | Should -Match "`r`n"
+        }
+
+        It 'Get-Content on test source file first line matches the Requires directive' {
+            $firstLine = (Get-Content -LiteralPath $PSCommandPath -First 1)
+            $firstLine | Should -Match '#Requires'
+        }
+    }
+}

--- a/en-US/about_PSWinOps.help.txt
+++ b/en-US/about_PSWinOps.help.txt
@@ -84,13 +84,15 @@ FUNCTION DOMAINS
       Get-ServiceHealth
       Get-WSUSHealth
 
-  iis (8 functions)
+  iis (9 functions)
     Functions for managing IIS sites, HTTPS bindings,
     log file analysis, real-time log streaming, worker
     process monitoring, in-flight request inspection,
-    and certificate binding validation across local or
+    certificate binding validation, and application pool
+    lifecycle history reconstruction across local or
     remote servers.
 
+      Get-IISAppPoolHistory
       Get-IISCertificateBinding
       Get-IISCurrentRequest
       Get-IISFailedRequestTrace
@@ -291,7 +293,7 @@ REMOTE EXECUTION PATTERN
     in the pipeline continue to be processed.
 
 PSWINOPS TYPE REGISTRY
-    The following 93 PSTypeName values are defined by the
+    The following 94 PSTypeName values are defined by the
     module. Each corresponds to the output of one or more
     public functions.
 
@@ -336,6 +338,7 @@ PSWINOPS TYPE REGISTRY
       PSWinOps.ExchangeServerHealth
       PSWinOps.FileServerHealth
       PSWinOps.HyperVHostHealth
+      PSWinOps.IISAppPoolHistoryEvent
       PSWinOps.IISBindingCertificateResult
       PSWinOps.IISCertificateBinding
       PSWinOps.IISCertificateBindingTestResult


### PR DESCRIPTION
## Summary
Mines the System (Microsoft-Windows-WAS), Application (W3SVC-WP, WAS) and optionally the Microsoft-Windows-IIS-W3SVC-WP/Operational event logs on one or more servers, then classifies every relevant entry into a typed `PSWinOps.IISAppPoolHistoryEvent` object enriched with the owning application pool, worker PID and a normalised reason code. Provides the operational timeline IISAdministration does not expose, with server-side filtering via `Get-WinEvent -FilterHashtable` for performance.

## Files touched
- `Public/iis/Get-IISAppPoolHistory.ps1` — implementation
- `Tests/Public/iis/Get-IISAppPoolHistory.Tests.ps1` — Pester v5 suite (36 tests, Windows-gated)
- `PSWinOps.psd1` — `FunctionsToExport`, `ModuleVersion` (0.1.8 → 0.1.9), `ReleaseNotes`
- `PSWinOps.Format.ps1xml` — new `<View>` for `PSWinOps.IISAppPoolHistoryEvent`
- `en-US/about_PSWinOps.help.txt` — iis counter bumped (8 → 9)

## Conformance checklist (auto-audited by fn-quality-gate)
- [x] UTF-8 BOM + CRLF on all new files
- [x] Approved PowerShell verb (`Get`)
- [x] `FunctionsToExport` alphabetically sorted (case-insensitive, repo convention)
- [x] `PSTypeName` consistent across `.ps1` / `Format.ps1xml` / help (`PSWinOps.IISAppPoolHistoryEvent`)
- [x] PSScriptAnalyzer clean (0 Error/Warning on changed paths)
- [x] Pester suite executes (0 failed; 36 skipped on Linux — Windows-gated, runs in CI)
- [x] No `Write-Host`, no `ToString('o')` introduced
- [x] `Test-ModuleManifest` succeeds
- [x] `PSWinOps.Format.ps1xml` valid XML, contains a `<View>` whose `<TypeName>` is `PSWinOps.IISAppPoolHistoryEvent`
- [x] Branch protection on `main` requires `validate`, `lint`, and all `test (Public/*)` jobs incl. `test (Public/iis)` — safe to arm auto-merge

## Auto-merge
✅ Armed via `gh pr merge --auto --squash --delete-branch`. Will merge automatically once all required Windows CI checks are green. Any failure is picked up by `pswinops-fn-ci-watcher`, which loops back through `pswinops-fn-author MODE=fix` (max 3 iterations).
