### PR TITLE
feat(iis): add Get-IISAppPool

### DIFF
--- a/.kdust/chains/get-iisapppool-2606222022.yaml
+++ b/.kdust/chains/get-iisapppool-2606222022.yaml
@@ -1,0 +1,7 @@
+chain: pswinops-function-author
+function: Get-IISAppPool
+domain: iis
+created: 2026-06-22T20:22:50Z
+created_by: pswinops-fn-spec-analyst
+chain_branch: kdust/chain/pswinops-fn-get-iisapppool-2606222022
+spec_path: work/get-iisapppool/spec.yaml

--- a/PSWinOps.Format.ps1xml
+++ b/PSWinOps.Format.ps1xml
@@ -7312,5 +7312,89 @@
         </TableRowEntries>
       </TableControl>
     </View>
+    <!-- ============================================================ -->
+    <!-- PSWinOps.IISAppPool                                         -->
+    <!-- Used by: Get-IISAppPool                                     -->
+    <!-- ============================================================ -->
+    <View>
+      <Name>PSWinOps.IISAppPool</Name>
+      <ViewSelectedBy>
+        <TypeName>PSWinOps.IISAppPool</TypeName>
+      </ViewSelectedBy>
+      <TableControl>
+        <AutoSize />
+        <TableHeaders>
+          <TableColumnHeader>
+            <Label>ComputerName</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Name</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>State</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>ManagedRuntimeVersion</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>ManagedPipelineMode</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>IdentityType</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>StartMode</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>QueueLength</Label>
+            <Alignment>Right</Alignment>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>IdleTimeoutMinutes</Label>
+            <Alignment>Right</Alignment>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>CpuLimitPercent</Label>
+            <Alignment>Right</Alignment>
+          </TableColumnHeader>
+        </TableHeaders>
+        <TableRowEntries>
+          <TableRowEntry>
+            <TableColumnItems>
+              <TableColumnItem>
+                <PropertyName>ComputerName</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>Name</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>State</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>ManagedRuntimeVersion</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>ManagedPipelineMode</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>IdentityType</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>StartMode</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>QueueLength</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>IdleTimeoutMinutes</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>CpuLimitPercent</PropertyName>
+              </TableColumnItem>
+            </TableColumnItems>
+          </TableRowEntry>
+        </TableRowEntries>
+      </TableControl>
+    </View>
   </ViewDefinitions>
 </Configuration>

--- a/PSWinOps.psd1
+++ b/PSWinOps.psd1
@@ -12,7 +12,7 @@
     RootModule           = 'PSWinOps.psm1'
 
     # Version number of this module.
-    ModuleVersion        = '0.0.23'
+    ModuleVersion        = '0.0.24'
 
     # Supported PSEditions
     # Core is supported on Windows only; the module-level guard in PSWinOps.psm1 blocks
@@ -265,7 +265,11 @@
             # IconUri = ''
 
             # ReleaseNotes of this module
-            ReleaseNotes = '## 0.0.23 - 2026-05-21
+            ReleaseNotes = '## 0.0.24 - 2026-06-22 UTC
+### Added
+- Get-IISAppPool: Inventory IIS application pool configuration across one or more servers
+
+## 0.0.23 - 2026-05-21
 ### Added
 - feat(iis): introduce new public domain Public/iis/ (registered in CI matrix and about_PSWinOps).
 - feat(iis): add Set-IISBindingCertificate — replace SSL/TLS certificate on IIS HTTPS bindings with idempotent rotation, -WhatIf/-Confirm (ConfirmImpact=High), remote execution via WinRM, pipeline-by-property-name from Get-SSLCertificate / Get-IISHealth (#47).

--- a/PSWinOps.psd1
+++ b/PSWinOps.psd1
@@ -123,6 +123,7 @@
         'Get-ExchangeServerHealth',
         'Get-FileServerHealth',
         'Get-HyperVHostHealth',
+        'Get-IISAppPool',
         'Get-IISAppPoolHistory',
         'Get-IISCertificateBinding',
         'Get-IISCurrentRequest',

--- a/Public/iis/Get-IISAppPool.ps1
+++ b/Public/iis/Get-IISAppPool.ps1
@@ -1,0 +1,318 @@
+﻿#Requires -Version 5.1
+function Get-IISAppPool {
+    <#
+        .SYNOPSIS
+            Inventory IIS application pool configuration across one or more servers
+
+        .DESCRIPTION
+            Enumerates every IIS application pool on each target server and returns its
+            current configuration as typed objects: state, .NET CLR version, managed
+            pipeline mode, process identity, auto-start / start mode, request queue
+            length, idle timeout, recycling settings (periodic, scheduled, memory
+            thresholds) and CPU limits. Read-only; targets remote machines via
+            Invoke-RemoteOrLocal and isolates failures per machine so one unreachable
+            server never aborts the batch.
+
+        .PARAMETER ComputerName
+            One or more computer names to target. Defaults to the local computer.
+            Accepts pipeline input by value and by property name (aliases: CN, Server,
+            MachineName). Use $env:COMPUTERNAME, localhost, or . for the local machine.
+
+        .PARAMETER Credential
+            Optional PSCredential for authenticating to remote computers.
+            Not used for local queries.
+
+        .PARAMETER Name
+            Restrict results to application pools whose Name matches one or more -like
+            patterns (alias: AppPoolName). Wildcards accepted. Omit to return all pools.
+            Accepts input by property name.
+
+        .EXAMPLE
+            Get-IISAppPool
+
+            Returns the configuration of every application pool on the local server.
+
+        .EXAMPLE
+            Get-IISAppPool -ComputerName 'WEB01' -Name 'api-*'
+
+            Returns only the application pools whose name starts with 'api-' on WEB01.
+
+        .EXAMPLE
+            'WEB01', 'WEB02' | Get-IISAppPool
+
+            Pipes a list of servers and returns every application pool on each.
+
+        .OUTPUTS
+            PSWinOps.IISAppPool
+            One object per application pool found on each target machine.
+
+        .NOTES
+            Author: Franck SALLET
+            Version: 1.0.0
+            Last Modified: 2026-06-22
+            Requires: PowerShell 5.1+ / Windows only
+            Requires: Web-Server (IIS) role (WebAdministration / IISAdministration module)
+
+        .LINK
+            https://github.com/k9fr4n/PSWinOps
+
+        .LINK
+            https://learn.microsoft.com/en-us/iis/configuration/system.applicationHost/applicationPools/
+    #>
+    [CmdletBinding(SupportsShouldProcess = $false, ConfirmImpact = 'None')]
+    [OutputType('PSWinOps.IISAppPool')]
+    param(
+        [Parameter(Mandatory = $false, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [ValidateNotNullOrEmpty()]
+        [Alias('CN', 'Server', 'MachineName')]
+        [string[]]$ComputerName = $env:COMPUTERNAME,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateNotNull()]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential,
+
+        [Parameter(Mandatory = $false, ValueFromPipelineByPropertyName = $true)]
+        [Alias('AppPoolName')]
+        [string[]]$Name
+    )
+
+    begin {
+        Write-Verbose -Message "[$($MyInvocation.MyCommand)] Starting"
+
+        # ── Remote-capable scriptblock ───────────────────────────────────────
+        # Enumerates application pools with the IISAdministration module first,
+        # then WebAdministration (IIS:\AppPools\*), then appcmd.exe; throws when
+        # no IIS provider is available so the caller can isolate the failure.
+        $scriptBlock = {
+            param(
+                [string[]] $NameFilter
+            )
+
+            # ── Local helpers (approved verbs; no top-level module state) ─────
+            $toMinutes = {
+                param($value)
+                if ($null -eq $value) { return 0 }
+                if ($value -is [timespan]) { return [int]$value.TotalMinutes }
+                $ts = [timespan]::Zero
+                if ([timespan]::TryParse([string]$value, [ref]$ts)) { return [int]$ts.TotalMinutes }
+                return 0
+            }
+
+            $toLong = {
+                param($value)
+                if ($null -eq $value) { return [long]0 }
+                $l = [long]0
+                if ([long]::TryParse([string]$value, [ref]$l)) { return $l }
+                return [long]0
+            }
+
+            $toSchedule = {
+                param($collection)
+                $result = New-Object 'System.Collections.Generic.List[string]'
+                if ($null -ne $collection) {
+                    foreach ($entry in $collection) {
+                        $t = $entry
+                        if ($null -ne $entry -and $entry.PSObject.Properties['Time']) { $t = $entry.Time }
+                        if ($t -is [timespan]) {
+                            $result.Add($t.ToString('hh\:mm'))
+                        }
+                        elseif ($null -ne $t) {
+                            $ts = [timespan]::Zero
+                            if ([timespan]::TryParse([string]$t, [ref]$ts)) { $result.Add($ts.ToString('hh\:mm')) }
+                        }
+                    }
+                }
+                return , ([string[]]$result.ToArray())
+            }
+
+            # Build a normalised row hashtable from a rich app-pool object
+            # (Microsoft.Web.Administration.ApplicationPool, as returned by both
+            # IISAdministration's Get-IISAppPool and WebAdministration's Get-Item).
+            $toRow = {
+                param($pool)
+
+                $cpuLimitRaw = & $toLong $pool.Cpu.Limit
+                $cpuPercent  = [int]([math]::Floor($cpuLimitRaw / 1000))
+
+                $identityType = ''
+                if ($null -ne $pool.ProcessModel -and $null -ne $pool.ProcessModel.IdentityType) {
+                    $identityType = [string]$pool.ProcessModel.IdentityType
+                }
+
+                $userName = ''
+                if ($identityType -eq 'SpecificUser' -and $null -ne $pool.ProcessModel) {
+                    $userName = [string]$pool.ProcessModel.UserName
+                }
+
+                @{
+                    Name                     = [string]$pool.Name
+                    State                    = if ($null -ne $pool.State) { [string]$pool.State } else { 'Unknown' }
+                    ManagedRuntimeVersion    = [string]$pool.ManagedRuntimeVersion
+                    ManagedPipelineMode      = [string]$pool.ManagedPipelineMode
+                    IdentityType             = $identityType
+                    Username                 = $userName
+                    AutoStart                = [bool]$pool.AutoStart
+                    StartMode                = [string]$pool.StartMode
+                    QueueLength              = [int](& $toLong $pool.QueueLength)
+                    IdleTimeoutMinutes       = & $toMinutes $pool.ProcessModel.IdleTimeout
+                    RecyclingPeriodicMinutes = & $toMinutes $pool.Recycling.PeriodicRestart.Time
+                    RecyclingScheduledTimes  = & $toSchedule $pool.Recycling.PeriodicRestart.Schedule
+                    RecyclingMemoryLimitKB   = & $toLong $pool.Recycling.PeriodicRestart.Memory
+                    RecyclingPrivateMemoryKB = & $toLong $pool.Recycling.PeriodicRestart.PrivateMemory
+                    CpuLimitPercent          = $cpuPercent
+                    CpuLimitAction           = if ($null -ne $pool.Cpu -and $null -ne $pool.Cpu.Action) { [string]$pool.Cpu.Action } else { 'NoAction' }
+                }
+            }
+
+            # ── 1. Collect raw pool objects via the best available provider ──
+            $rawPools  = $null
+            $iisLoaded = $false
+
+            if (Get-Module -Name 'IISAdministration' -ListAvailable -ErrorAction SilentlyContinue) {
+                try {
+                    Import-Module -Name 'IISAdministration' -ErrorAction Stop
+                    $rawPools  = @(Get-IISAppPool -ErrorAction Stop)
+                    $iisLoaded = $true
+                }
+                catch {
+                    Write-Warning "[$env:COMPUTERNAME] IISAdministration enumeration failed: $($_.Exception.Message)"
+                }
+            }
+
+            if (-not $iisLoaded -and (Get-Module -Name 'WebAdministration' -ListAvailable -ErrorAction SilentlyContinue)) {
+                try {
+                    Import-Module -Name 'WebAdministration' -ErrorAction Stop
+                    $rawPools  = @(Get-Item -Path 'IIS:\AppPools\*' -ErrorAction Stop)
+                    $iisLoaded = $true
+                }
+                catch {
+                    Write-Warning "[$env:COMPUTERNAME] WebAdministration enumeration failed: $($_.Exception.Message)"
+                }
+            }
+
+            if (-not $iisLoaded) {
+                $appcmd = Join-Path -Path $env:windir -ChildPath 'system32\inetsrv\appcmd.exe'
+                if (Test-Path -LiteralPath $appcmd -PathType Leaf) {
+                    $rawXml = & $appcmd list apppool /config:* /xml 2>$null
+                    if ($LASTEXITCODE -eq 0 -and $rawXml) {
+                        try {
+                            [xml]$doc = $rawXml
+                            $rows = New-Object 'System.Collections.Generic.List[hashtable]'
+                            foreach ($node in @($doc.appcmd.APPPOOL)) {
+                                $add  = $node.add
+                                $pm   = $add.processModel
+                                $rec  = $add.recycling.periodicRestart
+                                $cpu  = $add.cpu
+                                $idle = if ($pm) { $pm.idleTimeout } else { $null }
+                                $cpuLimitRaw = & $toLong ($(if ($cpu) { $cpu.limit } else { 0 }))
+                                $idt = if ($pm) { [string]$pm.identityType } else { '' }
+                                $rows.Add(@{
+                                    Name                     = [string]$node.'APPPOOL.NAME'
+                                    State                    = if ($node.state) { [string]$node.state } else { 'Unknown' }
+                                    ManagedRuntimeVersion    = [string]$add.managedRuntimeVersion
+                                    ManagedPipelineMode      = [string]$add.managedPipelineMode
+                                    IdentityType             = $idt
+                                    Username                 = if ($idt -eq 'SpecificUser' -and $pm) { [string]$pm.userName } else { '' }
+                                    AutoStart                = ([string]$add.autoStart -eq 'true')
+                                    StartMode                = [string]$add.startMode
+                                    QueueLength              = [int](& $toLong $add.queueLength)
+                                    IdleTimeoutMinutes       = & $toMinutes $idle
+                                    RecyclingPeriodicMinutes = & $toMinutes $(if ($rec) { $rec.time } else { $null })
+                                    RecyclingScheduledTimes  = & $toSchedule $(if ($rec) { $rec.schedule.add.value } else { $null })
+                                    RecyclingMemoryLimitKB   = & $toLong $(if ($rec) { $rec.memory } else { 0 })
+                                    RecyclingPrivateMemoryKB = & $toLong $(if ($rec) { $rec.privateMemory } else { 0 })
+                                    CpuLimitPercent          = [int]([math]::Floor($cpuLimitRaw / 1000))
+                                    CpuLimitAction           = if ($cpu -and $cpu.action) { [string]$cpu.action } else { 'NoAction' }
+                                })
+                            }
+                            $iisLoaded = $true
+                            # Apply name filter and emit appcmd rows directly.
+                            foreach ($row in $rows) {
+                                if ($NameFilter -and $NameFilter.Count -gt 0) {
+                                    $match = $false
+                                    foreach ($pat in $NameFilter) { if ($row['Name'] -like $pat) { $match = $true; break } }
+                                    if (-not $match) { continue }
+                                }
+                                $row
+                            }
+                            return
+                        }
+                        catch {
+                            Write-Warning "[$env:COMPUTERNAME] appcmd parse failed: $($_.Exception.Message)"
+                        }
+                    }
+                }
+            }
+
+            if (-not $iisLoaded) {
+                throw "IIS is not available on '$env:COMPUTERNAME' (no IISAdministration / WebAdministration module and no appcmd.exe). Is the Web-Server (IIS) role installed?"
+            }
+
+            # ── 2. Normalise rich objects, apply -Name filter, emit rows ─────
+            foreach ($pool in $rawPools) {
+                $row = & $toRow $pool
+                if ($NameFilter -and $NameFilter.Count -gt 0) {
+                    $match = $false
+                    foreach ($pat in $NameFilter) { if ($row['Name'] -like $pat) { $match = $true; break } }
+                    if (-not $match) { continue }
+                }
+                $row
+            }
+        }
+    }
+
+    process {
+        foreach ($targetComputer in $ComputerName) {
+            Write-Verbose -Message "[$($MyInvocation.MyCommand)] Querying '$targetComputer'"
+
+            try {
+                $invokeParams = @{
+                    ComputerName = $targetComputer
+                    ScriptBlock  = $scriptBlock
+                    ArgumentList = @(, $Name)
+                }
+                if ($PSBoundParameters.ContainsKey('Credential')) {
+                    $invokeParams['Credential'] = $Credential
+                }
+
+                $rawResults = Invoke-RemoteOrLocal @invokeParams
+            }
+            catch {
+                Write-Error -Message "[$($MyInvocation.MyCommand)] Failed to query '$targetComputer': $($_.Exception.Message)"
+                continue
+            }
+
+            if ($null -eq $rawResults) { continue }
+
+            foreach ($row in $rawResults) {
+                [PSCustomObject]@{
+                    PSTypeName               = 'PSWinOps.IISAppPool'
+                    ComputerName             = $targetComputer
+                    Name                     = $row['Name']
+                    State                    = $row['State']
+                    ManagedRuntimeVersion    = $row['ManagedRuntimeVersion']
+                    ManagedPipelineMode      = $row['ManagedPipelineMode']
+                    IdentityType             = $row['IdentityType']
+                    Username                 = $row['Username']
+                    AutoStart                = $row['AutoStart']
+                    StartMode                = $row['StartMode']
+                    QueueLength              = $row['QueueLength']
+                    IdleTimeoutMinutes       = $row['IdleTimeoutMinutes']
+                    RecyclingPeriodicMinutes = $row['RecyclingPeriodicMinutes']
+                    RecyclingScheduledTimes  = $row['RecyclingScheduledTimes']
+                    RecyclingMemoryLimitKB   = $row['RecyclingMemoryLimitKB']
+                    RecyclingPrivateMemoryKB = $row['RecyclingPrivateMemoryKB']
+                    CpuLimitPercent          = $row['CpuLimitPercent']
+                    CpuLimitAction           = $row['CpuLimitAction']
+                    Timestamp                = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
+                }
+            }
+        }
+    }
+
+    end {
+        Write-Verbose -Message "[$($MyInvocation.MyCommand)] Done"
+    }
+}

--- a/Tests/Public/iis/Get-IISAppPool.Tests.ps1
+++ b/Tests/Public/iis/Get-IISAppPool.Tests.ps1
@@ -1,0 +1,365 @@
+﻿#Requires -Version 5.1
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSUseDeclaredVarsMoreThanAssignments', '',
+    Justification = 'Script-scoped variables are assigned in mocks and asserted across separate scopes'
+)]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSAvoidUsingConvertToSecureStringWithPlainText', '',
+    Justification = 'Test fixture only -- not a real credential'
+)]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSAvoidUsingComputerNameHardcoded', '',
+    Justification = 'Fake target names used exclusively in test fixtures -- no real machines are contacted'
+)]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSReviewUnusedParameter', '',
+    Justification = 'Stub parameters are declared to satisfy the Pester mock engine (PR #42) but have no body'
+)]
+param()
+
+BeforeAll {
+    $script:modulePath = Split-Path -Path (Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent) -Parent
+    # PSWinOps is Windows-only. On Linux/macOS the module guard throws, so we
+    # conditionally import here and skip all tests via -Skip on the Describe block.
+    if ($IsWindows -or $PSEdition -eq 'Desktop') {
+        Import-Module -Name (Join-Path -Path $script:modulePath -ChildPath 'PSWinOps.psd1') -Force
+    }
+    $script:ModuleName = 'PSWinOps'
+
+    # ── Stubs for commands referenced only inside the remote scriptblock ──────────
+    # Declared with explicit parameters so the Pester mock engine binds correctly
+    # (PR #42). Get-IISAppPool (IISAdministration) and Import-Module never run on
+    # this host because Invoke-RemoteOrLocal is fully mocked, but the mocks are
+    # mandated by the spec, so we stub + mock them defensively.
+    if (-not (Get-Command -Name 'Get-IISAppPool' -CommandType Function, Cmdlet, Alias -ErrorAction SilentlyContinue)) {
+        function global:Get-IISAppPool {
+            param(
+                [string]$Name,
+                [string]$ErrorAction
+            )
+        }
+    }
+
+    # ── Row factory: builds a hashtable mirroring the shape the scriptblock emits ──
+    # (the public function reads each row by key, e.g. $row['Name']).
+    function script:New-PoolRow {
+        param(
+            [string]   $Name = 'DefaultAppPool',
+            [string]   $State = 'Started',
+            [string]   $ManagedRuntimeVersion = 'v4.0',
+            [string]   $ManagedPipelineMode = 'Integrated',
+            [string]   $IdentityType = 'ApplicationPoolIdentity',
+            [string]   $Username = '',
+            [bool]     $AutoStart = $true,
+            [string]   $StartMode = 'OnDemand',
+            [int]      $QueueLength = 1000,
+            [int]      $IdleTimeoutMinutes = 20,
+            [int]      $RecyclingPeriodicMinutes = 1740,
+            [string[]] $RecyclingScheduledTimes = @(),
+            [long]     $RecyclingMemoryLimitKB = [long]0,
+            [long]     $RecyclingPrivateMemoryKB = [long]0,
+            [int]      $CpuLimitPercent = 0,
+            [string]   $CpuLimitAction = 'NoAction'
+        )
+        return @{
+            Name                     = $Name
+            State                    = $State
+            ManagedRuntimeVersion    = $ManagedRuntimeVersion
+            ManagedPipelineMode      = $ManagedPipelineMode
+            IdentityType             = $IdentityType
+            Username                 = $Username
+            AutoStart                = $AutoStart
+            StartMode                = $StartMode
+            QueueLength              = $QueueLength
+            IdleTimeoutMinutes       = $IdleTimeoutMinutes
+            RecyclingPeriodicMinutes = $RecyclingPeriodicMinutes
+            RecyclingScheduledTimes  = $RecyclingScheduledTimes
+            RecyclingMemoryLimitKB   = $RecyclingMemoryLimitKB
+            RecyclingPrivateMemoryKB = $RecyclingPrivateMemoryKB
+            CpuLimitPercent          = $CpuLimitPercent
+            CpuLimitAction           = $CpuLimitAction
+        }
+    }
+
+    $script:mockDefaultPool = script:New-PoolRow
+
+    $script:mockSpecificUserPool = script:New-PoolRow -Name 'SvcPool' -IdentityType 'SpecificUser' `
+        -Username 'CONTOSO\svc-web' -ManagedRuntimeVersion '' -ManagedPipelineMode 'Classic' `
+        -State 'Stopped' -AutoStart $false -StartMode 'AlwaysRunning' -QueueLength 2000 `
+        -IdleTimeoutMinutes 0 -RecyclingPeriodicMinutes 0 `
+        -RecyclingScheduledTimes @('02:00', '14:00') `
+        -RecyclingMemoryLimitKB ([long]1048576) -RecyclingPrivateMemoryKB ([long]524288) `
+        -CpuLimitPercent 80 -CpuLimitAction 'KillW3wp'
+
+    # Three pools for -Name wildcard / fan-out coverage.
+    $script:mockMultiplePools = @(
+        (script:New-PoolRow -Name 'api-prod' -State 'Started'),
+        (script:New-PoolRow -Name 'api-stage' -State 'Stopped'),
+        (script:New-PoolRow -Name 'web-legacy' -State 'Started')
+    )
+}
+
+Describe 'Get-IISAppPool' -Skip:(-not ($IsWindows -or $PSEdition -eq 'Desktop')) {
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # Context 1 -- Local happy path: typed object + all mandatory properties
+    # ─────────────────────────────────────────────────────────────────────────
+    Context 'Local happy path against $env:COMPUTERNAME' {
+
+        It 'Should return PSWinOps.IISAppPool typed objects for the local computer' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith {
+                return $script:mockDefaultPool
+            }
+            $result = Get-IISAppPool
+            @($result).Count              | Should -Be 1
+            $result.PSObject.TypeNames[0] | Should -Be 'PSWinOps.IISAppPool'
+            $result.ComputerName          | Should -Be $env:COMPUTERNAME
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should populate every output property from the row hashtable' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith {
+                return $script:mockDefaultPool
+            }
+            $result = Get-IISAppPool
+            $result.Name                     | Should -Be 'DefaultAppPool'
+            $result.State                    | Should -Be 'Started'
+            $result.ManagedRuntimeVersion    | Should -Be 'v4.0'
+            $result.ManagedPipelineMode      | Should -Be 'Integrated'
+            $result.IdentityType             | Should -Be 'ApplicationPoolIdentity'
+            $result.AutoStart                | Should -BeTrue
+            $result.StartMode                | Should -Be 'OnDemand'
+            $result.QueueLength              | Should -Be 1000
+            $result.IdleTimeoutMinutes       | Should -Be 20
+            $result.RecyclingPeriodicMinutes | Should -Be 1740
+            $result.CpuLimitPercent          | Should -Be 0
+            $result.CpuLimitAction           | Should -Be 'NoAction'
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should emit a Timestamp string matching yyyy-MM-dd HH:mm:ss format' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith {
+                return $script:mockDefaultPool
+            }
+            $result = Get-IISAppPool
+            $result.Timestamp | Should -Match "^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$"
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should surface an empty ManagedRuntimeVersion as-is (No Managed Code) for a SpecificUser pool' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith {
+                return $script:mockSpecificUserPool
+            }
+            $result = Get-IISAppPool
+            $result.ManagedRuntimeVersion | Should -BeExactly ''
+            $result.IdentityType          | Should -Be 'SpecificUser'
+            $result.Username              | Should -Be 'CONTOSO\svc-web'
+            $result.RecyclingMemoryLimitKB   | Should -Be ([long]1048576)
+            $result.RecyclingPrivateMemoryKB | Should -Be ([long]524288)
+            $result.CpuLimitPercent       | Should -Be 80
+            $result.CpuLimitAction        | Should -Be 'KillW3wp'
+            $result.RecyclingScheduledTimes | Should -Contain '02:00'
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+    }
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # Context 2 -- State enum values are passed through verbatim
+    # ─────────────────────────────────────────────────────────────────────────
+    Context 'State enum values are surfaced verbatim' {
+
+        It 'Should surface State <State>' -TestCases @(
+            @{ State = 'Started' }
+            @{ State = 'Stopped' }
+            @{ State = 'Starting' }
+            @{ State = 'Stopping' }
+            @{ State = 'Unknown' }
+        ) {
+            param($State)
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith {
+                return (script:New-PoolRow -State $State)
+            }
+            $result = Get-IISAppPool
+            $result.State | Should -Be $State
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+    }
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # Context 3 -- Explicit remote machine via -ComputerName
+    # ─────────────────────────────────────────────────────────────────────────
+    Context 'Explicit remote machine via -ComputerName' {
+
+        It 'Should stamp ComputerName with the requested target' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith {
+                return $script:mockDefaultPool
+            }
+            $result = Get-IISAppPool -ComputerName 'WEB01'
+            $result.ComputerName | Should -Be 'WEB01'
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should accept the CN/Server/MachineName aliases for -ComputerName' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith {
+                return $script:mockDefaultPool
+            }
+            $result = Get-IISAppPool -Server 'WEB42'
+            $result.ComputerName | Should -Be 'WEB42'
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+    }
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # Context 4 -- Pipeline of multiple machine names + ComputerName fan-out
+    # ─────────────────────────────────────────────────────────────────────────
+    Context 'Pipeline and ComputerName fan-out' {
+
+        It 'Should query every machine supplied through the pipeline by value' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith {
+                return $script:mockDefaultPool
+            }
+            $result = 'WEB01', 'WEB02', 'WEB03' | Get-IISAppPool
+            @($result).Count             | Should -Be 3
+            ($result.ComputerName | Sort-Object) | Should -Be @('WEB01', 'WEB02', 'WEB03')
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 3 -Exactly
+        }
+
+        It 'Should fan out across multiple -ComputerName values' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith {
+                return $script:mockDefaultPool
+            }
+            $result = Get-IISAppPool -ComputerName 'WEB01', 'WEB02'
+            @($result).Count | Should -Be 2
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 2 -Exactly
+        }
+
+        It 'Should accept ComputerName from the pipeline by property name' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith {
+                return $script:mockDefaultPool
+            }
+            $result = [PSCustomObject]@{ ComputerName = 'WEB07' } | Get-IISAppPool
+            $result.ComputerName | Should -Be 'WEB07'
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should emit one object per pool when a target hosts several pools' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith {
+                return $script:mockMultiplePools
+            }
+            $result = Get-IISAppPool -ComputerName 'WEB01'
+            @($result).Count | Should -Be 3
+            ($result.Name | Sort-Object) | Should -Be @('api-prod', 'api-stage', 'web-legacy')
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+    }
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # Context 5 -- -Name wildcard filter forwarded via ArgumentList[0]
+    # ─────────────────────────────────────────────────────────────────────────
+    Context '-Name wildcard filter forwarded into the remote ArgumentList' {
+
+        It 'Should forward -Name patterns to ArgumentList[0]' {
+            $script:capturedNameArgs = $null
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith {
+                $script:capturedNameArgs = $ArgumentList[0]
+                return @()
+            }
+            $null = Get-IISAppPool -ComputerName 'WEB01' -Name 'api-*'
+            $script:capturedNameArgs | Should -Contain 'api-*'
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should accept the AppPoolName alias for -Name' {
+            $script:capturedAliasArgs = $null
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith {
+                $script:capturedAliasArgs = $ArgumentList[0]
+                return @()
+            }
+            $null = Get-IISAppPool -ComputerName 'WEB01' -AppPoolName 'web-*'
+            $script:capturedAliasArgs | Should -Contain 'web-*'
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+    }
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # Context 6 -- Credential propagation to Invoke-RemoteOrLocal
+    # ─────────────────────────────────────────────────────────────────────────
+    Context 'Credential propagation' {
+
+        It 'Should forward -Credential to Invoke-RemoteOrLocal when supplied' {
+            $script:capturedCredential = $null
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith {
+                $script:capturedCredential = $Credential
+                return $script:mockDefaultPool
+            }
+            $securePass = ConvertTo-SecureString -String 'P@ssw0rd!' -AsPlainText -Force
+            $cred = [System.Management.Automation.PSCredential]::new('CONTOSO\admin', $securePass)
+            $null = Get-IISAppPool -ComputerName 'WEB01' -Credential $cred
+            $script:capturedCredential                | Should -Not -BeNullOrEmpty
+            $script:capturedCredential.UserName       | Should -Be 'CONTOSO\admin'
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should not pass a Credential when none is supplied' {
+            $script:capturedNoCred = 'sentinel'
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith {
+                $script:capturedNoCred = $Credential
+                return $script:mockDefaultPool
+            }
+            $null = Get-IISAppPool -ComputerName 'WEB01'
+            $script:capturedNoCred | Should -BeNullOrEmpty
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+    }
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # Context 7 -- Per-machine error isolation (Rule 12)
+    # ─────────────────────────────────────────────────────────────────────────
+    Context 'Per-machine error isolation' {
+
+        It 'Should write a non-terminating error and continue when a target throws' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith {
+                $target = $ComputerName
+                if ($target -eq 'BROKEN') { throw 'WinRM connection failed' }
+                return $script:mockDefaultPool
+            }
+            $errors = $null
+            $result = Get-IISAppPool -ComputerName 'BROKEN', 'WEB02' -ErrorVariable errors -ErrorAction SilentlyContinue
+            @($result).Count       | Should -Be 1
+            $result.ComputerName   | Should -Be 'WEB02'
+            @($errors).Count       | Should -BeGreaterThan 0
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 2 -Exactly
+        }
+
+        It 'Should write a per-machine error (not throw) when the IIS role is absent' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -MockWith {
+                throw "IIS is not available on 'WEB01' (no IISAdministration / WebAdministration module and no appcmd.exe)."
+            }
+            $errors = $null
+            { Get-IISAppPool -ComputerName 'WEB01' -ErrorVariable errors -ErrorAction SilentlyContinue } |
+                Should -Not -Throw
+            @($errors).Count | Should -BeGreaterThan 0
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+    }
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # Context 8 -- Parameter validation
+    # ─────────────────────────────────────────────────────────────────────────
+    Context 'Parameter validation' {
+
+        It 'Should reject an empty ComputerName (ValidateNotNullOrEmpty)' {
+            { Get-IISAppPool -ComputerName '' } | Should -Throw
+        }
+
+        It 'Should reject a null ComputerName (ValidateNotNullOrEmpty)' {
+            { Get-IISAppPool -ComputerName $null } | Should -Throw
+        }
+
+        It 'Should reject an array containing an empty ComputerName entry' {
+            { Get-IISAppPool -ComputerName @('WEB01', '') } | Should -Throw
+        }
+    }
+}

--- a/en-US/about_PSWinOps.help.txt
+++ b/en-US/about_PSWinOps.help.txt
@@ -84,7 +84,7 @@ FUNCTION DOMAINS
       Get-ServiceHealth
       Get-WSUSHealth
 
-  iis (9 functions)
+  iis (10 functions)
     Functions for managing IIS sites, HTTPS bindings,
     log file analysis, real-time log streaming, worker
     process monitoring, in-flight request inspection,
@@ -92,6 +92,7 @@ FUNCTION DOMAINS
     lifecycle history reconstruction across local or
     remote servers.
 
+      Get-IISAppPool
       Get-IISAppPoolHistory
       Get-IISCertificateBinding
       Get-IISCurrentRequest
@@ -338,6 +339,7 @@ PSWINOPS TYPE REGISTRY
       PSWinOps.ExchangeServerHealth
       PSWinOps.FileServerHealth
       PSWinOps.HyperVHostHealth
+      PSWinOps.IISAppPool
       PSWinOps.IISAppPoolHistoryEvent
       PSWinOps.IISBindingCertificateResult
       PSWinOps.IISCertificateBinding


### PR DESCRIPTION
## Summary
Enumerates every IIS application pool on each target server and returns its current configuration as typed objects: state, .NET CLR version, managed pipeline mode, process identity, auto-start/start mode, request queue length, idle timeout, recycling settings (periodic, scheduled, memory thresholds) and CPU limits. Read-only; targets remote machines via Invoke-RemoteOrLocal and isolates failures per machine.

## Files touched
- `Public/iis/Get-IISAppPool.ps1` — implementation
- `Tests/Public/iis/Get-IISAppPool.Tests.ps1` — Pester v5 suite
- `PSWinOps.psd1` — FunctionsToExport, ModuleVersion, ReleaseNotes
- `PSWinOps.Format.ps1xml` — new `<View>` for `PSWinOps.IISAppPool`
- `en-US/about_PSWinOps.help.txt` — counters bumped

## Conformance checklist (audited locally by fn-quality-gate)
- [x] UTF-8 BOM + CRLF on both new files
- [x] Approved PowerShell verb
- [x] `FunctionsToExport` alphabetically sorted, present once
- [x] `PSTypeName` consistent across .ps1 / Format.ps1xml / about help
- [x] No `Write-Host`, no `ToString('o')`, no WMI cmdlets in the diff
- [x] `PSWinOps.Format.ps1xml` is valid XML with a matching `<View>`

## Verification
Dynamic verification (Test-ModuleManifest, PSScriptAnalyzer, Pester matrix) runs
on the Windows CI for this PR. Merge once all required checks are green.
