### PR TITLE
feat(system): add Get-RebootHistory

### DIFF
--- a/.kdust/chains/get-reboothistory-2606232113.yaml
+++ b/.kdust/chains/get-reboothistory-2606232113.yaml
@@ -1,0 +1,7 @@
+chain: pswinops-function-author
+function: Get-RebootHistory
+domain: system
+created: 2026-06-23T21:13:44Z
+created_by: pswinops-fn-spec-analyst
+chain_branch: kdust/chain/pswinops-fn-get-reboothistory-2606232113
+spec_path: work/get-reboothistory/spec.yaml

--- a/PSWinOps.Format.ps1xml
+++ b/PSWinOps.Format.ps1xml
@@ -7312,5 +7312,76 @@
         </TableRowEntries>
       </TableControl>
     </View>
+    <!-- ============================================================ -->
+    <!-- PSWinOps.RebootHistory                                       -->
+    <!-- Used by: Get-RebootHistory                                   -->
+    <!-- ============================================================ -->
+    <View>
+      <Name>PSWinOps.RebootHistory</Name>
+      <ViewSelectedBy>
+        <TypeName>PSWinOps.RebootHistory</TypeName>
+      </ViewSelectedBy>
+      <TableControl>
+        <AutoSize />
+        <TableHeaders>
+          <TableColumnHeader>
+            <Label>ComputerName</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>ShutdownTime</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>BootTime</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>DowntimeMinutes</Label>
+            <Alignment>Right</Alignment>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Type</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Cause</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Initiator</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>EventId</Label>
+            <Alignment>Right</Alignment>
+          </TableColumnHeader>
+        </TableHeaders>
+        <TableRowEntries>
+          <TableRowEntry>
+            <TableColumnItems>
+              <TableColumnItem>
+                <PropertyName>ComputerName</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>ShutdownTime</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>BootTime</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>DowntimeMinutes</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>Type</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>Cause</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>Initiator</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>EventId</PropertyName>
+              </TableColumnItem>
+            </TableColumnItems>
+          </TableRowEntry>
+        </TableRowEntries>
+      </TableControl>
+    </View>
   </ViewDefinitions>
 </Configuration>

--- a/PSWinOps.psd1
+++ b/PSWinOps.psd1
@@ -12,7 +12,7 @@
     RootModule           = 'PSWinOps.psm1'
 
     # Version number of this module.
-    ModuleVersion        = '0.0.23'
+    ModuleVersion        = '0.0.24'
 
     # Supported PSEditions
     # Core is supported on Windows only; the module-level guard in PSWinOps.psm1 blocks
@@ -265,7 +265,11 @@
             # IconUri = ''
 
             # ReleaseNotes of this module
-            ReleaseNotes = '## 0.0.23 - 2026-05-21
+            ReleaseNotes = '## 0.0.24 - 2026-06-24
+### Added
+- feat(system): add Get-RebootHistory — correlates Windows System event log entries (1074, 1076, 6005, 6006, 6008, Kernel-Power 41) to reconstruct reboot/shutdown history per computer; classifies each event as Planned/Unexpected/Crash/PowerLoss/Unknown with DowntimeMinutes, Cause, Initiator, Comment; -MaxEvents, -After, -Before filters; remote execution via Invoke-RemoteOrLocal (#59).
+
+## 0.0.23 - 2026-05-21
 ### Added
 - feat(iis): introduce new public domain Public/iis/ (registered in CI matrix and about_PSWinOps).
 - feat(iis): add Set-IISBindingCertificate — replace SSL/TLS certificate on IIS HTTPS bindings with idempotent rotation, -WhatIf/-Confirm (ConfirmImpact=High), remote execution via WinRM, pipeline-by-property-name from Get-SSLCertificate / Get-IISHealth (#47).

--- a/PSWinOps.psd1
+++ b/PSWinOps.psd1
@@ -142,6 +142,7 @@
         'Get-NTPSyncStatus',
         'Get-PageFileConfiguration',
         'Get-PendingReboot',
+        'Get-RebootHistory',
         'Get-PrintServerHealth',
         'Get-ProxyConfiguration',
         'Get-PublicIPAddress',

--- a/Public/system/Get-RebootHistory.ps1
+++ b/Public/system/Get-RebootHistory.ps1
@@ -1,0 +1,277 @@
+﻿#Requires -Version 5.1
+
+function Get-RebootHistory {
+    <#
+    .SYNOPSIS
+        Reconstructs reboot and shutdown history from the Windows System event log
+
+    .DESCRIPTION
+        Correlates Windows System event log entries (1074, 1076, 6005, 6006, 6008 and
+        Kernel-Power 41) to rebuild each reboot or shutdown for one or more computers.
+        Each event is classified as Planned, Unexpected, Crash, PowerLoss or Unknown,
+        with its cause, initiator and comment, and the downtime duration between a clean
+        stop and the following boot. Local and remote targets are dispatched through
+        Invoke-RemoteOrLocal.
+
+    .PARAMETER ComputerName
+        One or more computer names to target. Defaults to the local computer.
+        Accepts pipeline input by value and by property name.
+
+    .PARAMETER Credential
+        Optional PSCredential for authenticating to remote machines. Ignored for
+        local machine queries.
+
+    .PARAMETER MaxEvents
+        Number of reboot/shutdown events to return, newest first. Valid range is 1
+        to 10000. Defaults to 50.
+
+    .PARAMETER After
+        Only return events at or after this datetime. When omitted, no lower bound is
+        applied to the query.
+
+    .PARAMETER Before
+        Only return events at or before this datetime. When omitted, no upper bound is
+        applied to the query.
+
+    .EXAMPLE
+        Get-RebootHistory
+
+        Returns the 50 most recent reboot and shutdown records for the local machine.
+
+    .EXAMPLE
+        Get-RebootHistory -ComputerName 'SRV01' -MaxEvents 20
+
+        Returns the 20 most recent reboot records for SRV01 via WinRM.
+
+    .EXAMPLE
+        'SRV01', 'SRV02' | Get-RebootHistory -After (Get-Date).AddDays(-30)
+
+        Returns all reboots in the last 30 days for SRV01 and SRV02 via pipeline.
+
+    .OUTPUTS
+        PSWinOps.RebootHistory
+        One object per boot event, enriched with shutdown type, cause, initiator,
+        comment and downtime duration.
+
+    .NOTES
+        Author: Franck SALLET
+        Version: 1.0.0
+        Last Modified: 2026-06-23
+        Requires: PowerShell 5.1+ / Windows only
+        Requires: WinRM enabled on target machines for remote queries
+
+    .LINK
+        https://github.com/k9fr4n/PSWinOps
+    #>
+    [CmdletBinding()]
+    [OutputType('PSWinOps.RebootHistory')]
+    param(
+        [Parameter(Mandatory = $false, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [ValidateNotNullOrEmpty()]
+        [Alias('CN', 'Name', 'DNSHostName')]
+        [string[]]$ComputerName = $env:COMPUTERNAME,
+
+        [Parameter(Mandatory = $false)]
+        [System.Management.Automation.PSCredential]$Credential,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateRange(1, 10000)]
+        [int]$MaxEvents = 50,
+
+        [Parameter(Mandatory = $false)]
+        [datetime]$After,
+
+        [Parameter(Mandatory = $false)]
+        [datetime]$Before
+    )
+
+    begin {
+        Write-Verbose "[$($MyInvocation.MyCommand)] Starting reboot history query"
+
+        $hasAfter  = $PSBoundParameters.ContainsKey('After')
+        $hasBefore = $PSBoundParameters.ContainsKey('Before')
+        $afterVal  = if ($hasAfter)  { $After }  else { [datetime]::MinValue }
+        $beforeVal = if ($hasBefore) { $Before } else { [datetime]::MaxValue }
+
+        $scriptBlock = {
+            param(
+                [int]$MaxEvts,
+                [datetime]$AfterDate,
+                [datetime]$BeforeDate,
+                [bool]$HasAfter,
+                [bool]$HasBefore
+            )
+
+            # Build filter for System log events (1074, 1076, 6005, 6006, 6008)
+            $sysFilter = @{
+                LogName = 'System'
+                Id      = @(1074, 1076, 6005, 6006, 6008)
+            }
+            if ($HasAfter)  { $sysFilter['StartTime'] = $AfterDate }
+            if ($HasBefore) { $sysFilter['EndTime']   = $BeforeDate }
+
+            # Build filter for Kernel-Power 41 (crash / power loss)
+            $kpFilter = @{
+                LogName      = 'System'
+                ProviderName = 'Microsoft-Windows-Kernel-Power'
+                Id           = 41
+            }
+            if ($HasAfter)  { $kpFilter['StartTime'] = $AfterDate }
+            if ($HasBefore) { $kpFilter['EndTime']   = $BeforeDate }
+
+            $sysEvents = @(Get-WinEvent -FilterHashtable $sysFilter -ErrorAction SilentlyContinue)
+            $kpEvents  = @(Get-WinEvent -FilterHashtable $kpFilter  -ErrorAction SilentlyContinue)
+            $allEvents = ($sysEvents + $kpEvents) | Sort-Object TimeCreated
+
+            $bootEvents   = @($allEvents | Where-Object { $_.Id -eq 6005 })
+            $cleanStops   = @($allEvents | Where-Object { $_.Id -eq 6006 })
+            $dirtyStops   = @($allEvents | Where-Object { $_.Id -eq 6008 })
+            $crashEvents  = @($allEvents | Where-Object { $_.Id -eq 41   })
+            $plannedShuts = @($allEvents | Where-Object { $_.Id -eq 1074 })
+            $reasonRecs   = @($allEvents | Where-Object { $_.Id -eq 1076 })
+
+            $results = [System.Collections.Generic.List[psobject]]::new()
+
+            foreach ($boot in ($bootEvents | Sort-Object TimeCreated -Descending)) {
+                if ($results.Count -ge $MaxEvts) { break }
+
+                $bootTime        = $boot.TimeCreated
+                $shutdownTime    = $null
+                $downtimeMinutes = $null
+                $type            = 'Unknown'
+                $cause           = ''
+                $initiator       = ''
+                $comment         = ''
+                $eventId         = 6005
+
+                # Determine the search window lower bound: after the previous boot
+                $prevBoot = $bootEvents | Where-Object { $_.TimeCreated -lt $bootTime } |
+                            Sort-Object TimeCreated -Descending | Select-Object -First 1
+                $windowStart = if ($null -ne $prevBoot) {
+                    $prevBoot.TimeCreated
+                } else {
+                    $bootTime.AddDays(-365)
+                }
+
+                # Check for 6008 (dirty shutdown marker logged at boot time)
+                $dirty6008 = $dirtyStops | Where-Object {
+                    [math]::Abs(($_.TimeCreated - $bootTime).TotalMinutes) -le 5
+                } | Sort-Object TimeCreated | Select-Object -First 1
+
+                # Look for a Kernel-Power 41 just before this boot
+                $precedingCrash = $crashEvents | Where-Object {
+                    $_.TimeCreated -lt $bootTime -and $_.TimeCreated -gt $windowStart
+                } | Sort-Object TimeCreated -Descending | Select-Object -First 1
+
+                # Look for a clean shutdown (6006) just before this boot
+                $precedingClean = $cleanStops | Where-Object {
+                    $_.TimeCreated -lt $bootTime -and $_.TimeCreated -gt $windowStart
+                } | Sort-Object TimeCreated -Descending | Select-Object -First 1
+
+                if ($null -ne $dirty6008) {
+                    # Unexpected shutdown recorded at boot time by 6008
+                    $type    = 'Unexpected'
+                    $eventId = 6008
+
+                    # 6008 Properties[0] = time string, Properties[1] = date string
+                    try {
+                        if ($dirty6008.Properties.Count -ge 2) {
+                            $timeStr = [string]$dirty6008.Properties[0].Value
+                            $dateStr = [string]$dirty6008.Properties[1].Value
+                            $parsed  = [datetime]::Parse("$dateStr $timeStr")
+                            $shutdownTime    = $parsed
+                            $downtimeMinutes = [math]::Round(($bootTime - $shutdownTime).TotalMinutes, 2)
+                        }
+                    } catch { }
+
+                    # Look for 1076 (operator-supplied reason recorded after this boot)
+                    $reason1076 = $reasonRecs | Where-Object {
+                        $_.TimeCreated -ge $bootTime -and
+                        $_.TimeCreated -le $bootTime.AddHours(2)
+                    } | Sort-Object TimeCreated | Select-Object -First 1
+
+                    if ($null -ne $reason1076) {
+                        try {
+                            $cause     = if ($reason1076.Properties.Count -ge 2) { [string]$reason1076.Properties[1].Value } else { '' }
+                            $initiator = if ($reason1076.Properties.Count -ge 5) { [string]$reason1076.Properties[4].Value } else { '' }
+                            $comment   = if ($reason1076.Properties.Count -ge 7) { [string]$reason1076.Properties[6].Value } else { '' }
+                        } catch { }
+                    }
+
+                } elseif ($null -ne $precedingCrash) {
+                    # Kernel-Power 41: crash (BugcheckCode != 0) or power loss (== 0)
+                    $shutdownTime    = $precedingCrash.TimeCreated
+                    $downtimeMinutes = [math]::Round(($bootTime - $shutdownTime).TotalMinutes, 2)
+                    $eventId         = 41
+
+                    try {
+                        $bugcheck = [uint32]$precedingCrash.Properties[0].Value
+                        if ($bugcheck -ne 0) {
+                            $type  = 'Crash'
+                            $cause = 'BugcheckCode: 0x{0:X8}' -f $bugcheck
+                        } else {
+                            $type = 'PowerLoss'
+                        }
+                    } catch {
+                        $type = 'Crash'
+                    }
+
+                } elseif ($null -ne $precedingClean) {
+                    # Clean shutdown (6006), classified as Planned
+                    $shutdownTime    = $precedingClean.TimeCreated
+                    $downtimeMinutes = [math]::Round(($bootTime - $shutdownTime).TotalMinutes, 2)
+                    $type            = 'Planned'
+                    $eventId         = 6006
+
+                    # Enrich from 1074 near the 6006 time
+                    $plan1074 = $plannedShuts | Where-Object {
+                        $_.TimeCreated -le $shutdownTime.AddMinutes(2) -and
+                        $_.TimeCreated -ge $shutdownTime.AddMinutes(-10)
+                    } | Sort-Object TimeCreated -Descending | Select-Object -First 1
+
+                    if ($null -ne $plan1074) {
+                        $eventId = 1074
+                        try {
+                            $initiator = if ($plan1074.Properties.Count -ge 7) { [string]$plan1074.Properties[6].Value } else { '' }
+                            $cause     = if ($plan1074.Properties.Count -ge 3) { [string]$plan1074.Properties[2].Value } else { '' }
+                            $comment   = if ($plan1074.Properties.Count -ge 9) { [string]$plan1074.Properties[8].Value } else { '' }
+                        } catch { }
+                    }
+                }
+
+                $results.Add([PSCustomObject]@{
+                    PSTypeName      = 'PSWinOps.RebootHistory'
+                    ComputerName    = $env:COMPUTERNAME
+                    ShutdownTime    = if ($null -ne $shutdownTime) { $shutdownTime.ToString('yyyy-MM-dd HH:mm:ss') } else { $null }
+                    BootTime        = $bootTime.ToString('yyyy-MM-dd HH:mm:ss')
+                    DowntimeMinutes = $downtimeMinutes
+                    Type            = $type
+                    Cause           = $cause
+                    Initiator       = $initiator
+                    Comment         = $comment
+                    EventId         = $eventId
+                    Timestamp       = (Get-Date -Format 'yyyy-MM-dd HH:mm:ss')
+                })
+            }
+
+            $results
+        }
+    }
+
+    process {
+        foreach ($targetComputer in $ComputerName) {
+            try {
+                Write-Verbose "[$($MyInvocation.MyCommand)] Querying reboot history on '$targetComputer'"
+                Invoke-RemoteOrLocal -ComputerName $targetComputer -Credential $Credential `
+                    -ScriptBlock $scriptBlock `
+                    -ArgumentList @($MaxEvents, $afterVal, $beforeVal, $hasAfter, $hasBefore)
+            } catch {
+                Write-Error "[$($MyInvocation.MyCommand)] Failed on '$targetComputer': $_"
+            }
+        }
+    }
+
+    end {
+        Write-Verbose "[$($MyInvocation.MyCommand)] Completed reboot history query"
+    }
+}

--- a/Public/system/Get-RebootHistory.ps1
+++ b/Public/system/Get-RebootHistory.ps1
@@ -182,7 +182,7 @@ function Get-RebootHistory {
                             $shutdownTime    = $parsed
                             $downtimeMinutes = [math]::Round(($bootTime - $shutdownTime).TotalMinutes, 2)
                         }
-                    } catch { }
+                    } catch { Write-Verbose "Could not parse 6008 shutdown time: $_" }
 
                     # Look for 1076 (operator-supplied reason recorded after this boot)
                     $reason1076 = $reasonRecs | Where-Object {
@@ -195,7 +195,7 @@ function Get-RebootHistory {
                             $cause     = if ($reason1076.Properties.Count -ge 2) { [string]$reason1076.Properties[1].Value } else { '' }
                             $initiator = if ($reason1076.Properties.Count -ge 5) { [string]$reason1076.Properties[4].Value } else { '' }
                             $comment   = if ($reason1076.Properties.Count -ge 7) { [string]$reason1076.Properties[6].Value } else { '' }
-                        } catch { }
+                        } catch { Write-Verbose "Could not parse 1076 properties: $_" }
                     }
 
                 } elseif ($null -ne $precedingCrash) {
@@ -235,7 +235,7 @@ function Get-RebootHistory {
                             $initiator = if ($plan1074.Properties.Count -ge 7) { [string]$plan1074.Properties[6].Value } else { '' }
                             $cause     = if ($plan1074.Properties.Count -ge 3) { [string]$plan1074.Properties[2].Value } else { '' }
                             $comment   = if ($plan1074.Properties.Count -ge 9) { [string]$plan1074.Properties[8].Value } else { '' }
-                        } catch { }
+                        } catch { Write-Verbose "Could not parse 1074 properties: $_" }
                     }
                 }
 

--- a/Tests/Public/system/Get-RebootHistory.Tests.ps1
+++ b/Tests/Public/system/Get-RebootHistory.Tests.ps1
@@ -1,0 +1,450 @@
+﻿#Requires -Version 5.1
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSAvoidUsingConvertToSecureStringWithPlainText', '',
+    Justification = 'Test fixture only -- not a real credential'
+)]
+param()
+
+BeforeAll {
+    $script:modulePath = Split-Path -Path (Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent) -Parent
+    Import-Module -Name (Join-Path -Path $script:modulePath -ChildPath 'PSWinOps.psd1') -Force
+}
+
+Describe -Name 'Get-RebootHistory' -Fixture {
+
+    BeforeEach {
+        Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -MockWith {
+            [PSCustomObject]@{
+                PSTypeName      = 'PSWinOps.RebootHistory'
+                ComputerName    = $ComputerName
+                ShutdownTime    = '2026-06-20 10:00:00'
+                BootTime        = '2026-06-20 10:05:00'
+                DowntimeMinutes = 5.0
+                Type            = 'Planned'
+                Cause           = 'Operating System: Upgrade (Planned)'
+                Initiator       = 'DOMAIN\admin'
+                Comment         = 'Scheduled maintenance'
+                EventId         = 1074
+                Timestamp       = '2026-06-23 12:00:00'
+            }
+        }
+    }
+
+    Context -Name 'Happy path - local machine' -Fixture {
+
+        It -Name 'Should return a result for the local machine by default' -Test {
+            $result = Get-RebootHistory
+            $result | Should -Not -BeNullOrEmpty
+            $result.ComputerName | Should -Be $env:COMPUTERNAME
+        }
+
+        It -Name 'Should return a PSWinOps.RebootHistory typed object' -Test {
+            $result = Get-RebootHistory
+            $result.PSObject.TypeNames[0] | Should -Be 'PSWinOps.RebootHistory'
+        }
+
+        It -Name 'Should call Invoke-RemoteOrLocal once for local machine' -Test {
+            Get-RebootHistory
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -Times 1 -Exactly
+        }
+
+        It -Name 'Should return all required output properties' -Test {
+            $result = Get-RebootHistory
+            $props = $result.PSObject.Properties.Name
+            $props | Should -Contain 'ComputerName'
+            $props | Should -Contain 'ShutdownTime'
+            $props | Should -Contain 'BootTime'
+            $props | Should -Contain 'DowntimeMinutes'
+            $props | Should -Contain 'Type'
+            $props | Should -Contain 'Cause'
+            $props | Should -Contain 'Initiator'
+            $props | Should -Contain 'Comment'
+            $props | Should -Contain 'EventId'
+            $props | Should -Contain 'Timestamp'
+        }
+
+        It -Name 'Should format Timestamp as yyyy-MM-dd HH:mm:ss' -Test {
+            $result = Get-RebootHistory
+            $result.Timestamp | Should -Match "^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$"
+        }
+    }
+
+    Context -Name 'Status enum - Planned' -Fixture {
+
+        It -Name 'Should surface Type=Planned returned by Invoke-RemoteOrLocal' -Test {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -MockWith {
+                [PSCustomObject]@{
+                    PSTypeName      = 'PSWinOps.RebootHistory'
+                    ComputerName    = $ComputerName
+                    ShutdownTime    = '2026-06-20 10:00:00'
+                    BootTime        = '2026-06-20 10:05:00'
+                    DowntimeMinutes = 5.0
+                    Type            = 'Planned'
+                    Cause           = 'Operating System: Upgrade (Planned)'
+                    Initiator       = 'DOMAIN\admin'
+                    Comment         = 'Scheduled maintenance'
+                    EventId         = 6006
+                    Timestamp       = '2026-06-23 12:00:00'
+                }
+            }
+            $result = Get-RebootHistory
+            $result.Type | Should -Be 'Planned'
+        }
+    }
+
+    Context -Name 'Status enum - Unexpected' -Fixture {
+
+        It -Name 'Should surface Type=Unexpected returned by Invoke-RemoteOrLocal' -Test {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -MockWith {
+                [PSCustomObject]@{
+                    PSTypeName      = 'PSWinOps.RebootHistory'
+                    ComputerName    = $ComputerName
+                    ShutdownTime    = '2026-06-20 10:00:00'
+                    BootTime        = '2026-06-20 10:05:00'
+                    DowntimeMinutes = 5.0
+                    Type            = 'Unexpected'
+                    Cause           = ''
+                    Initiator       = ''
+                    Comment         = ''
+                    EventId         = 6008
+                    Timestamp       = '2026-06-23 12:00:00'
+                }
+            }
+            $result = Get-RebootHistory
+            $result.Type | Should -Be 'Unexpected'
+        }
+    }
+
+    Context -Name 'Status enum - Crash' -Fixture {
+
+        It -Name 'Should surface Type=Crash with BugcheckCode in Cause' -Test {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -MockWith {
+                [PSCustomObject]@{
+                    PSTypeName      = 'PSWinOps.RebootHistory'
+                    ComputerName    = $ComputerName
+                    ShutdownTime    = '2026-06-20 10:00:00'
+                    BootTime        = '2026-06-20 10:05:00'
+                    DowntimeMinutes = 5.0
+                    Type            = 'Crash'
+                    Cause           = 'BugcheckCode: 0x0000007E'
+                    Initiator       = ''
+                    Comment         = ''
+                    EventId         = 41
+                    Timestamp       = '2026-06-23 12:00:00'
+                }
+            }
+            $result = Get-RebootHistory
+            $result.Type | Should -Be 'Crash'
+            $result.Cause | Should -Match "BugcheckCode"
+        }
+    }
+
+    Context -Name 'Status enum - PowerLoss' -Fixture {
+
+        It -Name 'Should surface Type=PowerLoss with null ShutdownTime' -Test {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -MockWith {
+                [PSCustomObject]@{
+                    PSTypeName      = 'PSWinOps.RebootHistory'
+                    ComputerName    = $ComputerName
+                    ShutdownTime    = $null
+                    BootTime        = '2026-06-20 10:05:00'
+                    DowntimeMinutes = $null
+                    Type            = 'PowerLoss'
+                    Cause           = ''
+                    Initiator       = ''
+                    Comment         = ''
+                    EventId         = 41
+                    Timestamp       = '2026-06-23 12:00:00'
+                }
+            }
+            $result = Get-RebootHistory
+            $result.Type | Should -Be 'PowerLoss'
+            $result.ShutdownTime | Should -BeNullOrEmpty
+        }
+    }
+
+    Context -Name 'Status enum - Unknown' -Fixture {
+
+        It -Name 'Should surface Type=Unknown when no correlatable shutdown found' -Test {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -MockWith {
+                [PSCustomObject]@{
+                    PSTypeName      = 'PSWinOps.RebootHistory'
+                    ComputerName    = $ComputerName
+                    ShutdownTime    = $null
+                    BootTime        = '2026-06-20 10:05:00'
+                    DowntimeMinutes = $null
+                    Type            = 'Unknown'
+                    Cause           = ''
+                    Initiator       = ''
+                    Comment         = ''
+                    EventId         = 6005
+                    Timestamp       = '2026-06-23 12:00:00'
+                }
+            }
+            $result = Get-RebootHistory
+            $result.Type | Should -Be 'Unknown'
+        }
+    }
+
+    Context -Name 'Remote machine - explicit ComputerName' -Fixture {
+
+        It -Name 'Should return result for named remote machine' -Test {
+            $result = Get-RebootHistory -ComputerName 'SRV01'
+            $result | Should -Not -BeNullOrEmpty
+            $result.ComputerName | Should -Be 'SRV01'
+        }
+
+        It -Name 'Should call Invoke-RemoteOrLocal once for a named remote machine' -Test {
+            Get-RebootHistory -ComputerName 'SRV01'
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -Times 1 -Exactly
+        }
+    }
+
+    Context -Name 'Credential propagation' -Fixture {
+
+        BeforeAll {
+            $script:cred = [PSCredential]::new('admin', (ConvertTo-SecureString -String 'pass' -AsPlainText -Force))
+        }
+
+        It -Name 'Should pass Credential to Invoke-RemoteOrLocal' -Test {
+            Get-RebootHistory -ComputerName 'SRV01' -Credential $script:cred
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -Times 1 -Exactly -ParameterFilter {
+                $null -ne $Credential
+            }
+        }
+
+        It -Name 'Should return a result when Credential is provided' -Test {
+            $result = Get-RebootHistory -ComputerName 'SRV01' -Credential $script:cred
+            $result | Should -Not -BeNullOrEmpty
+            $result.ComputerName | Should -Be 'SRV01'
+        }
+    }
+
+    Context -Name 'Pipeline by property name - multiple machines' -Fixture {
+
+        It -Name 'Should process multiple machines supplied via pipeline' -Test {
+            $result = @('SRV01', 'SRV02') | Get-RebootHistory
+            $result | Should -HaveCount 2
+            $result[0].ComputerName | Should -Be 'SRV01'
+            $result[1].ComputerName | Should -Be 'SRV02'
+        }
+
+        It -Name 'Should call Invoke-RemoteOrLocal once per piped machine' -Test {
+            @('SRV01', 'SRV02') | Get-RebootHistory
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -Times 2 -Exactly
+        }
+
+        It -Name 'Should process multiple machines from ComputerName array parameter' -Test {
+            $result = Get-RebootHistory -ComputerName 'SRV01', 'SRV02', 'SRV03'
+            $result | Should -HaveCount 3
+        }
+    }
+
+    Context -Name 'Per-machine error isolation' -Fixture {
+
+        It -Name 'Should continue to next machine when one fails' -Test {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -MockWith {
+                if ($ComputerName -eq 'BADMACHINE') { throw 'WinRM connection failed' }
+                [PSCustomObject]@{
+                    PSTypeName      = 'PSWinOps.RebootHistory'
+                    ComputerName    = $ComputerName
+                    ShutdownTime    = '2026-06-20 10:00:00'
+                    BootTime        = '2026-06-20 10:05:00'
+                    DowntimeMinutes = 5.0
+                    Type            = 'Planned'
+                    Cause           = ''
+                    Initiator       = ''
+                    Comment         = ''
+                    EventId         = 1074
+                    Timestamp       = '2026-06-23 12:00:00'
+                }
+            }
+            $result = Get-RebootHistory -ComputerName 'BADMACHINE', 'SRV01' -ErrorAction SilentlyContinue
+            $result | Should -HaveCount 1
+            $result[0].ComputerName | Should -Be 'SRV01'
+        }
+
+        It -Name 'Should write an error for the failing machine' -Test {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -MockWith {
+                if ($ComputerName -eq 'BADMACHINE') { throw 'WinRM connection failed' }
+                [PSCustomObject]@{
+                    PSTypeName      = 'PSWinOps.RebootHistory'
+                    ComputerName    = $ComputerName
+                    ShutdownTime    = '2026-06-20 10:00:00'
+                    BootTime        = '2026-06-20 10:05:00'
+                    DowntimeMinutes = 5.0
+                    Type            = 'Planned'
+                    Cause           = ''
+                    Initiator       = ''
+                    Comment         = ''
+                    EventId         = 1074
+                    Timestamp       = '2026-06-23 12:00:00'
+                }
+            }
+            Get-RebootHistory -ComputerName 'BADMACHINE', 'SRV01' -ErrorAction SilentlyContinue -ErrorVariable 'capturedError'
+            $capturedError | Should -Not -BeNullOrEmpty
+        }
+    }
+
+    Context -Name 'MaxEvents parameter' -Fixture {
+
+        It -Name 'Should throw when MaxEvents is 0 (below valid range)' -Test {
+            { Get-RebootHistory -MaxEvents 0 } | Should -Throw
+        }
+
+        It -Name 'Should throw when MaxEvents is 10001 (above valid range)' -Test {
+            { Get-RebootHistory -MaxEvents 10001 } | Should -Throw
+        }
+
+        It -Name 'Should pass MaxEvents as first ArgumentList element to Invoke-RemoteOrLocal' -Test {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -MockWith {
+                $script:capturedMaxEvents = $ArgumentList[0]
+                [PSCustomObject]@{
+                    PSTypeName      = 'PSWinOps.RebootHistory'
+                    ComputerName    = $ComputerName
+                    ShutdownTime    = '2026-06-20 10:00:00'
+                    BootTime        = '2026-06-20 10:05:00'
+                    DowntimeMinutes = 5.0
+                    Type            = 'Planned'
+                    Cause           = ''
+                    Initiator       = ''
+                    Comment         = ''
+                    EventId         = 1074
+                    Timestamp       = '2026-06-23 12:00:00'
+                }
+            }
+            Get-RebootHistory -MaxEvents 10
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -Times 1 -Exactly
+            $script:capturedMaxEvents | Should -Be 10
+        }
+
+        It -Name 'Should default MaxEvents to 50 when not specified' -Test {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -MockWith {
+                $script:capturedDefaultMaxEvents = $ArgumentList[0]
+                [PSCustomObject]@{
+                    PSTypeName      = 'PSWinOps.RebootHistory'
+                    ComputerName    = $ComputerName
+                    ShutdownTime    = '2026-06-20 10:00:00'
+                    BootTime        = '2026-06-20 10:05:00'
+                    DowntimeMinutes = 5.0
+                    Type            = 'Planned'
+                    Cause           = ''
+                    Initiator       = ''
+                    Comment         = ''
+                    EventId         = 1074
+                    Timestamp       = '2026-06-23 12:00:00'
+                }
+            }
+            Get-RebootHistory
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -Times 1 -Exactly
+            $script:capturedDefaultMaxEvents | Should -Be 50
+        }
+    }
+
+    Context -Name 'After and Before datetime filtering' -Fixture {
+
+        It -Name 'Should set hasAfter flag in ArgumentList when -After is specified' -Test {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -MockWith {
+                $script:capturedAfterFlag = $ArgumentList[3]
+                [PSCustomObject]@{
+                    PSTypeName      = 'PSWinOps.RebootHistory'
+                    ComputerName    = $ComputerName
+                    ShutdownTime    = '2026-06-20 10:00:00'
+                    BootTime        = '2026-06-20 10:05:00'
+                    DowntimeMinutes = 5.0
+                    Type            = 'Planned'
+                    Cause           = ''
+                    Initiator       = ''
+                    Comment         = ''
+                    EventId         = 1074
+                    Timestamp       = '2026-06-23 12:00:00'
+                }
+            }
+            Get-RebootHistory -After (Get-Date '2026-01-01')
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -Times 1 -Exactly
+            $script:capturedAfterFlag | Should -Be $true
+        }
+
+        It -Name 'Should set hasBefore flag in ArgumentList when -Before is specified' -Test {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -MockWith {
+                $script:capturedBeforeFlag = $ArgumentList[4]
+                [PSCustomObject]@{
+                    PSTypeName      = 'PSWinOps.RebootHistory'
+                    ComputerName    = $ComputerName
+                    ShutdownTime    = '2026-06-20 10:00:00'
+                    BootTime        = '2026-06-20 10:05:00'
+                    DowntimeMinutes = 5.0
+                    Type            = 'Planned'
+                    Cause           = ''
+                    Initiator       = ''
+                    Comment         = ''
+                    EventId         = 1074
+                    Timestamp       = '2026-06-23 12:00:00'
+                }
+            }
+            Get-RebootHistory -Before (Get-Date '2026-06-01')
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -Times 1 -Exactly
+            $script:capturedBeforeFlag | Should -Be $true
+        }
+
+        It -Name 'Should leave hasAfter false when -After is not specified' -Test {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -MockWith {
+                $script:capturedNoAfterFlag = $ArgumentList[3]
+                [PSCustomObject]@{
+                    PSTypeName      = 'PSWinOps.RebootHistory'
+                    ComputerName    = $ComputerName
+                    ShutdownTime    = '2026-06-20 10:00:00'
+                    BootTime        = '2026-06-20 10:05:00'
+                    DowntimeMinutes = 5.0
+                    Type            = 'Planned'
+                    Cause           = ''
+                    Initiator       = ''
+                    Comment         = ''
+                    EventId         = 1074
+                    Timestamp       = '2026-06-23 12:00:00'
+                }
+            }
+            Get-RebootHistory
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -Times 1 -Exactly
+            $script:capturedNoAfterFlag | Should -Be $false
+        }
+    }
+
+    Context -Name 'Parameter validation' -Fixture {
+
+        It -Name 'Should throw when ComputerName is an empty string' -Test {
+            { Get-RebootHistory -ComputerName '' } | Should -Throw
+        }
+
+        It -Name 'Should throw when ComputerName is null' -Test {
+            { Get-RebootHistory -ComputerName $null } | Should -Throw
+        }
+
+        It -Name 'Should expose ComputerName with pipeline support by value and by property name' -Test {
+            $cmd = Get-Command -Name 'Get-RebootHistory'
+            $attr = $cmd.Parameters['ComputerName'].Attributes.Where({ $_ -is [System.Management.Automation.ParameterAttribute] })[0]
+            $attr.ValueFromPipeline | Should -Be $true
+            $attr.ValueFromPipelineByPropertyName | Should -Be $true
+        }
+
+        It -Name 'Should expose ComputerName aliases CN, Name and DNSHostName' -Test {
+            $cmd = Get-Command -Name 'Get-RebootHistory'
+            $aliases = $cmd.Parameters['ComputerName'].Aliases
+            $aliases | Should -Contain 'CN'
+            $aliases | Should -Contain 'Name'
+            $aliases | Should -Contain 'DNSHostName'
+        }
+
+        It -Name 'Should expose After parameter of type datetime' -Test {
+            $cmd = Get-Command -Name 'Get-RebootHistory'
+            $cmd.Parameters['After'].ParameterType | Should -Be ([datetime])
+        }
+
+        It -Name 'Should expose Before parameter of type datetime' -Test {
+            $cmd = Get-Command -Name 'Get-RebootHistory'
+            $cmd.Parameters['Before'].ParameterType | Should -Be ([datetime])
+        }
+    }
+}

--- a/en-US/about_PSWinOps.help.txt
+++ b/en-US/about_PSWinOps.help.txt
@@ -161,7 +161,7 @@ FUNCTION DOMAINS
       Get-RdpSessionLock
       Remove-RdpSession
 
-  system (14 functions)
+  system (15 functions)
     Functions for general system information, state,
     disk cleanup, profile management, and real-time monitoring.
 
@@ -173,6 +173,7 @@ FUNCTION DOMAINS
       Get-InstalledSoftware
       Get-PageFileConfiguration
       Get-PendingReboot
+      Get-RebootHistory
       Get-ScheduledTaskDetail
       Get-StartupProgram
       Get-SystemSummary
@@ -372,6 +373,7 @@ PSWINOPS TYPE REGISTRY
       PSWinOps.RdpSessionHistory
       PSWinOps.RdpSessionLock
       PSWinOps.RDSHealth
+      PSWinOps.RebootHistory
       PSWinOps.ScheduledTaskDetail
       PSWinOps.ServiceHealth
       PSWinOps.ShadowCopy


### PR DESCRIPTION
## Summary

Adds `Get-RebootHistory` to the `system` domain. Correlates Windows System event log entries to reconstruct reboot and shutdown history per computer.

## What's new

- **Function**: `Public/system/Get-RebootHistory.ps1`
- **Output type**: `PSWinOps.RebootHistory` with TableControl Format view
- **Tests**: `Tests/Public/system/Get-RebootHistory.Tests.ps1` (Pester v5)

## Event sources correlated

| Event ID | Provider | Meaning |
|----------|----------|---------|
| 1074 | User32 | Clean shutdown/restart initiated |
| 1076 | User32 | Reason recorded after unexpected shutdown |
| 6005 | EventLog | Service started = boot time |
| 6006 | EventLog | Service stopped cleanly = clean shutdown |
| 6008 | EventLog | Previous shutdown was unexpected |
| 41 | Kernel-Power | Crash / power loss |

## Classification

| Type | Description |
|------|-------------|
| Planned | Clean operator-initiated shutdown (1074 + 6006) |
| Unexpected | Dirty shutdown without clean stop (6008) |
| Crash | Kernel-Power 41 with non-zero BugcheckCode |
| PowerLoss | Kernel-Power 41 without bugcheck |
| Unknown | Boot (6005) with no correlatable preceding shutdown |

## Parameters

- `-ComputerName` — pipeline-friendly, remote via `Invoke-RemoteOrLocal`
- `-Credential`
- `-MaxEvents` (default 50, range 1-10000)
- `-After` / `-Before` datetime window filters

## Version bump

`0.0.23` → `0.0.24`