### PR TITLE
feat(eventlog): add Get-UnexpectedShutdown

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,7 @@ jobs:
           - "Public/utils"
           - "Public/vss"
           - "Public/windowsupdate"
+          - "Public/eventlog"
 
     steps:
       - name: Configure git line endings

--- a/.kdust/chains/get-unexpectedshutdown-2607052058.yaml
+++ b/.kdust/chains/get-unexpectedshutdown-2607052058.yaml
@@ -1,0 +1,7 @@
+chain: pswinops-function-author
+function: Get-UnexpectedShutdown
+domain: eventlog
+created: 2026-07-05T21:00:04Z
+created_by: pswinops-fn-spec-analyst
+chain_branch: kdust/chain/pswinops-fn-get-unexpectedshutdown-2607052058
+spec_path: work/get-unexpectedshutdown/spec.yaml

--- a/PSWinOps.Format.ps1xml
+++ b/PSWinOps.Format.ps1xml
@@ -7457,5 +7457,75 @@
         </ListEntries>
       </ListControl>
     </View>
+    <!-- ============================================================ -->
+    <!-- PSWinOps.UnexpectedShutdown                                  -->
+    <!-- Used by: Get-UnexpectedShutdown                              -->
+    <!-- ============================================================ -->
+    <View>
+      <Name>PSWinOps.UnexpectedShutdown</Name>
+      <ViewSelectedBy>
+        <TypeName>PSWinOps.UnexpectedShutdown</TypeName>
+      </ViewSelectedBy>
+      <TableControl>
+        <AutoSize />
+        <TableHeaders>
+          <TableColumnHeader>
+            <Label>EventTime</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>EventId</Label>
+            <Alignment>Right</Alignment>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>ShutdownType</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>IsExpected</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Cause</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Initiator</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>ReasonCode</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>ComputerName</Label>
+          </TableColumnHeader>
+        </TableHeaders>
+        <TableRowEntries>
+          <TableRowEntry>
+            <TableColumnItems>
+              <TableColumnItem>
+                <PropertyName>EventTime</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>EventId</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>ShutdownType</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>IsExpected</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>Cause</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>Initiator</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>ReasonCode</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>ComputerName</PropertyName>
+              </TableColumnItem>
+            </TableColumnItems>
+          </TableRowEntry>
+        </TableRowEntries>
+      </TableControl>
+    </View>
   </ViewDefinitions>
 </Configuration>

--- a/PSWinOps.psd1
+++ b/PSWinOps.psd1
@@ -158,6 +158,7 @@
         'Get-StartupProgram',
         'Get-SubnetInfo',
         'Get-SystemSummary',
+        'Get-UnexpectedShutdown',
         'Get-WindowsUpdate',
         'Get-WindowsUpdateConfiguration',
         'Get-WindowsUpdateHistory',

--- a/PSWinOps.psd1
+++ b/PSWinOps.psd1
@@ -12,7 +12,7 @@
     RootModule           = 'PSWinOps.psm1'
 
     # Version number of this module.
-    ModuleVersion        = '0.1.0'
+    ModuleVersion        = '0.2.0'
 
     # Supported PSEditions
     # Core is supported on Windows only; the module-level guard in PSWinOps.psm1 blocks
@@ -268,7 +268,11 @@
             # IconUri = ''
 
             # ReleaseNotes of this module
-            ReleaseNotes = '## 0.1.0 - 2026-06-24
+            ReleaseNotes = '## 0.2.0 - 2026-07-05 UTC
+### Added
+- Get-UnexpectedShutdown: Reports shutdown and restart events with cause, expectedness and initiator
+
+## 0.1.0 - 2026-06-24
 ### Added
 - feat(windowsupdate): add Reset-WindowsUpdateComponent — resets the Windows Update service stack to a clean state (stop BITS/wuauserv/appidsvc/cryptsvc, delete qmgr*.dat, back up SoftwareDistribution & Catroot2, reset BITS/wuauserv SDDL, reregister Windows Update DLLs, restart services, trigger detection with usoclient fallback); optional -IncludeNetworkReset resets Winsock/WinHTTP (requires reboot, may drop remote sessions); SupportsShouldProcess (ConfirmImpact=High), Test-IsAdministrator guard, remote execution via Invoke-RemoteOrLocal; returns PSWinOps.WindowsUpdateResetResult.
 

--- a/Public/eventlog/Get-UnexpectedShutdown.ps1
+++ b/Public/eventlog/Get-UnexpectedShutdown.ps1
@@ -1,0 +1,213 @@
+﻿#Requires -Version 5.1
+
+function Get-UnexpectedShutdown {
+    <#
+    .SYNOPSIS
+        Reports shutdown and restart events with cause, expectedness and initiator
+
+    .DESCRIPTION
+        Correlates Windows System event log entries (6008 dirty shutdown, Kernel-Power
+        41 unexpected, 1074 planned shutdown/restart, 6006 clean shutdown, 1076 reason
+        supplied) to report each shutdown or restart with its cause, whether it was
+        expected or unexpected, the initiating process/user and the reason code.
+        Local and remote targets are dispatched through Invoke-RemoteOrLocal; machines
+        with no matching events return nothing.
+
+    .PARAMETER ComputerName
+        One or more computer names to target. Defaults to the local computer.
+        Accepts pipeline input by value and by property name.
+
+    .PARAMETER Credential
+        Optional PSCredential for authenticating to remote machines. Ignored for
+        local machine queries.
+
+    .PARAMETER MaxEvents
+        Maximum number of shutdown/restart rows returned per machine, newest first.
+        Valid range is 1 to 10000. Defaults to 50.
+
+    .PARAMETER Days
+        Look-back window in days used to bound the event log scan. StartTime is
+        computed as (Get-Date).AddDays(-Days). Valid range is 1 to 3650. Defaults to 30.
+
+    .EXAMPLE
+        Get-UnexpectedShutdown
+
+        Returns the most recent shutdown/restart events for the local machine over
+        the last 30 days.
+
+    .EXAMPLE
+        Get-UnexpectedShutdown -ComputerName SRV01 -Days 90
+
+        Returns shutdown/restart events from SRV01 over the last 90 days via WinRM.
+
+    .EXAMPLE
+        'SRV01','SRV02' | Get-UnexpectedShutdown -MaxEvents 20
+
+        Returns up to 20 shutdown/restart events per machine for SRV01 and SRV02 via
+        pipeline.
+
+    .OUTPUTS
+        PSWinOps.UnexpectedShutdown
+        One object per shutdown/restart-related event (6008, 41, 1074, 6006, 1076),
+        newest first, with cause, expectedness, initiator, reason code and comment.
+
+    .NOTES
+        Author: Franck SALLET
+        Version: 1.0.0
+        Last Modified: 2026-07-05
+        Requires: PowerShell 5.1+ / Windows only
+        Requires: WinRM enabled on target machines for remote queries
+
+    .LINK
+        https://github.com/k9fr4n/PSWinOps
+
+    .LINK
+        Source of truth: Windows System event log (provider EventLog for 6008/6006/1074/1076; provider Microsoft-Windows-Kernel-Power for 41)
+    #>
+    [CmdletBinding(SupportsShouldProcess = $false, ConfirmImpact = 'None')]
+    [OutputType('PSWinOps.UnexpectedShutdown')]
+    param(
+        [Parameter(Mandatory = $false, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [ValidateNotNullOrEmpty()]
+        [Alias('CN', 'Name', 'DNSHostName')]
+        [string[]]$ComputerName = $env:COMPUTERNAME,
+
+        [Parameter(Mandatory = $false)]
+        [System.Management.Automation.PSCredential]$Credential,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateRange(1, 10000)]
+        [int]$MaxEvents = 50,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateRange(1, 3650)]
+        [int]$Days = 30
+    )
+
+    begin {
+        Write-Verbose "[$($MyInvocation.MyCommand)] Starting unexpected shutdown query"
+
+        $startTime = (Get-Date).AddDays(-$Days)
+
+        $scriptBlock = {
+            param(
+                [int]$MaxEvts,
+                [datetime]$ScanStartTime
+            )
+
+            # Build filter for System log events (6008, 1074, 6006, 1076)
+            $sysFilter = @{
+                LogName   = 'System'
+                Id        = @(6008, 1074, 6006, 1076)
+                StartTime = $ScanStartTime
+            }
+
+            # Build filter for Kernel-Power 41 (crash / power loss)
+            $kpFilter = @{
+                LogName      = 'System'
+                ProviderName = 'Microsoft-Windows-Kernel-Power'
+                Id           = 41
+                StartTime    = $ScanStartTime
+            }
+
+            $sysEvents = @(Get-WinEvent -FilterHashtable $sysFilter -ErrorAction SilentlyContinue)
+            $kpEvents  = @(Get-WinEvent -FilterHashtable $kpFilter  -ErrorAction SilentlyContinue)
+            $allEvents = @(($sysEvents + $kpEvents) | Sort-Object TimeCreated -Descending)
+
+            $results = [System.Collections.Generic.List[psobject]]::new()
+
+            foreach ($evt in $allEvents) {
+                if ($results.Count -ge $MaxEvts) { break }
+
+                $shutdownType = 'Unexpected'
+                $isExpected   = $false
+                $cause        = ''
+                $reasonCode   = ''
+                $initiator    = ''
+                $comment      = ''
+
+                switch ($evt.Id) {
+                    6008 {
+                        # Dirty/unexpected shutdown; no per-event cause available beyond the marker itself.
+                        $shutdownType = 'Unexpected'
+                        $isExpected   = $false
+                    }
+                    41 {
+                        # Kernel-Power 41: BugcheckCode 0 => PowerLoss, non-zero => Crash
+                        $isExpected = $false
+                        try {
+                            $bugcheck = [uint32]$evt.Properties[0].Value
+                            if ($bugcheck -ne 0) {
+                                $shutdownType = 'Crash'
+                                $cause        = 'BugcheckCode: 0x{0:X8}' -f $bugcheck
+                            } else {
+                                $shutdownType = 'PowerLoss'
+                            }
+                        } catch {
+                            $shutdownType = 'Crash'
+                            Write-Verbose "Could not parse Kernel-Power 41 BugcheckCode: $_"
+                        }
+                    }
+                    1074 {
+                        # Planned shutdown/restart: reason text, reason code, initiator, comment
+                        $shutdownType = 'Planned'
+                        $isExpected   = $true
+                        try {
+                            $cause      = if ($evt.Properties.Count -ge 3) { [string]$evt.Properties[2].Value } else { '' }
+                            $reasonCode = if ($evt.Properties.Count -ge 5) { [string]$evt.Properties[4].Value } else { '' }
+                            $initiator  = if ($evt.Properties.Count -ge 7) { [string]$evt.Properties[6].Value } else { '' }
+                            $comment    = if ($evt.Properties.Count -ge 9) { [string]$evt.Properties[8].Value } else { '' }
+                        } catch { Write-Verbose "Could not parse 1074 properties: $_" }
+                    }
+                    6006 {
+                        # Clean, service-controlled shutdown
+                        $shutdownType = 'Clean'
+                        $isExpected   = $true
+                    }
+                    1076 {
+                        # Operator-supplied reason after a prior unexpected shutdown
+                        $shutdownType = 'ReasonSupplied'
+                        $isExpected   = $false
+                        try {
+                            $cause     = if ($evt.Properties.Count -ge 2) { [string]$evt.Properties[1].Value } else { '' }
+                            $initiator = if ($evt.Properties.Count -ge 5) { [string]$evt.Properties[4].Value } else { '' }
+                        } catch { Write-Verbose "Could not parse 1076 properties: $_" }
+                    }
+                }
+
+                $results.Add([PSCustomObject]@{
+                    PSTypeName   = 'PSWinOps.UnexpectedShutdown'
+                    ComputerName = $env:COMPUTERNAME
+                    EventTime    = $evt.TimeCreated.ToString('yyyy-MM-dd HH:mm:ss')
+                    EventId      = $evt.Id
+                    ShutdownType = $shutdownType
+                    IsExpected   = $isExpected
+                    Cause        = $cause
+                    ReasonCode   = $reasonCode
+                    Initiator    = $initiator
+                    Comment      = $comment
+                    Timestamp    = (Get-Date -Format 'yyyy-MM-dd HH:mm:ss')
+                })
+            }
+
+            $results
+        }
+    }
+
+    process {
+        foreach ($targetComputer in $ComputerName) {
+            try {
+                Write-Verbose "[$($MyInvocation.MyCommand)] Querying unexpected shutdowns on '$targetComputer'"
+                Invoke-RemoteOrLocal -ComputerName $targetComputer -Credential $Credential `
+                    -ScriptBlock $scriptBlock `
+                    -ArgumentList @($MaxEvents, $startTime)
+            } catch {
+                Write-Error "[$($MyInvocation.MyCommand)] Failed on '$targetComputer': $_"
+            }
+        }
+    }
+
+    end {
+        Write-Verbose "[$($MyInvocation.MyCommand)] Completed unexpected shutdown query"
+    }
+}

--- a/Tests/Public/eventlog/Get-UnexpectedShutdown.Tests.ps1
+++ b/Tests/Public/eventlog/Get-UnexpectedShutdown.Tests.ps1
@@ -1,0 +1,312 @@
+﻿#Requires -Version 5.1
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+
+param()
+
+BeforeAll {
+    $script:modulePath = Split-Path -Path (Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent) -Parent
+    Import-Module -Name (Join-Path -Path $script:modulePath -ChildPath 'PSWinOps.psd1') -Force
+
+    function New-FakeShutdownEvent {
+        param(
+            [int]$Id,
+            [datetime]$TimeCreated,
+            [object[]]$PropertyValues = @()
+        )
+        $props = [System.Collections.Generic.List[object]]::new()
+        foreach ($v in $PropertyValues) {
+            $props.Add([PSCustomObject]@{ Value = $v })
+        }
+        [PSCustomObject]@{
+            Id          = $Id
+            TimeCreated = $TimeCreated
+            Properties  = $props.ToArray()
+        }
+    }
+}
+
+Describe -Name 'Get-UnexpectedShutdown' -Fixture {
+
+    Context -Name 'Local happy path - mixed shutdown/restart events' -Fixture {
+
+        BeforeAll {
+            $script:evt1074 = New-FakeShutdownEvent -Id 1074 -TimeCreated (Get-Date '2026-07-01 10:00:00') `
+                -PropertyValues @('reason1', 'reason2', 'Operating System: Upgrade', 'code1', '1:2', 'code2', 'DOMAIN\admin', 'code3', 'Scheduled maintenance')
+            $script:evt6008 = New-FakeShutdownEvent -Id 6008 -TimeCreated (Get-Date '2026-07-01 09:00:00')
+            $script:evt6006 = New-FakeShutdownEvent -Id 6006 -TimeCreated (Get-Date '2026-07-01 08:00:00')
+            $script:evt1076 = New-FakeShutdownEvent -Id 1076 -TimeCreated (Get-Date '2026-07-01 07:00:00') `
+                -PropertyValues @('code0', 'Power outage reported', 'code2', 'code3', 'DOMAIN\jdoe')
+            $script:evt41PowerLoss = New-FakeShutdownEvent -Id 41 -TimeCreated (Get-Date '2026-07-01 06:00:00') -PropertyValues @([uint32]0)
+            $script:evt41Crash = New-FakeShutdownEvent -Id 41 -TimeCreated (Get-Date '2026-07-01 05:00:00') -PropertyValues @([uint32]0x7E)
+
+            Mock -CommandName 'Get-WinEvent' -ModuleName 'PSWinOps' -MockWith {
+                if ($FilterHashtable.ContainsKey('ProviderName')) {
+                    return @($script:evt41PowerLoss, $script:evt41Crash)
+                }
+                return @($script:evt1074, $script:evt6008, $script:evt6006, $script:evt1076)
+            }
+        }
+
+        It -Name 'Should return one row per correlated event' -Test {
+            $result = Get-UnexpectedShutdown
+            $result.Count | Should -Be 6
+        }
+
+        It -Name 'Should return a PSWinOps.UnexpectedShutdown typed object' -Test {
+            $result = Get-UnexpectedShutdown
+            $result[0].PSObject.TypeNames[0] | Should -Be 'PSWinOps.UnexpectedShutdown'
+        }
+
+        It -Name 'Should return all required output properties' -Test {
+            $result = Get-UnexpectedShutdown
+            $props = $result[0].PSObject.Properties.Name
+            $props | Should -Contain 'ComputerName'
+            $props | Should -Contain 'EventTime'
+            $props | Should -Contain 'EventId'
+            $props | Should -Contain 'ShutdownType'
+            $props | Should -Contain 'IsExpected'
+            $props | Should -Contain 'Cause'
+            $props | Should -Contain 'ReasonCode'
+            $props | Should -Contain 'Initiator'
+            $props | Should -Contain 'Comment'
+            $props | Should -Contain 'Timestamp'
+        }
+
+        It -Name 'Should set ComputerName to the local machine' -Test {
+            $result = Get-UnexpectedShutdown
+            $result[0].ComputerName | Should -Be $env:COMPUTERNAME
+        }
+
+        It -Name 'Should format EventTime and Timestamp as yyyy-MM-dd HH:mm:ss' -Test {
+            $result = Get-UnexpectedShutdown
+            $result[0].EventTime | Should -Match "^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$"
+            $result[0].Timestamp | Should -Match "^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$"
+        }
+
+        It -Name 'Should sort events newest first' -Test {
+            $result = Get-UnexpectedShutdown
+            $sorted = $result.EventTime | Sort-Object -Descending
+            [string[]]$result.EventTime | Should -Be ([string[]]$sorted)
+        }
+
+        It -Name 'Should map 1074 to ShutdownType Planned and IsExpected true' -Test {
+            $result = Get-UnexpectedShutdown
+            $row = $result | Where-Object { $_.EventId -eq 1074 }
+            $row.ShutdownType | Should -Be 'Planned'
+            $row.IsExpected | Should -Be $true
+        }
+
+        It -Name 'Should populate Cause, ReasonCode, Initiator and Comment from 1074 properties' -Test {
+            $result = Get-UnexpectedShutdown
+            $row = $result | Where-Object { $_.EventId -eq 1074 }
+            $row.Cause | Should -Be 'Operating System: Upgrade'
+            $row.ReasonCode | Should -Be '1:2'
+            $row.Initiator | Should -Be 'DOMAIN\admin'
+            $row.Comment | Should -Be 'Scheduled maintenance'
+        }
+
+        It -Name 'Should map 6008 to ShutdownType Unexpected and IsExpected false' -Test {
+            $result = Get-UnexpectedShutdown
+            $row = $result | Where-Object { $_.EventId -eq 6008 }
+            $row.ShutdownType | Should -Be 'Unexpected'
+            $row.IsExpected | Should -Be $false
+        }
+
+        It -Name 'Should map 6006 to ShutdownType Clean and IsExpected true' -Test {
+            $result = Get-UnexpectedShutdown
+            $row = $result | Where-Object { $_.EventId -eq 6006 }
+            $row.ShutdownType | Should -Be 'Clean'
+            $row.IsExpected | Should -Be $true
+        }
+
+        It -Name 'Should map 1076 to ShutdownType ReasonSupplied and IsExpected false' -Test {
+            $result = Get-UnexpectedShutdown
+            $row = $result | Where-Object { $_.EventId -eq 1076 }
+            $row.ShutdownType | Should -Be 'ReasonSupplied'
+            $row.IsExpected | Should -Be $false
+        }
+
+        It -Name 'Should populate Cause and Initiator from 1076 properties' -Test {
+            $result = Get-UnexpectedShutdown
+            $row = $result | Where-Object { $_.EventId -eq 1076 }
+            $row.Cause | Should -Be 'Power outage reported'
+            $row.Initiator | Should -Be 'DOMAIN\jdoe'
+        }
+
+        It -Name 'Should map Kernel-Power 41 with BugcheckCode 0 to PowerLoss and IsExpected false' -Test {
+            $result = Get-UnexpectedShutdown
+            $row = $result | Where-Object { $_.EventId -eq 41 -and $_.EventTime -eq '2026-07-01 06:00:00' }
+            $row.ShutdownType | Should -Be 'PowerLoss'
+            $row.IsExpected | Should -Be $false
+        }
+
+        It -Name 'Should map Kernel-Power 41 with non-zero BugcheckCode to Crash and set Cause' -Test {
+            $result = Get-UnexpectedShutdown
+            $row = $result | Where-Object { $_.EventId -eq 41 -and $_.EventTime -eq '2026-07-01 05:00:00' }
+            $row.ShutdownType | Should -Be 'Crash'
+            $row.IsExpected | Should -Be $false
+            $row.Cause | Should -Match 'BugcheckCode'
+        }
+    }
+
+    Context -Name 'No matching events on the machine' -Fixture {
+
+        BeforeAll {
+            Mock -CommandName 'Get-WinEvent' -ModuleName 'PSWinOps' -MockWith {
+                return $null
+            }
+        }
+
+        It -Name 'Should emit nothing for that machine without error' -Test {
+            $result = @(Get-UnexpectedShutdown -ErrorAction Stop)
+            $result.Count | Should -Be 0
+        }
+    }
+
+    Context -Name 'Explicit remote machine' -Fixture {
+
+        BeforeAll {
+            Mock -CommandName 'Invoke-Command' -ModuleName 'PSWinOps' -MockWith {
+                [PSCustomObject]@{
+                    PSTypeName   = 'PSWinOps.UnexpectedShutdown'
+                    ComputerName = 'SRV01'
+                    EventTime    = '2026-07-01 10:00:00'
+                    EventId      = 1074
+                    ShutdownType = 'Planned'
+                    IsExpected   = $true
+                    Cause        = 'Operating System: Upgrade'
+                    ReasonCode   = '1:2'
+                    Initiator    = 'DOMAIN\admin'
+                    Comment      = 'Scheduled maintenance'
+                    Timestamp    = '2026-07-05 12:00:00'
+                }
+            }
+        }
+
+        It -Name 'Should dispatch via Invoke-Command for a remote machine' -Test {
+            $result = Get-UnexpectedShutdown -ComputerName 'SRV01'
+            Should -Invoke -CommandName 'Invoke-Command' -ModuleName 'PSWinOps' -Times 1 -Exactly
+            $result.ComputerName | Should -Be 'SRV01'
+        }
+
+        It -Name 'Should propagate Credential to Invoke-Command' -Test {
+            $securePwd = ConvertTo-SecureString -String 'P@ssw0rd123!' -AsPlainText -Force
+            $cred = [System.Management.Automation.PSCredential]::new('DOMAIN\svc', $securePwd)
+            Get-UnexpectedShutdown -ComputerName 'SRV01' -Credential $cred
+            Should -Invoke -CommandName 'Invoke-Command' -ModuleName 'PSWinOps' -Times 1 -Exactly -ParameterFilter {
+                $Credential -eq $cred
+            }
+        }
+    }
+
+    Context -Name 'Pipeline of multiple machine names' -Fixture {
+
+        BeforeAll {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -MockWith {
+                [PSCustomObject]@{
+                    PSTypeName   = 'PSWinOps.UnexpectedShutdown'
+                    ComputerName = $ComputerName
+                    EventTime    = '2026-07-01 10:00:00'
+                    EventId      = 6006
+                    ShutdownType = 'Clean'
+                    IsExpected   = $true
+                    Cause        = ''
+                    ReasonCode   = ''
+                    Initiator    = ''
+                    Comment      = ''
+                    Timestamp    = '2026-07-05 12:00:00'
+                }
+            }
+        }
+
+        It -Name 'Should call Invoke-RemoteOrLocal once per machine and return a result for each' -Test {
+            $result = 'SRV01', 'SRV02' | Get-UnexpectedShutdown
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -Times 2 -Exactly
+            ($result | Select-Object -ExpandProperty ComputerName) | Should -Contain 'SRV01'
+            ($result | Select-Object -ExpandProperty ComputerName) | Should -Contain 'SRV02'
+        }
+    }
+
+    Context -Name 'Per-machine failure - continues processing remaining machines' -Fixture {
+
+        BeforeAll {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -MockWith {
+                if ($ComputerName -eq 'SRV01') {
+                    throw 'Simulated WinRM failure on SRV01'
+                }
+                [PSCustomObject]@{
+                    PSTypeName   = 'PSWinOps.UnexpectedShutdown'
+                    ComputerName = $ComputerName
+                    EventTime    = '2026-07-01 10:00:00'
+                    EventId      = 6006
+                    ShutdownType = 'Clean'
+                    IsExpected   = $true
+                    Cause        = ''
+                    ReasonCode   = ''
+                    Initiator    = ''
+                    Comment      = ''
+                    Timestamp    = '2026-07-05 12:00:00'
+                }
+            }
+            $script:perMachineOutput    = 'SRV01', 'SRV02' |
+                Get-UnexpectedShutdown -ErrorAction Continue 2>&1
+            $script:perMachineErrors    = @($script:perMachineOutput | Where-Object {
+                $_ -is [System.Management.Automation.ErrorRecord]
+            })
+            $script:perMachineSuccesses = @($script:perMachineOutput | Where-Object {
+                $_ -isnot [System.Management.Automation.ErrorRecord]
+            })
+        }
+
+        It -Name 'Should write an error for the failing machine' -Test {
+            $script:perMachineErrors.Count | Should -BeGreaterThan 0
+        }
+
+        It -Name 'Should still return a result for the succeeding machine' -Test {
+            $script:perMachineSuccesses.Count | Should -Be 1
+            $script:perMachineSuccesses[0].ComputerName | Should -Be 'SRV02'
+        }
+    }
+
+    Context -Name 'Parameter validation' -Fixture {
+
+        It -Name 'Should throw when ComputerName is an empty string' -Test {
+            { Get-UnexpectedShutdown -ComputerName '' } | Should -Throw
+        }
+
+        It -Name 'Should throw when ComputerName is null' -Test {
+            { Get-UnexpectedShutdown -ComputerName $null } | Should -Throw
+        }
+
+        It -Name 'Should throw when MaxEvents is below the valid range' -Test {
+            { Get-UnexpectedShutdown -MaxEvents 0 } | Should -Throw
+        }
+
+        It -Name 'Should throw when MaxEvents is above the valid range' -Test {
+            { Get-UnexpectedShutdown -MaxEvents 10001 } | Should -Throw
+        }
+
+        It -Name 'Should throw when Days is below the valid range' -Test {
+            { Get-UnexpectedShutdown -Days 0 } | Should -Throw
+        }
+
+        It -Name 'Should throw when Days is above the valid range' -Test {
+            { Get-UnexpectedShutdown -Days 3651 } | Should -Throw
+        }
+
+        It -Name 'Should expose ComputerName with pipeline support by value and by property name' -Test {
+            $cmd = Get-Command -Name 'Get-UnexpectedShutdown'
+            $attr = $cmd.Parameters['ComputerName'].Attributes.Where({ $_ -is [System.Management.Automation.ParameterAttribute] })[0]
+            $attr.ValueFromPipeline | Should -Be $true
+            $attr.ValueFromPipelineByPropertyName | Should -Be $true
+        }
+
+        It -Name 'Should expose ComputerName aliases CN, Name and DNSHostName' -Test {
+            $cmd = Get-Command -Name 'Get-UnexpectedShutdown'
+            $aliases = $cmd.Parameters['ComputerName'].Aliases
+            $aliases | Should -Contain 'CN'
+            $aliases | Should -Contain 'Name'
+            $aliases | Should -Contain 'DNSHostName'
+        }
+    }
+}

--- a/en-US/about_PSWinOps.help.txt
+++ b/en-US/about_PSWinOps.help.txt
@@ -12,7 +12,7 @@ LONG DESCRIPTION
     PSWinOps is a comprehensive toolbox designed for Windows
     system administrators running PowerShell 5.1 or later.
     It provides a curated collection of functions organized
-    into eleven functional domains, covering everything from
+    into twelve functional domains, covering everything from
     Active Directory inventory and security auditing,
     service health monitoring, network troubleshooting,
     NTP synchronization, proxy management, RDP session
@@ -31,7 +31,7 @@ LONG DESCRIPTION
     Requires    : PowerShell 5.1+ / Windows only
 
 FUNCTION DOMAINS
-    PSWinOps organizes its functions into eleven domains.
+    PSWinOps organizes its functions into twelve domains.
 
   activedirectory (21 functions)
     Functions for Active Directory inventory, user and
@@ -61,6 +61,13 @@ FUNCTION DOMAINS
       Reset-ADUserPassword
       Search-ADObject
       Unlock-ADUserAccount
+
+  eventlog (1 function)
+    Functions for correlating Windows System event log
+    entries into shutdown/restart history, cause and
+    initiator reporting.
+
+      Get-UnexpectedShutdown
 
   healthcheck (16 functions)
     Functions that evaluate the health of Windows roles and
@@ -297,7 +304,7 @@ REMOTE EXECUTION PATTERN
     in the pipeline continue to be processed.
 
 PSWINOPS TYPE REGISTRY
-    The following 94 PSTypeName values are defined by the
+    The following 95 PSTypeName values are defined by the
     module. Each corresponds to the output of one or more
     public functions.
 
@@ -390,6 +397,7 @@ PSWINOPS TYPE REGISTRY
       PSWinOps.SubnetInfo
       PSWinOps.SystemSummary
       PSWinOps.TraceRouteHop
+      PSWinOps.UnexpectedShutdown
       PSWinOps.UserProfileRemoval
       PSWinOps.WindowsUpdate
       PSWinOps.WindowsUpdateConfiguration


### PR DESCRIPTION
## Summary
Correlates Windows System event log entries (6008 dirty shutdown, Kernel-Power 41 unexpected, 1074 planned shutdown/restart, 6006 clean shutdown, 1076 reason supplied) to report each shutdown or restart with its cause, whether it was expected or unexpected, the initiating process/user and the reason code. Local and remote targets are dispatched through Invoke-RemoteOrLocal; machines with no matching events return nothing.

## Files touched
- `Public/eventlog/Get-UnexpectedShutdown.ps1` — implementation (new `eventlog` domain)
- `Tests/Public/eventlog/Get-UnexpectedShutdown.Tests.ps1` — Pester v5 suite
- `PSWinOps.psd1` — FunctionsToExport, ModuleVersion (0.1.0 -> 0.2.0), ReleaseNotes
- `PSWinOps.Format.ps1xml` — new `<View>` for `PSWinOps.UnexpectedShutdown`
- `en-US/about_PSWinOps.help.txt` — eventlog domain section + type registry + counters
- `.github/workflows/ci.yml` — matrix updated with `Public/eventlog`

## Conformance checklist (audited locally by fn-quality-gate)
- [x] UTF-8 BOM + CRLF on both new files
- [x] Approved PowerShell verb (Get)
- [x] `FunctionsToExport` present once, inserted alphabetically (Get-SystemSummary < Get-UnexpectedShutdown < Get-WindowsUpdate)
- [x] `PSTypeName` (PSWinOps.UnexpectedShutdown) consistent across .ps1 / Format.ps1xml / about help
- [x] No `Write-Host`, no `ToString('o')`, no WMI cmdlets in the diff
- [x] `PSWinOps.Format.ps1xml` is valid XML with a matching `<View>` (TableControl + AutoSize)

## Verification
Dynamic verification (Test-ModuleManifest, PSScriptAnalyzer, Pester matrix) runs on the Windows CI for this PR. Merge once all required checks are green.