### PR TITLE
feat(system): add Get-CrashDump

### DIFF
--- a/.kdust/chains/get-crashdump-2607052126.yaml
+++ b/.kdust/chains/get-crashdump-2607052126.yaml
@@ -1,0 +1,7 @@
+chain: pswinops-function-author
+function: Get-CrashDump
+domain: system
+created: 2026-07-05T21:28:03Z
+created_by: pswinops-fn-spec-analyst
+chain_branch: kdust/chain/pswinops-fn-get-crashdump-2607052126
+spec_path: work/get-crashdump/spec.yaml

--- a/PSWinOps.Format.ps1xml
+++ b/PSWinOps.Format.ps1xml
@@ -7527,5 +7527,69 @@
         </TableRowEntries>
       </TableControl>
     </View>
+    <!-- ============================================================ -->
+    <!-- PSWinOps.CrashDump                                           -->
+    <!-- Used by: Get-CrashDump                                       -->
+    <!-- ============================================================ -->
+    <View>
+      <Name>PSWinOps.CrashDump</Name>
+      <ViewSelectedBy>
+        <TypeName>PSWinOps.CrashDump</TypeName>
+      </ViewSelectedBy>
+      <TableControl>
+        <AutoSize />
+        <TableHeaders>
+          <TableColumnHeader>
+            <Label>ComputerName</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>DumpFile</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>DumpType</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>SizeMB</Label>
+            <Alignment>Right</Alignment>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>CreationTime</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>BugCheckCode</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>BugCheckSymbol</Label>
+          </TableColumnHeader>
+        </TableHeaders>
+        <TableRowEntries>
+          <TableRowEntry>
+            <TableColumnItems>
+              <TableColumnItem>
+                <PropertyName>ComputerName</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>DumpFile</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>DumpType</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>SizeMB</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>CreationTime</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>BugCheckCode</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>BugCheckSymbol</PropertyName>
+              </TableColumnItem>
+            </TableColumnItems>
+          </TableRowEntry>
+        </TableRowEntries>
+      </TableControl>
+    </View>
   </ViewDefinitions>
 </Configuration>

--- a/PSWinOps.psd1
+++ b/PSWinOps.psd1
@@ -113,6 +113,7 @@
         'Get-CertificateAuthorityHealth',
         'Get-ClusterHealth',
         'Get-ComputerUptime',
+        'Get-CrashDump',
         'Get-DfsNamespaceHealth',
         'Get-DfsReplicationHealth',
         'Get-DhcpServerHealth',

--- a/PSWinOps.psd1
+++ b/PSWinOps.psd1
@@ -12,7 +12,7 @@
     RootModule           = 'PSWinOps.psm1'
 
     # Version number of this module.
-    ModuleVersion        = '0.2.0'
+    ModuleVersion        = '0.2.1'
 
     # Supported PSEditions
     # Core is supported on Windows only; the module-level guard in PSWinOps.psm1 blocks
@@ -269,7 +269,11 @@
             # IconUri = ''
 
             # ReleaseNotes of this module
-            ReleaseNotes = '## 0.2.0 - 2026-07-05 UTC
+            ReleaseNotes = '## 0.2.1 - 2026-07-05 UTC
+### Added
+- Get-CrashDump: Inventory Windows crash memory dumps with size, type and BugCheck code
+
+## 0.2.0 - 2026-07-05 UTC
 ### Added
 - Get-UnexpectedShutdown: Reports shutdown and restart events with cause, expectedness and initiator
 

--- a/Public/system/Get-CrashDump.ps1
+++ b/Public/system/Get-CrashDump.ps1
@@ -1,0 +1,233 @@
+﻿#Requires -Version 5.1
+function Get-CrashDump {
+    <#
+    .SYNOPSIS
+        Inventory Windows crash memory dumps with size, type and BugCheck code
+
+    .DESCRIPTION
+        Enumerates minidumps and the full/kernel MEMORY.DMP on one or more machines in a single
+        pass, reporting size, creation time and configured dump type. The BugCheck code and
+        symbol are correlated from WER System Error Reporting event 1001 by temporal proximity,
+        so no binary dump parsing is required. Local and remote targets are dispatched through
+        Invoke-RemoteOrLocal.
+
+    .PARAMETER ComputerName
+        One or more computer names to target. Defaults to the local computer.
+        Accepts pipeline input by value and by property name.
+
+    .PARAMETER Credential
+        Optional PSCredential for authenticating to remote machines. Ignored for
+        local machine queries.
+
+    .PARAMETER Path
+        Override dump directory/glob. Default is '%SystemRoot%\Minidump\*.dmp' plus
+        '%SystemRoot%\MEMORY.DMP'. When supplied, this path or glob is searched instead
+        of the two defaults.
+
+    .PARAMETER Newest
+        Return only the N most recent dumps per machine, sorted by CreationTime
+        descending. When omitted, all discovered dumps are returned.
+
+    .EXAMPLE
+        Get-CrashDump
+
+        Returns every crash dump found on the local computer.
+
+    .EXAMPLE
+        Get-CrashDump -ComputerName 'SRV01' -Newest 5
+
+        Returns the 5 most recent crash dumps on SRV01 via WinRM.
+
+    .EXAMPLE
+        'SRV01', 'SRV02' | Get-CrashDump -Credential $cred
+
+        Returns crash dumps for SRV01 and SRV02 via pipeline, using alternate credentials.
+
+    .OUTPUTS
+        PSWinOps.CrashDump
+        One object per discovered dump file, with size, creation time, configured dump
+        type, and the correlated BugCheck code/symbol when resolvable.
+
+    .NOTES
+        Author: Franck SALLET
+        Version: 1.0.0
+        Last Modified: 2026-07-05
+        Requires: PowerShell 5.1+ / Windows only
+        Requires: Read access to %SystemRoot%\Minidump and %SystemRoot%\MEMORY.DMP;
+        WinRM enabled on target machines for remote queries
+
+    .LINK
+        https://github.com/k9fr4n/PSWinOps
+
+    .LINK
+        https://github.com/k9fr4n/PSWinOps/issues/66
+    #>
+    [CmdletBinding()]
+    [OutputType('PSWinOps.CrashDump')]
+    param(
+        [Parameter(Mandatory = $false, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [ValidateNotNullOrEmpty()]
+        [Alias('CN', 'Name', 'DNSHostName')]
+        [string[]]$ComputerName = $env:COMPUTERNAME,
+
+        [Parameter(Mandatory = $false)]
+        [System.Management.Automation.PSCredential]$Credential,
+
+        [Parameter(Mandatory = $false)]
+        [string]$Path,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateRange(1, [int]::MaxValue)]
+        [int]$Newest
+    )
+
+    begin {
+        Write-Verbose "[$($MyInvocation.MyCommand)] Starting crash dump inventory"
+
+        $hasNewest = $PSBoundParameters.ContainsKey('Newest')
+        $newestVal = if ($hasNewest) { $Newest } else { 0 }
+        $hasPath   = $PSBoundParameters.ContainsKey('Path')
+        $pathVal   = if ($hasPath) { $Path } else { '' }
+
+        $scriptBlock = {
+            param(
+                [bool]$HasPath,
+                [string]$OverridePath,
+                [bool]$HasNewest,
+                [int]$NewestCount
+            )
+
+            # Bugcheck code -> human readable symbol lookup (common codes only)
+            $bugCheckSymbols = @{
+                '0X00000001' = 'APC_INDEX_MISMATCH'
+                '0X0000000A' = 'IRQL_NOT_LESS_OR_EQUAL'
+                '0X0000001A' = 'MEMORY_MANAGEMENT'
+                '0X0000001E' = 'KMODE_EXCEPTION_NOT_HANDLED'
+                '0X00000024' = 'NTFS_FILE_SYSTEM'
+                '0X0000003B' = 'SYSTEM_SERVICE_EXCEPTION'
+                '0X0000004E' = 'PFN_LIST_CORRUPT'
+                '0X00000050' = 'PAGE_FAULT_IN_NONPAGED_AREA'
+                '0X0000007A' = 'KERNEL_DATA_INPAGE_ERROR'
+                '0X0000007E' = 'SYSTEM_THREAD_EXCEPTION_NOT_HANDLED_M'
+                '0X0000007F' = 'UNEXPECTED_KERNEL_MODE_TRAP'
+                '0X0000008E' = 'KERNEL_MODE_EXCEPTION_NOT_HANDLED'
+                '0X0000009F' = 'DRIVER_POWER_STATE_FAILURE'
+                '0X000000C2' = 'BAD_POOL_CALLER'
+                '0X000000CE' = 'DRIVER_UNLOADED_WITHOUT_CANCELLING_PENDING_OPERATIONS'
+                '0X000000D1' = 'DRIVER_IRQL_NOT_LESS_OR_EQUAL'
+                '0X000000EF' = 'CRITICAL_PROCESS_DIED'
+                '0X000000F4' = 'CRITICAL_OBJECT_TERMINATION'
+                '0X00000109' = 'CRITICAL_STRUCTURE_CORRUPTION'
+                '0X00000119' = 'VIDEO_SCHEDULER_INTERNAL_ERROR'
+                '0X00000124' = 'WHEA_UNCORRECTABLE_ERROR'
+                '0X00000133' = 'DPC_WATCHDOG_VIOLATION'
+                '0X00000139' = 'KERNEL_SECURITY_CHECK_FAILURE'
+            }
+
+            # Rule 5: CIM over WMI for the Windows directory
+            $systemRoot = (Get-CimInstance -ClassName 'Win32_OperatingSystem' -ErrorAction Stop).WindowsDirectory
+
+            $dumpFiles = [System.Collections.Generic.List[System.IO.FileInfo]]::new()
+
+            if ($HasPath -and -not [string]::IsNullOrWhiteSpace($OverridePath)) {
+                $resolvedOverride = $OverridePath
+                if (Test-Path -Path $resolvedOverride -PathType Container -ErrorAction SilentlyContinue) {
+                    $resolvedOverride = Join-Path -Path $resolvedOverride -ChildPath '*.dmp'
+                }
+                $found = @(Get-ChildItem -Path $resolvedOverride -File -ErrorAction SilentlyContinue)
+                foreach ($item in $found) { $dumpFiles.Add($item) }
+            } else {
+                $miniDumpGlob = Join-Path -Path $systemRoot -ChildPath 'Minidump\*.dmp'
+                $memoryDump   = Join-Path -Path $systemRoot -ChildPath 'MEMORY.DMP'
+
+                $miniFound = @(Get-ChildItem -Path $miniDumpGlob -File -ErrorAction SilentlyContinue)
+                foreach ($item in $miniFound) { $dumpFiles.Add($item) }
+
+                $memoryFound = @(Get-Item -Path $memoryDump -ErrorAction SilentlyContinue)
+                foreach ($item in $memoryFound) { $dumpFiles.Add($item) }
+            }
+
+            if ($dumpFiles.Count -eq 0) {
+                return @()
+            }
+
+            # Configured dump type, read once, used to classify MEMORY.DMP
+            $crashControlPath = 'HKLM:\SYSTEM\CurrentControlSet\Control\CrashControl'
+            $crashDumpEnabled = (Get-ItemProperty -Path $crashControlPath -Name 'CrashDumpEnabled' -ErrorAction SilentlyContinue).CrashDumpEnabled
+
+            # WER System Error Reporting 1001 events, fetched once and correlated by proximity
+            $werEvents = @(Get-WinEvent -FilterHashtable @{
+                    LogName      = 'Application'
+                    ProviderName = 'Microsoft-Windows-WER-SystemErrorReporting'
+                    Id           = 1001
+                } -ErrorAction SilentlyContinue)
+
+            $results = [System.Collections.Generic.List[psobject]]::new()
+
+            foreach ($dump in $dumpFiles) {
+                $dumpType = if ($dump.Name -like 'Mini*.dmp') {
+                    'Mini'
+                } elseif ($crashDumpEnabled -eq 2) {
+                    'Kernel'
+                } else {
+                    'Full'
+                }
+
+                $bugCheckCode   = $null
+                $bugCheckSymbol = $null
+
+                $closestEvent = $werEvents | Where-Object {
+                    [math]::Abs(($_.TimeCreated - $dump.CreationTime).TotalMinutes) -le 10
+                } | Sort-Object -Property { [math]::Abs(($_.TimeCreated - $dump.CreationTime).TotalMinutes) } | Select-Object -First 1
+
+                if ($null -ne $closestEvent) {
+                    $matched = [regex]::Match($closestEvent.Message, '0x[0-9A-Fa-f]{8}')
+                    if ($matched.Success) {
+                        $bugCheckCode = $matched.Value.ToUpperInvariant() -replace '^0X', '0x'
+                        $lookupKey = $matched.Value.ToUpperInvariant()
+                        if ($bugCheckSymbols.ContainsKey($lookupKey)) {
+                            $bugCheckSymbol = $bugCheckSymbols[$lookupKey]
+                        }
+                    }
+                }
+
+                $results.Add([PSCustomObject]@{
+                        PSTypeName      = 'PSWinOps.CrashDump'
+                        ComputerName    = $env:COMPUTERNAME
+                        DumpFile        = $dump.FullName
+                        DumpType        = $dumpType
+                        SizeMB          = [math]::Round($dump.Length / 1MB, 2)
+                        CreationTime    = $dump.CreationTime.ToString('yyyy-MM-dd HH:mm:ss')
+                        BugCheckCode    = $bugCheckCode
+                        BugCheckSymbol  = $bugCheckSymbol
+                        Timestamp       = (Get-Date -Format 'yyyy-MM-dd HH:mm:ss')
+                    })
+            }
+
+            $sorted = @($results | Sort-Object -Property CreationTime -Descending)
+
+            if ($HasNewest -and $NewestCount -gt 0) {
+                $sorted = @($sorted | Select-Object -First $NewestCount)
+            }
+
+            $sorted
+        }
+    }
+
+    process {
+        foreach ($targetComputer in $ComputerName) {
+            try {
+                Write-Verbose "[$($MyInvocation.MyCommand)] Querying crash dumps on '$targetComputer'"
+                Invoke-RemoteOrLocal -ComputerName $targetComputer -Credential $Credential `
+                    -ScriptBlock $scriptBlock `
+                    -ArgumentList @($hasPath, $pathVal, $hasNewest, $newestVal)
+            } catch {
+                Write-Error "[$($MyInvocation.MyCommand)] Failed on '$targetComputer': $_"
+            }
+        }
+    }
+
+    end {
+        Write-Verbose "[$($MyInvocation.MyCommand)] Completed crash dump inventory"
+    }
+}

--- a/Tests/Public/system/Get-CrashDump.Tests.ps1
+++ b/Tests/Public/system/Get-CrashDump.Tests.ps1
@@ -1,0 +1,425 @@
+﻿#Requires -Version 5.1
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSAvoidUsingConvertToSecureStringWithPlainText', '',
+    Justification = 'Test fixture only -- not a real credential'
+)]
+param()
+
+BeforeAll {
+    $script:modulePath = Split-Path -Path (Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent) -Parent
+    Import-Module -Name (Join-Path -Path $script:modulePath -ChildPath 'PSWinOps.psd1') -Force
+}
+
+Describe -Name 'Get-CrashDump' -Fixture {
+
+    BeforeEach {
+        Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -MockWith {
+            [PSCustomObject]@{
+                PSTypeName     = 'PSWinOps.CrashDump'
+                ComputerName   = $ComputerName
+                DumpFile       = 'C:\Windows\Minidump\070526-12345-01.dmp'
+                DumpType       = 'Mini'
+                SizeMB         = 0.45
+                CreationTime   = '2026-07-05 08:00:00'
+                BugCheckCode   = '0x0000009F'
+                BugCheckSymbol = 'DRIVER_POWER_STATE_FAILURE'
+                Timestamp      = '2026-07-05 12:00:00'
+            }
+        }
+    }
+
+    Context -Name 'Happy path - local machine' -Fixture {
+
+        It -Name 'Should return a result for the local machine by default' -Test {
+            $result = Get-CrashDump
+            $result | Should -Not -BeNullOrEmpty
+            $result.ComputerName | Should -Be $env:COMPUTERNAME
+        }
+
+        It -Name 'Should return a PSWinOps.CrashDump typed object' -Test {
+            $result = Get-CrashDump
+            $result.PSObject.TypeNames[0] | Should -Be 'PSWinOps.CrashDump'
+        }
+
+        It -Name 'Should call Invoke-RemoteOrLocal once for local machine' -Test {
+            Get-CrashDump
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -Times 1 -Exactly
+        }
+
+        It -Name 'Should return all required output properties' -Test {
+            $result = Get-CrashDump
+            $props = $result.PSObject.Properties.Name
+            $props | Should -Contain 'ComputerName'
+            $props | Should -Contain 'DumpFile'
+            $props | Should -Contain 'DumpType'
+            $props | Should -Contain 'SizeMB'
+            $props | Should -Contain 'CreationTime'
+            $props | Should -Contain 'BugCheckCode'
+            $props | Should -Contain 'BugCheckSymbol'
+            $props | Should -Contain 'Timestamp'
+        }
+
+        It -Name 'Should format Timestamp as yyyy-MM-dd HH:mm:ss' -Test {
+            $result = Get-CrashDump
+            $result.Timestamp | Should -Match "^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$"
+        }
+
+        It -Name 'Should format CreationTime as yyyy-MM-dd HH:mm:ss' -Test {
+            $result = Get-CrashDump
+            $result.CreationTime | Should -Match "^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$"
+        }
+    }
+
+    Context -Name 'DumpType enum - Mini' -Fixture {
+
+        It -Name 'Should surface DumpType=Mini returned by Invoke-RemoteOrLocal' -Test {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -MockWith {
+                [PSCustomObject]@{
+                    PSTypeName     = 'PSWinOps.CrashDump'
+                    ComputerName   = $ComputerName
+                    DumpFile       = 'C:\Windows\Minidump\070526-12345-01.dmp'
+                    DumpType       = 'Mini'
+                    SizeMB         = 0.45
+                    CreationTime   = '2026-07-05 08:00:00'
+                    BugCheckCode   = $null
+                    BugCheckSymbol = $null
+                    Timestamp      = '2026-07-05 12:00:00'
+                }
+            }
+            $result = Get-CrashDump
+            $result.DumpType | Should -Be 'Mini'
+        }
+    }
+
+    Context -Name 'DumpType enum - Full' -Fixture {
+
+        It -Name 'Should surface DumpType=Full returned by Invoke-RemoteOrLocal' -Test {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -MockWith {
+                [PSCustomObject]@{
+                    PSTypeName     = 'PSWinOps.CrashDump'
+                    ComputerName   = $ComputerName
+                    DumpFile       = 'C:\Windows\MEMORY.DMP'
+                    DumpType       = 'Full'
+                    SizeMB         = 2048.0
+                    CreationTime   = '2026-07-05 08:00:00'
+                    BugCheckCode   = '0x0000007E'
+                    BugCheckSymbol = 'SYSTEM_THREAD_EXCEPTION_NOT_HANDLED_M'
+                    Timestamp      = '2026-07-05 12:00:00'
+                }
+            }
+            $result = Get-CrashDump
+            $result.DumpType | Should -Be 'Full'
+        }
+    }
+
+    Context -Name 'DumpType enum - Kernel' -Fixture {
+
+        It -Name 'Should surface DumpType=Kernel returned by Invoke-RemoteOrLocal' -Test {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -MockWith {
+                [PSCustomObject]@{
+                    PSTypeName     = 'PSWinOps.CrashDump'
+                    ComputerName   = $ComputerName
+                    DumpFile       = 'C:\Windows\MEMORY.DMP'
+                    DumpType       = 'Kernel'
+                    SizeMB         = 512.0
+                    CreationTime   = '2026-07-05 08:00:00'
+                    BugCheckCode   = $null
+                    BugCheckSymbol = $null
+                    Timestamp      = '2026-07-05 12:00:00'
+                }
+            }
+            $result = Get-CrashDump
+            $result.DumpType | Should -Be 'Kernel'
+        }
+    }
+
+    Context -Name 'BugCheck correlation' -Fixture {
+
+        It -Name 'Should populate BugCheckCode and BugCheckSymbol when correlated' -Test {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -MockWith {
+                [PSCustomObject]@{
+                    PSTypeName     = 'PSWinOps.CrashDump'
+                    ComputerName   = $ComputerName
+                    DumpFile       = 'C:\Windows\Minidump\070526-12345-01.dmp'
+                    DumpType       = 'Mini'
+                    SizeMB         = 0.45
+                    CreationTime   = '2026-07-05 08:00:00'
+                    BugCheckCode   = '0x0000009F'
+                    BugCheckSymbol = 'DRIVER_POWER_STATE_FAILURE'
+                    Timestamp      = '2026-07-05 12:00:00'
+                }
+            }
+            $result = Get-CrashDump
+            $result.BugCheckCode | Should -Be '0x0000009F'
+            $result.BugCheckSymbol | Should -Be 'DRIVER_POWER_STATE_FAILURE'
+        }
+
+        It -Name 'Should leave BugCheckCode and BugCheckSymbol null when unresolved' -Test {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -MockWith {
+                [PSCustomObject]@{
+                    PSTypeName     = 'PSWinOps.CrashDump'
+                    ComputerName   = $ComputerName
+                    DumpFile       = 'C:\Windows\Minidump\070526-12345-01.dmp'
+                    DumpType       = 'Mini'
+                    SizeMB         = 0.45
+                    CreationTime   = '2026-07-05 08:00:00'
+                    BugCheckCode   = $null
+                    BugCheckSymbol = $null
+                    Timestamp      = '2026-07-05 12:00:00'
+                }
+            }
+            $result = Get-CrashDump
+            $result.BugCheckCode | Should -BeNullOrEmpty
+            $result.BugCheckSymbol | Should -BeNullOrEmpty
+        }
+    }
+
+    Context -Name 'No dumps present' -Fixture {
+
+        It -Name 'Should emit nothing and no error when no dumps are found' -Test {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -MockWith {
+                return @()
+            }
+            $result = Get-CrashDump -ErrorVariable 'capturedError'
+            $result | Should -BeNullOrEmpty
+            $capturedError | Should -BeNullOrEmpty
+        }
+    }
+
+    Context -Name 'Remote machine - explicit ComputerName' -Fixture {
+
+        It -Name 'Should return result for named remote machine' -Test {
+            $result = Get-CrashDump -ComputerName 'SRV01'
+            $result | Should -Not -BeNullOrEmpty
+            $result.ComputerName | Should -Be 'SRV01'
+        }
+
+        It -Name 'Should call Invoke-RemoteOrLocal once for a named remote machine' -Test {
+            Get-CrashDump -ComputerName 'SRV01'
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -Times 1 -Exactly
+        }
+    }
+
+    Context -Name 'Credential propagation' -Fixture {
+
+        BeforeAll {
+            $script:cred = [PSCredential]::new('admin', (ConvertTo-SecureString -String 'pass' -AsPlainText -Force))
+        }
+
+        It -Name 'Should pass Credential to Invoke-RemoteOrLocal' -Test {
+            Get-CrashDump -ComputerName 'SRV01' -Credential $script:cred
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -Times 1 -Exactly -ParameterFilter {
+                $null -ne $Credential
+            }
+        }
+
+        It -Name 'Should return a result when Credential is provided' -Test {
+            $result = Get-CrashDump -ComputerName 'SRV01' -Credential $script:cred
+            $result | Should -Not -BeNullOrEmpty
+            $result.ComputerName | Should -Be 'SRV01'
+        }
+    }
+
+    Context -Name 'Pipeline by property name - multiple machines' -Fixture {
+
+        It -Name 'Should process multiple machines supplied via pipeline' -Test {
+            $result = @('SRV01', 'SRV02') | Get-CrashDump
+            $result | Should -HaveCount 2
+            $result[0].ComputerName | Should -Be 'SRV01'
+            $result[1].ComputerName | Should -Be 'SRV02'
+        }
+
+        It -Name 'Should call Invoke-RemoteOrLocal once per piped machine' -Test {
+            @('SRV01', 'SRV02') | Get-CrashDump
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -Times 2 -Exactly
+        }
+
+        It -Name 'Should process multiple machines from ComputerName array parameter' -Test {
+            $result = Get-CrashDump -ComputerName 'SRV01', 'SRV02', 'SRV03'
+            $result | Should -HaveCount 3
+        }
+
+        It -Name 'Should accept pipeline input by property name' -Test {
+            $objects = @(
+                [PSCustomObject]@{ ComputerName = 'SRV01' },
+                [PSCustomObject]@{ ComputerName = 'SRV02' }
+            )
+            $result = $objects | Get-CrashDump
+            $result | Should -HaveCount 2
+        }
+    }
+
+    Context -Name 'Per-machine error isolation' -Fixture {
+
+        It -Name 'Should continue to next machine when one fails' -Test {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -MockWith {
+                if ($ComputerName -eq 'BADMACHINE') { throw 'WinRM connection failed' }
+                [PSCustomObject]@{
+                    PSTypeName     = 'PSWinOps.CrashDump'
+                    ComputerName   = $ComputerName
+                    DumpFile       = 'C:\Windows\Minidump\070526-12345-01.dmp'
+                    DumpType       = 'Mini'
+                    SizeMB         = 0.45
+                    CreationTime   = '2026-07-05 08:00:00'
+                    BugCheckCode   = $null
+                    BugCheckSymbol = $null
+                    Timestamp      = '2026-07-05 12:00:00'
+                }
+            }
+            $result = Get-CrashDump -ComputerName 'BADMACHINE', 'SRV01' -ErrorAction SilentlyContinue
+            $result | Should -HaveCount 1
+            $result[0].ComputerName | Should -Be 'SRV01'
+        }
+
+        It -Name 'Should write an error for the failing machine' -Test {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -MockWith {
+                if ($ComputerName -eq 'BADMACHINE') { throw 'WinRM connection failed' }
+                [PSCustomObject]@{
+                    PSTypeName     = 'PSWinOps.CrashDump'
+                    ComputerName   = $ComputerName
+                    DumpFile       = 'C:\Windows\Minidump\070526-12345-01.dmp'
+                    DumpType       = 'Mini'
+                    SizeMB         = 0.45
+                    CreationTime   = '2026-07-05 08:00:00'
+                    BugCheckCode   = $null
+                    BugCheckSymbol = $null
+                    Timestamp      = '2026-07-05 12:00:00'
+                }
+            }
+            Get-CrashDump -ComputerName 'BADMACHINE', 'SRV01' -ErrorAction SilentlyContinue -ErrorVariable 'capturedError'
+            $capturedError | Should -Not -BeNullOrEmpty
+        }
+    }
+
+    Context -Name 'Path parameter' -Fixture {
+
+        It -Name 'Should pass HasPath flag and Path value as ArgumentList to Invoke-RemoteOrLocal' -Test {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -MockWith {
+                $script:capturedHasPath = $ArgumentList[0]
+                $script:capturedPath = $ArgumentList[1]
+                [PSCustomObject]@{
+                    PSTypeName     = 'PSWinOps.CrashDump'
+                    ComputerName   = $ComputerName
+                    DumpFile       = 'D:\Dumps\custom.dmp'
+                    DumpType       = 'Mini'
+                    SizeMB         = 0.45
+                    CreationTime   = '2026-07-05 08:00:00'
+                    BugCheckCode   = $null
+                    BugCheckSymbol = $null
+                    Timestamp      = '2026-07-05 12:00:00'
+                }
+            }
+            Get-CrashDump -Path 'D:\Dumps\*.dmp'
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -Times 1 -Exactly
+            $script:capturedHasPath | Should -Be $true
+            $script:capturedPath | Should -Be 'D:\Dumps\*.dmp'
+        }
+
+        It -Name 'Should leave HasPath false when Path is not specified' -Test {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -MockWith {
+                $script:capturedNoPathFlag = $ArgumentList[0]
+                [PSCustomObject]@{
+                    PSTypeName     = 'PSWinOps.CrashDump'
+                    ComputerName   = $ComputerName
+                    DumpFile       = 'C:\Windows\Minidump\070526-12345-01.dmp'
+                    DumpType       = 'Mini'
+                    SizeMB         = 0.45
+                    CreationTime   = '2026-07-05 08:00:00'
+                    BugCheckCode   = $null
+                    BugCheckSymbol = $null
+                    Timestamp      = '2026-07-05 12:00:00'
+                }
+            }
+            Get-CrashDump
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -Times 1 -Exactly
+            $script:capturedNoPathFlag | Should -Be $false
+        }
+    }
+
+    Context -Name 'Newest parameter' -Fixture {
+
+        It -Name 'Should throw when Newest is 0 (below valid range)' -Test {
+            { Get-CrashDump -Newest 0 } | Should -Throw
+        }
+
+        It -Name 'Should pass HasNewest flag and NewestCount as ArgumentList to Invoke-RemoteOrLocal' -Test {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -MockWith {
+                $script:capturedHasNewest = $ArgumentList[2]
+                $script:capturedNewestCount = $ArgumentList[3]
+                [PSCustomObject]@{
+                    PSTypeName     = 'PSWinOps.CrashDump'
+                    ComputerName   = $ComputerName
+                    DumpFile       = 'C:\Windows\Minidump\070526-12345-01.dmp'
+                    DumpType       = 'Mini'
+                    SizeMB         = 0.45
+                    CreationTime   = '2026-07-05 08:00:00'
+                    BugCheckCode   = $null
+                    BugCheckSymbol = $null
+                    Timestamp      = '2026-07-05 12:00:00'
+                }
+            }
+            Get-CrashDump -Newest 5
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -Times 1 -Exactly
+            $script:capturedHasNewest | Should -Be $true
+            $script:capturedNewestCount | Should -Be 5
+        }
+
+        It -Name 'Should leave HasNewest false when Newest is not specified' -Test {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -MockWith {
+                $script:capturedNoNewestFlag = $ArgumentList[2]
+                [PSCustomObject]@{
+                    PSTypeName     = 'PSWinOps.CrashDump'
+                    ComputerName   = $ComputerName
+                    DumpFile       = 'C:\Windows\Minidump\070526-12345-01.dmp'
+                    DumpType       = 'Mini'
+                    SizeMB         = 0.45
+                    CreationTime   = '2026-07-05 08:00:00'
+                    BugCheckCode   = $null
+                    BugCheckSymbol = $null
+                    Timestamp      = '2026-07-05 12:00:00'
+                }
+            }
+            Get-CrashDump
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -Times 1 -Exactly
+            $script:capturedNoNewestFlag | Should -Be $false
+        }
+    }
+
+    Context -Name 'Parameter validation' -Fixture {
+
+        It -Name 'Should throw when ComputerName is an empty string' -Test {
+            { Get-CrashDump -ComputerName '' } | Should -Throw
+        }
+
+        It -Name 'Should throw when ComputerName is null' -Test {
+            { Get-CrashDump -ComputerName $null } | Should -Throw
+        }
+
+        It -Name 'Should expose ComputerName with pipeline support by value and by property name' -Test {
+            $cmd = Get-Command -Name 'Get-CrashDump'
+            $attr = $cmd.Parameters['ComputerName'].Attributes.Where({ $_ -is [System.Management.Automation.ParameterAttribute] })[0]
+            $attr.ValueFromPipeline | Should -Be $true
+            $attr.ValueFromPipelineByPropertyName | Should -Be $true
+        }
+
+        It -Name 'Should expose ComputerName aliases CN, Name and DNSHostName' -Test {
+            $cmd = Get-Command -Name 'Get-CrashDump'
+            $aliases = $cmd.Parameters['ComputerName'].Aliases
+            $aliases | Should -Contain 'CN'
+            $aliases | Should -Contain 'Name'
+            $aliases | Should -Contain 'DNSHostName'
+        }
+
+        It -Name 'Should expose Path parameter of type string' -Test {
+            $cmd = Get-Command -Name 'Get-CrashDump'
+            $cmd.Parameters['Path'].ParameterType | Should -Be ([string])
+        }
+
+        It -Name 'Should expose Newest parameter of type int' -Test {
+            $cmd = Get-Command -Name 'Get-CrashDump'
+            $cmd.Parameters['Newest'].ParameterType | Should -Be ([int])
+        }
+    }
+}

--- a/en-US/about_PSWinOps.help.txt
+++ b/en-US/about_PSWinOps.help.txt
@@ -168,12 +168,13 @@ FUNCTION DOMAINS
       Get-RdpSessionLock
       Remove-RdpSession
 
-  system (15 functions)
+  system (16 functions)
     Functions for general system information, state,
     disk cleanup, profile management, and real-time monitoring.
 
       Clear-DiskCleanup
       Get-ComputerUptime
+      Get-CrashDump
       Get-DiskCleanupInfo
       Get-DiskSpace
       Get-EnvironmentVariable
@@ -304,7 +305,7 @@ REMOTE EXECUTION PATTERN
     in the pipeline continue to be processed.
 
 PSWINOPS TYPE REGISTRY
-    The following 95 PSTypeName values are defined by the
+    The following 98 PSTypeName values are defined by the
     module. Each corresponds to the output of one or more
     public functions.
 
@@ -337,6 +338,7 @@ PSWINOPS TYPE REGISTRY
       PSWinOps.CertificateAuthorityHealth
       PSWinOps.ClusterHealth
       PSWinOps.ComputerUptime
+      PSWinOps.CrashDump
       PSWinOps.DfsNamespaceHealth
       PSWinOps.DfsReplicationHealth
       PSWinOps.DhcpServerHealth


### PR DESCRIPTION
## Summary
Enumerates minidumps and the full/kernel MEMORY.DMP on one or more machines in a single pass, reporting size, creation time and configured dump type. The BugCheck code and symbol are correlated from WER System Error Reporting event 1001 by temporal proximity, so no binary dump parsing is required.

Closes #66

## Files touched
- `Public/system/Get-CrashDump.ps1` — implementation
- `Tests/Public/system/Get-CrashDump.Tests.ps1` — Pester v5 suite
- `PSWinOps.psd1` — FunctionsToExport, ModuleVersion, ReleaseNotes
- `PSWinOps.Format.ps1xml` — new `<View>` for `PSWinOps.CrashDump`
- `en-US/about_PSWinOps.help.txt` — counters bumped

## Conformance checklist (audited locally by fn-quality-gate)
- [x] UTF-8 BOM + CRLF on both new files
- [x] Approved PowerShell verb (Get)
- [x] `FunctionsToExport` present once, `Get-CrashDump` correctly placed alphabetically
- [x] `PSTypeName` consistent across .ps1 / Format.ps1xml / about help (PSWinOps.CrashDump)
- [x] No `Write-Host`, no `ToString('o')`, no WMI cmdlets in the diff
- [x] `PSWinOps.Format.ps1xml` is valid XML with a matching `<View>`

## Verification
Dynamic verification (Test-ModuleManifest, PSScriptAnalyzer, Pester matrix) runs on the Windows CI for this PR. Merge once all required checks are green.