### PR TITLE
feat(security): add Get-AuditPolicy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,7 @@ jobs:
           - "Public/ntp"
           - "Public/proxy"
           - "Public/rdp"
+          - "Public/security"
           - "Public/system"
           - "Public/utils"
           - "Public/vss"

--- a/.kdust/chains/get-auditpolicy-2607052151.yaml
+++ b/.kdust/chains/get-auditpolicy-2607052151.yaml
@@ -1,0 +1,7 @@
+chain: pswinops-function-author
+function: Get-AuditPolicy
+domain: security
+created: 2026-07-05T21:53:04Z
+created_by: pswinops-fn-spec-analyst
+chain_branch: kdust/chain/pswinops-fn-get-auditpolicy-2607052151
+spec_path: work/get-auditpolicy/spec.yaml

--- a/PSWinOps.Format.ps1xml
+++ b/PSWinOps.Format.ps1xml
@@ -7591,5 +7591,62 @@
         </TableRowEntries>
       </TableControl>
     </View>
+    <!-- ============================================================ -->
+    <!-- PSWinOps.AuditPolicy                                         -->
+    <!-- Used by: Get-AuditPolicy                                     -->
+    <!-- ============================================================ -->
+    <View>
+      <Name>PSWinOps.AuditPolicy</Name>
+      <ViewSelectedBy>
+        <TypeName>PSWinOps.AuditPolicy</TypeName>
+      </ViewSelectedBy>
+      <TableControl>
+        <AutoSize />
+        <TableHeaders>
+          <TableColumnHeader>
+            <Label>ComputerName</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Category</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Subcategory</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>AuditSuccess</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>AuditFailure</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Setting</Label>
+          </TableColumnHeader>
+        </TableHeaders>
+        <TableRowEntries>
+          <TableRowEntry>
+            <TableColumnItems>
+              <TableColumnItem>
+                <PropertyName>ComputerName</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>Category</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>Subcategory</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>AuditSuccess</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>AuditFailure</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>Setting</PropertyName>
+              </TableColumnItem>
+            </TableColumnItems>
+          </TableRowEntry>
+        </TableRowEntries>
+      </TableControl>
+    </View>
   </ViewDefinitions>
 </Configuration>

--- a/PSWinOps.psd1
+++ b/PSWinOps.psd1
@@ -12,7 +12,7 @@
     RootModule           = 'PSWinOps.psm1'
 
     # Version number of this module.
-    ModuleVersion        = '0.2.1'
+    ModuleVersion        = '0.3.0'
 
     # Supported PSEditions
     # Core is supported on Windows only; the module-level guard in PSWinOps.psm1 blocks
@@ -270,7 +270,11 @@
             # IconUri = ''
 
             # ReleaseNotes of this module
-            ReleaseNotes = '## 0.2.1 - 2026-07-05 UTC
+            ReleaseNotes = '## 0.3.0 - 2026-07-05 UTC
+### Added
+- Get-AuditPolicy: Report advanced audit policy subcategory settings from auditpol.exe
+
+## 0.2.1 - 2026-07-05 UTC
 ### Added
 - Get-CrashDump: Inventory Windows crash memory dumps with size, type and BugCheck code
 

--- a/PSWinOps.psd1
+++ b/PSWinOps.psd1
@@ -110,6 +110,7 @@
         'Get-ADUserGroupInventory',
         'Get-ADUserInventory',
         'Get-ARPTable',
+        'Get-AuditPolicy',
         'Get-CertificateAuthorityHealth',
         'Get-ClusterHealth',
         'Get-ComputerUptime',

--- a/Public/security/Get-AuditPolicy.ps1
+++ b/Public/security/Get-AuditPolicy.ps1
@@ -189,16 +189,8 @@ function Get-AuditPolicy {
                     # Local execution: use Invoke-NativeCommand for testable auditpol calls
                     $auditResult = Invoke-NativeCommand -FilePath $auditpolPath -ArgumentList @('/get', '/category:*', '/r')
                     if ($auditResult.ExitCode -ne 0) {
-                        $PSCmdlet.ThrowTerminatingError(
-                            [System.Management.Automation.ErrorRecord]::new(
-                                [System.InvalidOperationException]::new(
-                                    "auditpol /get /category:* /r failed (exit code $($auditResult.ExitCode)): $($auditResult.Output)"
-                                ),
-                                'AuditPolGetFailed',
-                                [System.Management.Automation.ErrorCategory]::InvalidOperation,
-                                $targetComputer
-                            )
-                        )
+                        Write-Error "[$($MyInvocation.MyCommand)] auditpol /get /category:* /r failed (exit code $($auditResult.ExitCode)) on '$targetComputer': $($auditResult.Output)"
+                        continue
                     }
                     $rawOutput = $auditResult.Output -split '\r?\n'
                 } else {
@@ -230,9 +222,9 @@ function Get-AuditPolicy {
 
                 foreach ($row in $rows) {
                     $subcategoryGuid = ($row.'Subcategory GUID' -replace '[{}]', '').Trim().ToUpperInvariant()
-                    $category = if ($categoryMap.ContainsKey($subcategoryGuid)) { $categoryMap[$subcategoryGuid] } else { 'Unknown' }
+                    $resolvedCategory = if ($categoryMap.ContainsKey($subcategoryGuid)) { $categoryMap[$subcategoryGuid] } else { 'Unknown' }
 
-                    if ($Category -and ($category -ne $Category)) {
+                    if ($Category -and ($resolvedCategory -ne $Category)) {
                         continue
                     }
 
@@ -253,7 +245,7 @@ function Get-AuditPolicy {
                     [PSCustomObject]@{
                         PSTypeName      = 'PSWinOps.AuditPolicy'
                         ComputerName    = $targetComputer
-                        Category        = $category
+                        Category        = $resolvedCategory
                         Subcategory     = $row.Subcategory
                         SubcategoryGuid = $subcategoryGuid
                         AuditSuccess    = $auditSuccess

--- a/Public/security/Get-AuditPolicy.ps1
+++ b/Public/security/Get-AuditPolicy.ps1
@@ -1,0 +1,275 @@
+﻿#Requires -Version 5.1
+
+function Get-AuditPolicy {
+    <#
+    .SYNOPSIS
+        Report advanced audit policy subcategory settings from auditpol.exe
+
+    .DESCRIPTION
+        Parses the advanced audit policy returned by 'auditpol.exe /get /category:* /r' (CSV)
+        into one object per subcategory, reporting Success and Failure auditing state. It is a
+        base building block for CIS/ANSSI compliance auditing and supports local and remote
+        targets via Invoke-RemoteOrLocal, with optional filtering to a single category. Each
+        Subcategory GUID is mapped to its parent Category using a static, well-known GUID map
+        since 'auditpol /r' does not expose Category as a column.
+
+    .PARAMETER ComputerName
+        One or more computer names to target. Defaults to the local computer.
+        Accepts pipeline input by value and by property name.
+
+    .PARAMETER Credential
+        Optional PSCredential for authenticating to remote machines. Ignored for local
+        machine queries.
+
+    .PARAMETER Category
+        Filter results to a single audit category, e.g. 'Logon/Logoff'. Matched
+        case-insensitively against the parsed Category column. When set and no subcategory
+        matches on a given machine, that machine yields no rows (no error is raised).
+
+    .EXAMPLE
+        Get-AuditPolicy
+
+        Returns advanced audit policy subcategory settings for the local machine.
+
+    .EXAMPLE
+        Get-AuditPolicy -Category 'Logon/Logoff'
+
+        Returns only the subcategories belonging to the 'Logon/Logoff' category on the
+        local machine.
+
+    .EXAMPLE
+        Get-AuditPolicy -ComputerName SRV01 -Credential (Get-Credential)
+
+        Returns advanced audit policy subcategory settings from SRV01 via WinRM, using
+        the supplied credential.
+
+    .EXAMPLE
+        'SRV01','SRV02' | Get-AuditPolicy
+
+        Returns advanced audit policy subcategory settings for SRV01 and SRV02 via pipeline.
+
+    .OUTPUTS
+        PSWinOps.AuditPolicy
+        One object per audit subcategory, with Category, Subcategory, SubcategoryGuid,
+        AuditSuccess, AuditFailure and the derived Setting string.
+
+    .NOTES
+        Author: Franck SALLET
+        Version: 1.0.0
+        Last Modified: 2026-07-05
+        Requires: PowerShell 5.1+ / Windows only
+        Requires: Elevated (administrator) session for auditpol.exe to return data
+
+    .LINK
+        https://github.com/k9fr4n/PSWinOps
+
+    .LINK
+        https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/auditpol
+    #>
+    [CmdletBinding(SupportsShouldProcess = $false, ConfirmImpact = 'None')]
+    [OutputType('PSWinOps.AuditPolicy')]
+    param(
+        [Parameter(Mandatory = $false, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [ValidateNotNullOrEmpty()]
+        [Alias('CN', 'Name', 'DNSHostName')]
+        [string[]]$ComputerName = $env:COMPUTERNAME,
+
+        [Parameter(Mandatory = $false)]
+        [System.Management.Automation.PSCredential]$Credential,
+
+        [Parameter(Mandatory = $false)]
+        [string]$Category
+    )
+
+    begin {
+        Write-Verbose "[$($MyInvocation.MyCommand)] Starting audit policy query"
+
+        $auditpolPath = Join-Path -Path $env:SystemRoot -ChildPath 'System32\auditpol.exe'
+
+        # Static, well-known Subcategory GUID -> top-level Category map. auditpol /r does not
+        # expose Category as a column, so it must be derived from the (stable) subcategory GUID.
+        $categoryMap = @{
+            # System
+            '0CCE9210-69AE-11D9-BED3-505054503030' = 'System'
+            '0CCE9211-69AE-11D9-BED3-505054503030' = 'System'
+            '0CCE9212-69AE-11D9-BED3-505054503030' = 'System'
+            '0CCE9213-69AE-11D9-BED3-505054503030' = 'System'
+            '0CCE9214-69AE-11D9-BED3-505054503030' = 'System'
+            # Logon/Logoff
+            '0CCE9215-69AE-11D9-BED3-505054503030' = 'Logon/Logoff'
+            '0CCE9216-69AE-11D9-BED3-505054503030' = 'Logon/Logoff'
+            '0CCE9217-69AE-11D9-BED3-505054503030' = 'Logon/Logoff'
+            '0CCE9218-69AE-11D9-BED3-505054503030' = 'Logon/Logoff'
+            '0CCE9219-69AE-11D9-BED3-505054503030' = 'Logon/Logoff'
+            '0CCE921A-69AE-11D9-BED3-505054503030' = 'Logon/Logoff'
+            '0CCE921B-69AE-11D9-BED3-505054503030' = 'Logon/Logoff'
+            '0CCE921C-69AE-11D9-BED3-505054503030' = 'Logon/Logoff'
+            '0CCE9243-69AE-11D9-BED3-505054503030' = 'Logon/Logoff'
+            '0CCE9247-69AE-11D9-BED3-505054503030' = 'Logon/Logoff'
+            '0CCE9249-69AE-11D9-BED3-505054503030' = 'Logon/Logoff'
+            # Object Access
+            '0CCE921D-69AE-11D9-BED3-505054503030' = 'Object Access'
+            '0CCE921E-69AE-11D9-BED3-505054503030' = 'Object Access'
+            '0CCE921F-69AE-11D9-BED3-505054503030' = 'Object Access'
+            '0CCE9220-69AE-11D9-BED3-505054503030' = 'Object Access'
+            '0CCE9221-69AE-11D9-BED3-505054503030' = 'Object Access'
+            '0CCE9222-69AE-11D9-BED3-505054503030' = 'Object Access'
+            '0CCE9223-69AE-11D9-BED3-505054503030' = 'Object Access'
+            '0CCE9224-69AE-11D9-BED3-505054503030' = 'Object Access'
+            '0CCE9225-69AE-11D9-BED3-505054503030' = 'Object Access'
+            '0CCE9226-69AE-11D9-BED3-505054503030' = 'Object Access'
+            '0CCE9227-69AE-11D9-BED3-505054503030' = 'Object Access'
+            '0CCE9244-69AE-11D9-BED3-505054503030' = 'Object Access'
+            '0CCE9245-69AE-11D9-BED3-505054503030' = 'Object Access'
+            '0CCE9246-69AE-11D9-BED3-505054503030' = 'Object Access'
+            # Privilege Use
+            '0CCE9228-69AE-11D9-BED3-505054503030' = 'Privilege Use'
+            '0CCE9229-69AE-11D9-BED3-505054503030' = 'Privilege Use'
+            '0CCE922A-69AE-11D9-BED3-505054503030' = 'Privilege Use'
+            # Detailed Tracking
+            '0CCE922B-69AE-11D9-BED3-505054503030' = 'Detailed Tracking'
+            '0CCE922C-69AE-11D9-BED3-505054503030' = 'Detailed Tracking'
+            '0CCE922D-69AE-11D9-BED3-505054503030' = 'Detailed Tracking'
+            '0CCE922E-69AE-11D9-BED3-505054503030' = 'Detailed Tracking'
+            '0CCE9248-69AE-11D9-BED3-505054503030' = 'Detailed Tracking'
+            '0CCE924A-69AE-11D9-BED3-505054503030' = 'Detailed Tracking'
+            # Policy Change
+            '0CCE922F-69AE-11D9-BED3-505054503030' = 'Policy Change'
+            '0CCE9230-69AE-11D9-BED3-505054503030' = 'Policy Change'
+            '0CCE9231-69AE-11D9-BED3-505054503030' = 'Policy Change'
+            '0CCE9232-69AE-11D9-BED3-505054503030' = 'Policy Change'
+            '0CCE9233-69AE-11D9-BED3-505054503030' = 'Policy Change'
+            '0CCE9234-69AE-11D9-BED3-505054503030' = 'Policy Change'
+            # Account Management
+            '0CCE9235-69AE-11D9-BED3-505054503030' = 'Account Management'
+            '0CCE9236-69AE-11D9-BED3-505054503030' = 'Account Management'
+            '0CCE9237-69AE-11D9-BED3-505054503030' = 'Account Management'
+            '0CCE9238-69AE-11D9-BED3-505054503030' = 'Account Management'
+            '0CCE9239-69AE-11D9-BED3-505054503030' = 'Account Management'
+            '0CCE923A-69AE-11D9-BED3-505054503030' = 'Account Management'
+            # DS Access
+            '0CCE923B-69AE-11D9-BED3-505054503030' = 'DS Access'
+            '0CCE923C-69AE-11D9-BED3-505054503030' = 'DS Access'
+            '0CCE923D-69AE-11D9-BED3-505054503030' = 'DS Access'
+            '0CCE923E-69AE-11D9-BED3-505054503030' = 'DS Access'
+            # Account Logon
+            '0CCE923F-69AE-11D9-BED3-505054503030' = 'Account Logon'
+            '0CCE9240-69AE-11D9-BED3-505054503030' = 'Account Logon'
+            '0CCE9241-69AE-11D9-BED3-505054503030' = 'Account Logon'
+            '0CCE9242-69AE-11D9-BED3-505054503030' = 'Account Logon'
+        }
+
+        # Scriptblock used for REMOTE execution only (Invoke-Command).
+        # Resolves the full auditpol.exe path inside the remote session because remote
+        # runspaces do not inherit local mock context, then checks $LASTEXITCODE and
+        # throws on non-zero, returning the raw CSV text.
+        $auditPolRemoteScriptBlock = {
+            $remoteAuditpolPath = Join-Path -Path $env:SystemRoot -ChildPath 'System32\auditpol.exe'
+            if (-not (Test-Path -Path $remoteAuditpolPath)) {
+                throw "auditpol.exe not found at '$remoteAuditpolPath'"
+            }
+            $auditOutput = & $remoteAuditpolPath '/get' '/category:*' '/r' 2>&1
+            if ($LASTEXITCODE -ne 0) {
+                throw "auditpol /get /category:* /r failed (exit code $LASTEXITCODE): $($auditOutput -join ' ')"
+            }
+            $auditOutput
+        }
+    }
+
+    process {
+        foreach ($targetComputer in $ComputerName) {
+            try {
+                Write-Verbose "[$($MyInvocation.MyCommand)] Querying audit policy on '$targetComputer'"
+
+                $isLocal = ($targetComputer -eq $env:COMPUTERNAME) -or
+                ($targetComputer -eq 'localhost') -or
+                ($targetComputer -eq '.')
+
+                if ($isLocal) {
+                    # Local execution: use Invoke-NativeCommand for testable auditpol calls
+                    $auditResult = Invoke-NativeCommand -FilePath $auditpolPath -ArgumentList @('/get', '/category:*', '/r')
+                    if ($auditResult.ExitCode -ne 0) {
+                        $PSCmdlet.ThrowTerminatingError(
+                            [System.Management.Automation.ErrorRecord]::new(
+                                [System.InvalidOperationException]::new(
+                                    "auditpol /get /category:* /r failed (exit code $($auditResult.ExitCode)): $($auditResult.Output)"
+                                ),
+                                'AuditPolGetFailed',
+                                [System.Management.Automation.ErrorCategory]::InvalidOperation,
+                                $targetComputer
+                            )
+                        )
+                    }
+                    $rawOutput = $auditResult.Output -split '\r?\n'
+                } else {
+                    $invokeParams = @{
+                        ComputerName = $targetComputer
+                        ScriptBlock  = $auditPolRemoteScriptBlock
+                        ErrorAction  = 'Stop'
+                    }
+                    if ($null -ne $Credential) {
+                        $invokeParams['Credential'] = $Credential
+                    }
+                    $rawOutput = Invoke-Command @invokeParams
+                }
+
+                # Normalise to a non-empty string array of lines (header + data rows)
+                $csvLines = @($rawOutput | ForEach-Object { "$_" } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+
+                if ($csvLines.Count -lt 2) {
+                    Write-Error "[$($MyInvocation.MyCommand)] No audit policy data returned by auditpol.exe on '$targetComputer'"
+                    continue
+                }
+
+                $rows = @($csvLines | ConvertFrom-Csv)
+
+                if ($rows.Count -eq 0) {
+                    Write-Error "[$($MyInvocation.MyCommand)] Failed to parse auditpol CSV output on '$targetComputer'"
+                    continue
+                }
+
+                foreach ($row in $rows) {
+                    $subcategoryGuid = ($row.'Subcategory GUID' -replace '[{}]', '').Trim().ToUpperInvariant()
+                    $category = if ($categoryMap.ContainsKey($subcategoryGuid)) { $categoryMap[$subcategoryGuid] } else { 'Unknown' }
+
+                    if ($Category -and ($category -ne $Category)) {
+                        continue
+                    }
+
+                    $inclusionSetting = [string]$row.'Inclusion Setting'
+                    $auditSuccess = $inclusionSetting -match 'Success'
+                    $auditFailure = $inclusionSetting -match 'Failure'
+
+                    $setting = if ($auditSuccess -and $auditFailure) {
+                        'Success and Failure'
+                    } elseif ($auditSuccess) {
+                        'Success'
+                    } elseif ($auditFailure) {
+                        'Failure'
+                    } else {
+                        'No Auditing'
+                    }
+
+                    [PSCustomObject]@{
+                        PSTypeName      = 'PSWinOps.AuditPolicy'
+                        ComputerName    = $targetComputer
+                        Category        = $category
+                        Subcategory     = $row.Subcategory
+                        SubcategoryGuid = $subcategoryGuid
+                        AuditSuccess    = $auditSuccess
+                        AuditFailure    = $auditFailure
+                        Setting         = $setting
+                        Timestamp       = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
+                    }
+                }
+            } catch {
+                Write-Error "[$($MyInvocation.MyCommand)] Failed to query '$targetComputer': $_"
+                continue
+            }
+        }
+    }
+
+    end {
+        Write-Verbose "[$($MyInvocation.MyCommand)] Completed audit policy query"
+    }
+}

--- a/Tests/Public/security/Get-AuditPolicy.Tests.ps1
+++ b/Tests/Public/security/Get-AuditPolicy.Tests.ps1
@@ -1,0 +1,291 @@
+﻿#Requires -Version 5.1
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+
+<#
+.SYNOPSIS
+    Pester tests for Get-AuditPolicy function
+
+.DESCRIPTION
+    Comprehensive test coverage for Get-AuditPolicy, including:
+    - Local happy path parsing of auditpol /r CSV output
+    - Setting derivation (No Auditing / Success / Failure / Success and Failure)
+    - Subcategory GUID -> Category mapping (known and unmapped GUIDs)
+    - -Category filtering
+    - Remote single-machine execution via Invoke-Command
+    - Credential propagation to Invoke-Command
+    - Pipeline fan-out across multiple machines
+    - Per-machine error isolation (exit-code failure, malformed CSV, mock throws)
+    - Parameter validation
+
+.NOTES
+    Author:        Franck SALLET
+    Version:       1.0.0
+    Last Modified: 2026-07-05
+    Requires:      Pester 5.x, PowerShell 5.1+
+    Permissions:   None required (all external commands are mocked)
+#>
+
+BeforeAll {
+    $script:modulePath = Split-Path -Path (Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent) -Parent
+    Import-Module -Name (Join-Path -Path $script:modulePath -ChildPath 'PSWinOps.psd1') -Force
+
+    #region Mock CSV data (mirrors auditpol.exe /get /category:* /r output)
+    $script:mockCsvLines = @(
+        '"Machine Name","Policy Target","Subcategory","Subcategory GUID","Inclusion Setting","Exclusion Setting"'
+        '"HOSTNAME","System","Logon","{0CCE9215-69AE-11D9-BED3-505054503030}","Success and Failure","No Auditing"'
+        '"HOSTNAME","System","Logoff","{0CCE9216-69AE-11D9-BED3-505054503030}","Success","No Auditing"'
+        '"HOSTNAME","System","Special Logon","{0CCE9243-69AE-11D9-BED3-505054503030}","No Auditing","No Auditing"'
+        '"HOSTNAME","System","File System","{0CCE921D-69AE-11D9-BED3-505054503030}","Failure","No Auditing"'
+        '"HOSTNAME","System","Unmapped Subcategory","{0CCE9999-69AE-11D9-BED3-505054503030}","No Auditing","No Auditing"'
+    )
+    #endregion
+}
+
+Describe -Name 'Get-AuditPolicy' -Fixture {
+
+    Context -Name 'Local happy path - mixed audit settings' -Fixture {
+
+        BeforeEach {
+            Mock -CommandName 'Invoke-NativeCommand' -ModuleName 'PSWinOps' -MockWith {
+                [PSCustomObject]@{ Output = ($script:mockCsvLines -join "`r`n"); ExitCode = 0 }
+            }
+        }
+
+        It -Name 'Should return one row per subcategory' -Test {
+            $result = Get-AuditPolicy
+            $result.Count | Should -Be 5
+        }
+
+        It -Name 'Should return a PSWinOps.AuditPolicy typed object' -Test {
+            $result = Get-AuditPolicy
+            $result[0].PSObject.TypeNames[0] | Should -Be 'PSWinOps.AuditPolicy'
+        }
+
+        It -Name 'Should return all required output properties' -Test {
+            $result = Get-AuditPolicy
+            $props = $result[0].PSObject.Properties.Name
+            $props | Should -Contain 'ComputerName'
+            $props | Should -Contain 'Category'
+            $props | Should -Contain 'Subcategory'
+            $props | Should -Contain 'SubcategoryGuid'
+            $props | Should -Contain 'AuditSuccess'
+            $props | Should -Contain 'AuditFailure'
+            $props | Should -Contain 'Setting'
+            $props | Should -Contain 'Timestamp'
+        }
+
+        It -Name 'Should set ComputerName to the local machine' -Test {
+            $result = Get-AuditPolicy
+            $result[0].ComputerName | Should -Be $env:COMPUTERNAME
+        }
+
+        It -Name 'Should format Timestamp as yyyy-MM-dd HH:mm:ss' -Test {
+            $result = Get-AuditPolicy
+            $result[0].Timestamp | Should -Match "^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$"
+        }
+
+        It -Name 'Should derive Setting "Success and Failure" for the Logon row' -Test {
+            $result = Get-AuditPolicy
+            $row = $result | Where-Object { $_.Subcategory -eq 'Logon' }
+            $row.AuditSuccess | Should -Be $true
+            $row.AuditFailure | Should -Be $true
+            $row.Setting | Should -Be 'Success and Failure'
+        }
+
+        It -Name 'Should derive Setting "Success" for the Logoff row' -Test {
+            $result = Get-AuditPolicy
+            $row = $result | Where-Object { $_.Subcategory -eq 'Logoff' }
+            $row.AuditSuccess | Should -Be $true
+            $row.AuditFailure | Should -Be $false
+            $row.Setting | Should -Be 'Success'
+        }
+
+        It -Name 'Should derive Setting "No Auditing" for the Special Logon row' -Test {
+            $result = Get-AuditPolicy
+            $row = $result | Where-Object { $_.Subcategory -eq 'Special Logon' }
+            $row.AuditSuccess | Should -Be $false
+            $row.AuditFailure | Should -Be $false
+            $row.Setting | Should -Be 'No Auditing'
+        }
+
+        It -Name 'Should derive Setting "Failure" for the File System row' -Test {
+            $result = Get-AuditPolicy
+            $row = $result | Where-Object { $_.Subcategory -eq 'File System' }
+            $row.AuditSuccess | Should -Be $false
+            $row.AuditFailure | Should -Be $true
+            $row.Setting | Should -Be 'Failure'
+        }
+
+        It -Name 'Should map known GUIDs to their Category via the static GUID map' -Test {
+            $result = Get-AuditPolicy
+            $result | Where-Object { $_.Subcategory -eq 'Logon' } | Select-Object -ExpandProperty Category | Should -Be 'Logon/Logoff'
+            $result | Where-Object { $_.Subcategory -eq 'File System' } | Select-Object -ExpandProperty Category | Should -Be 'Object Access'
+        }
+
+        It -Name 'Should map an unmapped Subcategory GUID to Category Unknown' -Test {
+            $result = Get-AuditPolicy
+            $row = $result | Where-Object { $_.Subcategory -eq 'Unmapped Subcategory' }
+            $row.Category | Should -Be 'Unknown'
+        }
+
+        It -Name 'Should strip braces and upper-case the SubcategoryGuid' -Test {
+            $result = Get-AuditPolicy
+            $row = $result | Where-Object { $_.Subcategory -eq 'Logon' }
+            $row.SubcategoryGuid | Should -Be '0CCE9215-69AE-11D9-BED3-505054503030'
+        }
+    }
+
+    Context -Name '-Category filter' -Fixture {
+
+        BeforeEach {
+            Mock -CommandName 'Invoke-NativeCommand' -ModuleName 'PSWinOps' -MockWith {
+                [PSCustomObject]@{ Output = ($script:mockCsvLines -join "`r`n"); ExitCode = 0 }
+            }
+        }
+
+        It -Name 'Should return only subcategories belonging to the requested Category' -Test {
+            $result = @(Get-AuditPolicy -Category 'Logon/Logoff')
+            $result.Count | Should -Be 3
+            $result.Category | Should -Not -Contain 'Object Access'
+        }
+
+        It -Name 'Should return nothing without error when Category has no match' -Test {
+            $result = @(Get-AuditPolicy -Category 'NoSuchCategory' -ErrorAction Stop)
+            $result.Count | Should -Be 0
+        }
+    }
+
+    Context -Name 'Explicit remote machine' -Fixture {
+
+        BeforeEach {
+            Mock -CommandName 'Invoke-Command' -ModuleName 'PSWinOps' -MockWith {
+                $script:mockCsvLines
+            }
+        }
+
+        It -Name 'Should dispatch via Invoke-Command for a remote machine' -Test {
+            $result = Get-AuditPolicy -ComputerName 'SRV01'
+            Should -Invoke -CommandName 'Invoke-Command' -ModuleName 'PSWinOps' -Times 1 -Exactly
+            $result[0].ComputerName | Should -Be 'SRV01'
+        }
+
+        It -Name 'Should propagate Credential to Invoke-Command' -Test {
+            $securePwd = ConvertTo-SecureString -String 'P@ssw0rd123!' -AsPlainText -Force
+            $cred = [System.Management.Automation.PSCredential]::new('DOMAIN\svc', $securePwd)
+            Get-AuditPolicy -ComputerName 'SRV01' -Credential $cred
+            Should -Invoke -CommandName 'Invoke-Command' -ModuleName 'PSWinOps' -Times 1 -Exactly -ParameterFilter {
+                $Credential -eq $cred
+            }
+        }
+    }
+
+    Context -Name 'Pipeline of multiple machine names' -Fixture {
+
+        BeforeEach {
+            Mock -CommandName 'Invoke-Command' -ModuleName 'PSWinOps' -MockWith {
+                $script:mockCsvLines
+            }
+        }
+
+        It -Name 'Should call Invoke-Command once per machine and return rows for each' -Test {
+            $result = 'SRV01', 'SRV02' | Get-AuditPolicy
+            Should -Invoke -CommandName 'Invoke-Command' -ModuleName 'PSWinOps' -Times 2 -Exactly
+            ($result | Select-Object -ExpandProperty ComputerName -Unique) | Should -Contain 'SRV01'
+            ($result | Select-Object -ExpandProperty ComputerName -Unique) | Should -Contain 'SRV02'
+        }
+    }
+
+    Context -Name 'Per-machine failure - continues processing remaining machines' -Fixture {
+
+        BeforeEach {
+            Mock -CommandName 'Invoke-Command' -ModuleName 'PSWinOps' -MockWith {
+                if ($ComputerName -eq 'SRV01') {
+                    throw 'Simulated WinRM failure on SRV01'
+                }
+                $script:mockCsvLines
+            }
+            $script:perMachineOutput = 'SRV01', 'SRV02' |
+                Get-AuditPolicy -ErrorAction Continue 2>&1
+            $script:perMachineErrors = @($script:perMachineOutput | Where-Object {
+                $_ -is [System.Management.Automation.ErrorRecord]
+            })
+            $script:perMachineSuccesses = @($script:perMachineOutput | Where-Object {
+                $_ -isnot [System.Management.Automation.ErrorRecord]
+            })
+        }
+
+        It -Name 'Should write an error for the failing machine' -Test {
+            $script:perMachineErrors.Count | Should -BeGreaterThan 0
+        }
+
+        It -Name 'Should still return results for the succeeding machine' -Test {
+            $script:perMachineSuccesses.Count | Should -Be 5
+            ($script:perMachineSuccesses | Select-Object -ExpandProperty ComputerName -Unique) | Should -Be 'SRV02'
+        }
+    }
+
+    Context -Name 'Local exit-code failure from auditpol.exe' -Fixture {
+
+        BeforeEach {
+            Mock -CommandName 'Invoke-NativeCommand' -ModuleName 'PSWinOps' -MockWith {
+                [PSCustomObject]@{ Output = 'ERROR: Access is denied.'; ExitCode = 1 }
+            }
+        }
+
+        It -Name 'Should write an error and not throw a terminating exception' -Test {
+            { Get-AuditPolicy -ErrorAction Continue } | Should -Not -Throw
+        }
+
+        It -Name 'Should write an error record when auditpol exits non-zero' -Test {
+            $output = Get-AuditPolicy -ErrorAction SilentlyContinue -ErrorVariable auditErrors
+            $output | Should -BeNullOrEmpty
+            $auditErrors.Count | Should -BeGreaterThan 0
+        }
+    }
+
+    Context -Name 'Empty or malformed CSV output' -Fixture {
+
+        BeforeEach {
+            Mock -CommandName 'Invoke-NativeCommand' -ModuleName 'PSWinOps' -MockWith {
+                [PSCustomObject]@{ Output = ''; ExitCode = 0 }
+            }
+        }
+
+        It -Name 'Should write an error and return nothing for that machine' -Test {
+            $output = Get-AuditPolicy -ErrorAction SilentlyContinue -ErrorVariable auditErrors
+            $output | Should -BeNullOrEmpty
+            $auditErrors.Count | Should -BeGreaterThan 0
+        }
+    }
+
+    Context -Name 'Parameter validation' -Fixture {
+
+        It -Name 'Should throw when ComputerName is an empty string' -Test {
+            { Get-AuditPolicy -ComputerName '' } | Should -Throw
+        }
+
+        It -Name 'Should throw when ComputerName is null' -Test {
+            { Get-AuditPolicy -ComputerName $null } | Should -Throw
+        }
+
+        It -Name 'Should expose ComputerName with pipeline support by value and by property name' -Test {
+            $cmd = Get-Command -Name 'Get-AuditPolicy'
+            $attr = $cmd.Parameters['ComputerName'].Attributes.Where({ $_ -is [System.Management.Automation.ParameterAttribute] })[0]
+            $attr.ValueFromPipeline | Should -Be $true
+            $attr.ValueFromPipelineByPropertyName | Should -Be $true
+        }
+
+        It -Name 'Should expose ComputerName aliases CN, Name and DNSHostName' -Test {
+            $cmd = Get-Command -Name 'Get-AuditPolicy'
+            $aliases = $cmd.Parameters['ComputerName'].Aliases
+            $aliases | Should -Contain 'CN'
+            $aliases | Should -Contain 'Name'
+            $aliases | Should -Contain 'DNSHostName'
+        }
+
+        It -Name 'Should not support ShouldProcess (read-only function)' -Test {
+            $cmd = Get-Command -Name 'Get-AuditPolicy'
+            $cmd.Parameters.ContainsKey('WhatIf') | Should -Be $false
+        }
+    }
+}

--- a/en-US/about_PSWinOps.help.txt
+++ b/en-US/about_PSWinOps.help.txt
@@ -12,7 +12,7 @@ LONG DESCRIPTION
     PSWinOps is a comprehensive toolbox designed for Windows
     system administrators running PowerShell 5.1 or later.
     It provides a curated collection of functions organized
-    into twelve functional domains, covering everything from
+    into thirteen functional domains, covering everything from
     Active Directory inventory and security auditing,
     service health monitoring, network troubleshooting,
     NTP synchronization, proxy management, RDP session
@@ -31,7 +31,7 @@ LONG DESCRIPTION
     Requires    : PowerShell 5.1+ / Windows only
 
 FUNCTION DOMAINS
-    PSWinOps organizes its functions into twelve domains.
+    PSWinOps organizes its functions into thirteen domains.
 
   activedirectory (21 functions)
     Functions for Active Directory inventory, user and
@@ -167,6 +167,13 @@ FUNCTION DOMAINS
       Get-RdpSessionHistory
       Get-RdpSessionLock
       Remove-RdpSession
+
+  security (1 function)
+    Functions for auditing Windows security configuration,
+    starting with advanced audit policy subcategory
+    reporting via auditpol.exe.
+
+      Get-AuditPolicy
 
   system (16 functions)
     Functions for general system information, state,
@@ -305,7 +312,7 @@ REMOTE EXECUTION PATTERN
     in the pipeline continue to be processed.
 
 PSWINOPS TYPE REGISTRY
-    The following 98 PSTypeName values are defined by the
+    The following 99 PSTypeName values are defined by the
     module. Each corresponds to the output of one or more
     public functions.
 
@@ -335,6 +342,7 @@ PSWINOPS TYPE REGISTRY
       PSWinOps.ADUserGroupInventory
       PSWinOps.ADUserInventory
       PSWinOps.ArpEntry
+      PSWinOps.AuditPolicy
       PSWinOps.CertificateAuthorityHealth
       PSWinOps.ClusterHealth
       PSWinOps.ComputerUptime
@@ -420,4 +428,4 @@ SEE ALSO
 
 KEYWORDS
     PSWinOps, Windows, Administration, ActiveDirectory, DiskCleanup,
-    HealthCheck, Network, NTP, RDP, System, VSS, WindowsUpdate
+    HealthCheck, Network, NTP, RDP, Security, System, VSS, WindowsUpdate


### PR DESCRIPTION
## Summary
Parses the advanced audit policy returned by `auditpol.exe /get /category:* /r` (CSV) into one object per subcategory, reporting Success and Failure auditing state. It is a base building block for CIS/ANSSI compliance auditing and supports local and remote targets via Invoke-RemoteOrLocal, with optional filtering to a single category.

Introduces a new `security` domain. Closes #73.

## Files touched
- `Public/security/Get-AuditPolicy.ps1` — implementation
- `Tests/Public/security/Get-AuditPolicy.Tests.ps1` — Pester v5 suite
- `PSWinOps.psd1` — FunctionsToExport, ModuleVersion (0.2.1 -> 0.3.0), ReleaseNotes
- `PSWinOps.Format.ps1xml` — new `<View>` (Table) for `PSWinOps.AuditPolicy`
- `en-US/about_PSWinOps.help.txt` — new `security` domain section, counters, type registry
- `.github/workflows/ci.yml` — matrix updated with `Public/security`

## Conformance checklist (audited locally by fn-quality-gate)
- [x] UTF-8 BOM + CRLF on both new files
- [x] Approved PowerShell verb (`Get`)
- [x] `FunctionsToExport` alphabetically sorted, `Get-AuditPolicy` present once
- [x] `PSTypeName` consistent across .ps1 / Format.ps1xml / about help (`PSWinOps.AuditPolicy`)
- [x] No `Write-Host`, no `ToString('o')`, no WMI cmdlets in the diff
- [x] `PSWinOps.Format.ps1xml` is valid XML with a matching `<View>`

## Verification
Dynamic verification (Test-ModuleManifest, PSScriptAnalyzer, Pester matrix) runs on the Windows CI for this PR. Merge once all required checks are green.