### PR TITLE
feat(network): add Reset-NetworkStack

### DIFF
--- a/.kdust/chains/reset-networkstack-2607061237.yaml
+++ b/.kdust/chains/reset-networkstack-2607061237.yaml
@@ -1,0 +1,7 @@
+chain: pswinops-function-author
+function: Reset-NetworkStack
+domain: network
+created: 2026-07-06T12:39:37Z
+created_by: pswinops-fn-spec-analyst
+chain_branch: kdust/chain/pswinops-fn-reset-networkstack-2607061237
+spec_path: work/reset-networkstack/spec.yaml

--- a/PSWinOps.Format.ps1xml
+++ b/PSWinOps.Format.ps1xml
@@ -7648,5 +7648,43 @@
         </TableRowEntries>
       </TableControl>
     </View>
+    <!-- ============================================================ -->
+    <!-- PSWinOps.NetworkStackResetResult                             -->
+    <!-- Used by: Reset-NetworkStack                                  -->
+    <!-- ============================================================ -->
+    <View>
+      <Name>PSWinOps.NetworkStackResetResult</Name>
+      <ViewSelectedBy>
+        <TypeName>PSWinOps.NetworkStackResetResult</TypeName>
+      </ViewSelectedBy>
+      <ListControl>
+        <ListEntries>
+          <ListEntry>
+            <ListItems>
+              <ListItem>
+                <Label>Computer name</Label>
+                <PropertyName>ComputerName</PropertyName>
+              </ListItem>
+              <ListItem>
+                <Label>Steps run</Label>
+                <ScriptBlock>(($_.StepsRun | ForEach-Object { "$($_.Step)=$($_.ExitCode)" }) -join ', ')</ScriptBlock>
+              </ListItem>
+              <ListItem>
+                <Label>Success</Label>
+                <PropertyName>Success</PropertyName>
+              </ListItem>
+              <ListItem>
+                <Label>Reboot required</Label>
+                <PropertyName>RebootRequired</PropertyName>
+              </ListItem>
+              <ListItem>
+                <Label>Timestamp</Label>
+                <PropertyName>Timestamp</PropertyName>
+              </ListItem>
+            </ListItems>
+          </ListEntry>
+        </ListEntries>
+      </ListControl>
+    </View>
   </ViewDefinitions>
 </Configuration>

--- a/PSWinOps.psd1
+++ b/PSWinOps.psd1
@@ -179,6 +179,7 @@
         'Remove-StringDiacritic',
         'Remove-UserProfile',
         'Reset-ADUserPassword',
+        'Reset-NetworkStack',
         'Reset-WindowsUpdateComponent',
         'Resolve-MACVendor',
         'Restore-ShadowCopyFile',

--- a/PSWinOps.psd1
+++ b/PSWinOps.psd1
@@ -12,7 +12,7 @@
     RootModule           = 'PSWinOps.psm1'
 
     # Version number of this module.
-    ModuleVersion        = '0.3.0'
+    ModuleVersion        = '0.4.0'
 
     # Supported PSEditions
     # Core is supported on Windows only; the module-level guard in PSWinOps.psm1 blocks
@@ -271,7 +271,11 @@
             # IconUri = ''
 
             # ReleaseNotes of this module
-            ReleaseNotes = '## 0.3.0 - 2026-07-05 UTC
+            ReleaseNotes = '## 0.4.0 - 2026-07-06 UTC
+### Added
+- Reset-NetworkStack: Reset the Windows network stack (winsock, TCP/IP, DNS cache, ARP)
+
+## 0.3.0 - 2026-07-05 UTC
 ### Added
 - Get-AuditPolicy: Report advanced audit policy subcategory settings from auditpol.exe
 

--- a/Public/network/Reset-NetworkStack.ps1
+++ b/Public/network/Reset-NetworkStack.ps1
@@ -1,0 +1,193 @@
+﻿#Requires -Version 5.1
+
+function Reset-NetworkStack {
+    <#
+    .SYNOPSIS
+        Reset the Windows network stack (winsock, TCP/IP, DNS cache, ARP)
+
+    .DESCRIPTION
+        Encapsulates the classic netsh network-repair sequence (netsh winsock reset and
+        netsh int ip reset) plus a DNS client cache flush and ARP cache clear into one
+        idempotent, ShouldProcess-guarded action. Returns a structured result listing
+        each step that ran with its exit code, overall success, and RebootRequired
+        (always true). Requires administrator privileges and ALWAYS needs a reboot to
+        finalize. WARNING: on a remote target `netsh int ip reset` can drop the WinRM
+        session mid-run, so verify results out-of-band after running remotely.
+
+    .PARAMETER ComputerName
+        One or more computer names to target. Defaults to the local computer.
+        Accepts pipeline input by value and by property name.
+
+    .PARAMETER Credential
+        Optional PSCredential for authenticating to remote computers. Ignored for
+        local machine operations.
+
+    .PARAMETER IncludeFirewall
+        Opt-in switch. Adds a `netsh advfirewall reset` step, which is more intrusive
+        (resets all Windows Firewall profiles and rules to their default state).
+
+    .PARAMETER SkipDnsFlush
+        Opt-in switch. Skips the DNS client cache flush step (Clear-DnsClientCache).
+
+    .EXAMPLE
+        Reset-NetworkStack
+        Local usage example.
+
+    .EXAMPLE
+        Reset-NetworkStack -ComputerName SRV01 -IncludeFirewall
+        Remote single-machine example.
+
+    .EXAMPLE
+        'SRV01', 'SRV02' | Reset-NetworkStack -SkipDnsFlush
+        Pipeline usage example.
+
+    .OUTPUTS
+        PSWinOps.NetworkStackResetResult
+        One object per target machine describing the steps that ran, their exit
+        codes, overall Success, and RebootRequired (always $true).
+
+    .NOTES
+        Author: Franck SALLET
+        Version: 1.0.0
+        Last Modified: 2026-07-06
+        Requires: PowerShell 5.1+ / Windows only
+        Requires: Administrator privileges (winsock/int ip/advfirewall reset)
+        WARNING: netsh int ip reset can drop the WinRM session on a remote target
+        mid-run; verify results out-of-band after running remotely.
+
+    .LINK
+        https://github.com/k9fr4n/PSWinOps
+
+    .LINK
+        https://learn.microsoft.com/en-us/windows-server/networking/technologies/netsh/netsh-interface-ip
+    #>
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
+    [OutputType('PSWinOps.NetworkStackResetResult')]
+    param(
+        [Parameter(Mandatory = $false, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]$ComputerName = $env:COMPUTERNAME,
+
+        [Parameter(Mandatory = $false)]
+        [System.Management.Automation.PSCredential]$Credential,
+
+        [Parameter(Mandatory = $false)]
+        [switch]$IncludeFirewall,
+
+        [Parameter(Mandatory = $false)]
+        [switch]$SkipDnsFlush
+    )
+
+    begin {
+        Write-Verbose "[$($MyInvocation.MyCommand)] Starting network stack reset"
+
+        if (-not (Test-IsAdministrator)) {
+            $PSCmdlet.ThrowTerminatingError(
+                [System.Management.Automation.ErrorRecord]::new(
+                    [System.UnauthorizedAccessException]::new('Reset-NetworkStack requires Administrator privileges.'),
+                    'ElevationRequired',
+                    [System.Management.Automation.ErrorCategory]::PermissionDenied,
+                    $null
+                )
+            )
+        }
+
+        $netshPath = Join-Path -Path $env:SystemRoot -ChildPath 'System32\netsh.exe'
+        if (-not (Test-Path -Path $netshPath -PathType Leaf)) {
+            $PSCmdlet.ThrowTerminatingError(
+                [System.Management.Automation.ErrorRecord]::new(
+                    [System.IO.FileNotFoundException]::new("netsh.exe not found at '$netshPath'."),
+                    'NetshNotFound',
+                    [System.Management.Automation.ErrorCategory]::ObjectNotFound,
+                    $netshPath
+                )
+            )
+        }
+
+        $resetScriptBlock = {
+            param(
+                [string]$NetshPath,
+                [bool]$SkipDns,
+                [bool]$IncludeFw
+            )
+
+            $stepsRun = [System.Collections.Generic.List[psobject]]::new()
+
+            # WinsockReset — always run
+            $winsockResult = Invoke-NativeCommand -FilePath $NetshPath -ArgumentList @('winsock', 'reset')
+            $stepsRun.Add([PSCustomObject]@{ Step = 'WinsockReset'; ExitCode = $winsockResult.ExitCode })
+
+            # IpReset — always run (may drop WinRM on a remote target)
+            $ipResult = Invoke-NativeCommand -FilePath $NetshPath -ArgumentList @('int', 'ip', 'reset')
+            $stepsRun.Add([PSCustomObject]@{ Step = 'IpReset'; ExitCode = $ipResult.ExitCode })
+
+            # DnsFlush — skipped when SkipDns is set
+            if (-not $SkipDns) {
+                try {
+                    Clear-DnsClientCache -ErrorAction Stop
+                    $stepsRun.Add([PSCustomObject]@{ Step = 'DnsFlush'; ExitCode = 0 })
+                } catch {
+                    $stepsRun.Add([PSCustomObject]@{ Step = 'DnsFlush'; ExitCode = 1 })
+                }
+            }
+
+            # ArpClear — always run
+            try {
+                Clear-Arp -Confirm:$false -ErrorAction Stop
+                $stepsRun.Add([PSCustomObject]@{ Step = 'ArpClear'; ExitCode = 0 })
+            } catch {
+                $stepsRun.Add([PSCustomObject]@{ Step = 'ArpClear'; ExitCode = 1 })
+            }
+
+            # FirewallReset — opt-in only
+            if ($IncludeFw) {
+                $fwResult = Invoke-NativeCommand -FilePath $NetshPath -ArgumentList @('advfirewall', 'reset')
+                $stepsRun.Add([PSCustomObject]@{ Step = 'FirewallReset'; ExitCode = $fwResult.ExitCode })
+            }
+
+            $overallSuccess = -not ($stepsRun | Where-Object { $_.ExitCode -ne 0 })
+
+            [PSCustomObject]@{
+                StepsRun = $stepsRun.ToArray()
+                Success  = [bool]$overallSuccess
+            }
+        }
+    }
+
+    process {
+        foreach ($targetComputer in $ComputerName) {
+            try {
+                $shouldProcessTarget = "network stack on $targetComputer"
+                $shouldProcessAction = 'Reset (winsock + int ip + dns + arp' + $(if ($IncludeFirewall) { ' + firewall' } else { '' }) + ')'
+
+                if (-not $PSCmdlet.ShouldProcess($shouldProcessTarget, $shouldProcessAction)) {
+                    continue
+                }
+
+                $invokeParams = @{
+                    ComputerName = $targetComputer
+                    ScriptBlock  = $resetScriptBlock
+                    ArgumentList = @($netshPath, [bool]$SkipDnsFlush, [bool]$IncludeFirewall)
+                    Credential   = $Credential
+                }
+
+                $rawResult = Invoke-RemoteOrLocal @invokeParams
+
+                [PSCustomObject]@{
+                    PSTypeName     = 'PSWinOps.NetworkStackResetResult'
+                    ComputerName   = $targetComputer
+                    StepsRun       = $rawResult.StepsRun
+                    Success        = $rawResult.Success
+                    RebootRequired = $true
+                    Timestamp      = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
+                }
+            } catch {
+                Write-Error "[$($MyInvocation.MyCommand)] Failed on '$targetComputer': $_"
+            }
+        }
+    }
+
+    end {
+        Write-Verbose "[$($MyInvocation.MyCommand)] Completed network stack reset"
+    }
+}

--- a/Tests/Public/network/Reset-NetworkStack.Tests.ps1
+++ b/Tests/Public/network/Reset-NetworkStack.Tests.ps1
@@ -1,0 +1,352 @@
+﻿#Requires -Version 5.1
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+BeforeAll {
+    $script:modulePath = Split-Path -Path (Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent) -Parent
+    Import-Module -Name (Join-Path -Path $script:modulePath -ChildPath 'PSWinOps.psd1') -Force
+    $script:ModuleName = 'PSWinOps'
+
+    function global:Clear-DnsClientCache {
+        param()
+    }
+}
+
+Describe 'Reset-NetworkStack' {
+
+    Context 'Parameter validation' {
+        It 'Should have CmdletBinding with SupportsShouldProcess' {
+            $cmd = Get-Command -Name 'Reset-NetworkStack'
+            $meta = [System.Management.Automation.CommandMetadata]::new($cmd)
+            $meta.SupportsShouldProcess | Should -BeTrue
+        }
+
+        It 'Should have ConfirmImpact set to High' {
+            $cmd = Get-Command -Name 'Reset-NetworkStack'
+            $meta = [System.Management.Automation.CommandMetadata]::new($cmd)
+            $meta.ConfirmImpact | Should -Be 'High'
+        }
+
+        It 'Should have OutputType of PSWinOps.NetworkStackResetResult' {
+            $cmd = Get-Command -Name 'Reset-NetworkStack'
+            $cmd.OutputType.Name | Should -Contain 'PSWinOps.NetworkStackResetResult'
+        }
+
+        It 'Should have no mandatory parameters' {
+            $cmd = Get-Command -Name 'Reset-NetworkStack'
+            $mandatoryParams = $cmd.Parameters.Values | Where-Object {
+                $_.Attributes | Where-Object {
+                    $_ -is [System.Management.Automation.ParameterAttribute] -and $_.Mandatory
+                }
+            }
+            $mandatoryParams | Should -BeNullOrEmpty
+        }
+
+        It 'Should reject empty ComputerName' {
+            { Reset-NetworkStack -ComputerName '' -Confirm:$false } | Should -Throw
+        }
+
+        It 'Should reject null ComputerName' {
+            { Reset-NetworkStack -ComputerName $null -Confirm:$false } | Should -Throw
+        }
+
+        It 'Should have IncludeFirewall as a switch parameter' {
+            $cmd = Get-Command -Name 'Reset-NetworkStack'
+            $cmd.Parameters['IncludeFirewall'].ParameterType.Name | Should -Be 'SwitchParameter'
+        }
+
+        It 'Should have SkipDnsFlush as a switch parameter' {
+            $cmd = Get-Command -Name 'Reset-NetworkStack'
+            $cmd.Parameters['SkipDnsFlush'].ParameterType.Name | Should -Be 'SwitchParameter'
+        }
+
+        It 'Should have a Credential parameter of type PSCredential' {
+            $cmd = Get-Command -Name 'Reset-NetworkStack'
+            $cmd.Parameters['Credential'].ParameterType.Name | Should -Be 'PSCredential'
+        }
+    }
+
+    Context 'Elevation check' {
+        BeforeEach {
+            Mock -ModuleName $script:ModuleName -CommandName 'Test-IsAdministrator' -MockWith { return $false }
+        }
+
+        It 'Should throw terminating error when not elevated' {
+            { Reset-NetworkStack -Confirm:$false } | Should -Throw '*Administrator privileges*'
+        }
+
+        It 'Should throw UnauthorizedAccessException when not elevated' {
+            $threw = $false
+            try {
+                Reset-NetworkStack -Confirm:$false
+            } catch {
+                $threw = $true
+                $_.Exception | Should -BeOfType [System.UnauthorizedAccessException]
+            }
+            $threw | Should -BeTrue
+        }
+    }
+
+    Context 'Binary validation' {
+        BeforeEach {
+            Mock -ModuleName $script:ModuleName -CommandName 'Test-IsAdministrator' -MockWith { return $true }
+            Mock -ModuleName $script:ModuleName -CommandName 'Test-Path' -ParameterFilter {
+                $Path -like '*netsh*'
+            } -MockWith { $false }
+        }
+
+        It 'Should throw terminating error when netsh.exe is not found' {
+            { Reset-NetworkStack -Confirm:$false } | Should -Throw '*netsh.exe not found*'
+        }
+
+        It 'Should throw FileNotFoundException when netsh.exe is missing' {
+            $threw = $false
+            try {
+                Reset-NetworkStack -Confirm:$false
+            } catch {
+                $threw = $true
+                $_.Exception | Should -BeOfType [System.IO.FileNotFoundException]
+            }
+            $threw | Should -BeTrue
+        }
+    }
+
+    Context 'Happy path - local machine' {
+        BeforeEach {
+            Mock -ModuleName $script:ModuleName -CommandName 'Test-IsAdministrator' -MockWith { return $true }
+            Mock -ModuleName $script:ModuleName -CommandName 'Test-Path' -ParameterFilter {
+                $Path -like '*netsh*'
+            } -MockWith { $true }
+            Mock -ModuleName $script:ModuleName -CommandName 'Invoke-NativeCommand' -MockWith {
+                [PSCustomObject]@{ Output = ''; ExitCode = 0 }
+            }
+            Mock -ModuleName $script:ModuleName -CommandName 'Clear-DnsClientCache' -MockWith { }
+            Mock -ModuleName $script:ModuleName -CommandName 'Clear-Arp' -MockWith { }
+            Mock -ModuleName $script:ModuleName -CommandName 'Invoke-RemoteOrLocal' -MockWith {
+                param($ComputerName, $ScriptBlock, $ArgumentList, $Credential)
+                & $ScriptBlock @ArgumentList
+            }
+        }
+
+        It 'Should return Success = $true and RebootRequired = $true for the local machine' {
+            $result = Reset-NetworkStack -Confirm:$false
+
+            $result.ComputerName | Should -Be $env:COMPUTERNAME
+            $result.Success | Should -BeTrue
+            $result.RebootRequired | Should -BeTrue
+            $result.PSTypeNames | Should -Contain 'PSWinOps.NetworkStackResetResult'
+        }
+
+        It 'Should include a valid Timestamp' {
+            $result = Reset-NetworkStack -Confirm:$false
+            $result.Timestamp | Should -Match "^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$"
+        }
+
+        It 'Should run all always-steps by default (Winsock, IpReset, DnsFlush, ArpClear) without FirewallReset' {
+            $result = Reset-NetworkStack -Confirm:$false
+            $stepNames = $result.StepsRun | ForEach-Object { $_.Step }
+
+            $stepNames | Should -Contain 'WinsockReset'
+            $stepNames | Should -Contain 'IpReset'
+            $stepNames | Should -Contain 'DnsFlush'
+            $stepNames | Should -Contain 'ArpClear'
+            $stepNames | Should -Not -Contain 'FirewallReset'
+        }
+
+        It 'Should respect -WhatIf and not dispatch via Invoke-RemoteOrLocal' {
+            $null = Reset-NetworkStack -WhatIf
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 0 -Exactly
+        }
+    }
+
+    Context 'Step failure aggregation' {
+        BeforeEach {
+            Mock -ModuleName $script:ModuleName -CommandName 'Test-IsAdministrator' -MockWith { return $true }
+            Mock -ModuleName $script:ModuleName -CommandName 'Test-Path' -ParameterFilter {
+                $Path -like '*netsh*'
+            } -MockWith { $true }
+            Mock -ModuleName $script:ModuleName -CommandName 'Clear-DnsClientCache' -MockWith { }
+            Mock -ModuleName $script:ModuleName -CommandName 'Clear-Arp' -MockWith { }
+            Mock -ModuleName $script:ModuleName -CommandName 'Invoke-RemoteOrLocal' -MockWith {
+                param($ComputerName, $ScriptBlock, $ArgumentList, $Credential)
+                & $ScriptBlock @ArgumentList
+            }
+        }
+
+        It 'Should keep running remaining steps and report Success = $false when a step exits non-zero' {
+            Mock -ModuleName $script:ModuleName -CommandName 'Invoke-NativeCommand' -MockWith {
+                param($FilePath, $ArgumentList)
+                if ($ArgumentList[0] -eq 'int') {
+                    return [PSCustomObject]@{ Output = 'failed'; ExitCode = 1 }
+                }
+                return [PSCustomObject]@{ Output = ''; ExitCode = 0 }
+            }
+
+            $result = Reset-NetworkStack -Confirm:$false
+
+            $result.Success | Should -BeFalse
+            $stepNames = $result.StepsRun | ForEach-Object { $_.Step }
+            $stepNames | Should -Contain 'WinsockReset'
+            $stepNames | Should -Contain 'IpReset'
+            $stepNames | Should -Contain 'DnsFlush'
+            $stepNames | Should -Contain 'ArpClear'
+
+            $ipStep = $result.StepsRun | Where-Object { $_.Step -eq 'IpReset' }
+            $ipStep.ExitCode | Should -Be 1
+        }
+
+        It 'Should still report RebootRequired = $true even when a step fails' {
+            Mock -ModuleName $script:ModuleName -CommandName 'Invoke-NativeCommand' -MockWith {
+                [PSCustomObject]@{ Output = 'failed'; ExitCode = 1 }
+            }
+
+            $result = Reset-NetworkStack -Confirm:$false
+            $result.RebootRequired | Should -BeTrue
+        }
+    }
+
+    Context '-SkipDnsFlush' {
+        BeforeEach {
+            Mock -ModuleName $script:ModuleName -CommandName 'Test-IsAdministrator' -MockWith { return $true }
+            Mock -ModuleName $script:ModuleName -CommandName 'Test-Path' -ParameterFilter {
+                $Path -like '*netsh*'
+            } -MockWith { $true }
+            Mock -ModuleName $script:ModuleName -CommandName 'Invoke-NativeCommand' -MockWith {
+                [PSCustomObject]@{ Output = ''; ExitCode = 0 }
+            }
+            Mock -ModuleName $script:ModuleName -CommandName 'Clear-DnsClientCache' -MockWith { }
+            Mock -ModuleName $script:ModuleName -CommandName 'Clear-Arp' -MockWith { }
+            Mock -ModuleName $script:ModuleName -CommandName 'Invoke-RemoteOrLocal' -MockWith {
+                param($ComputerName, $ScriptBlock, $ArgumentList, $Credential)
+                & $ScriptBlock @ArgumentList
+            }
+        }
+
+        It 'Should omit the DnsFlush step from StepsRun' {
+            $result = Reset-NetworkStack -SkipDnsFlush -Confirm:$false
+            $stepNames = $result.StepsRun | ForEach-Object { $_.Step }
+            $stepNames | Should -Not -Contain 'DnsFlush'
+        }
+    }
+
+    Context '-IncludeFirewall' {
+        BeforeEach {
+            Mock -ModuleName $script:ModuleName -CommandName 'Test-IsAdministrator' -MockWith { return $true }
+            Mock -ModuleName $script:ModuleName -CommandName 'Test-Path' -ParameterFilter {
+                $Path -like '*netsh*'
+            } -MockWith { $true }
+            Mock -ModuleName $script:ModuleName -CommandName 'Invoke-NativeCommand' -MockWith {
+                [PSCustomObject]@{ Output = ''; ExitCode = 0 }
+            }
+            Mock -ModuleName $script:ModuleName -CommandName 'Clear-DnsClientCache' -MockWith { }
+            Mock -ModuleName $script:ModuleName -CommandName 'Clear-Arp' -MockWith { }
+            Mock -ModuleName $script:ModuleName -CommandName 'Invoke-RemoteOrLocal' -MockWith {
+                param($ComputerName, $ScriptBlock, $ArgumentList, $Credential)
+                & $ScriptBlock @ArgumentList
+            }
+        }
+
+        It 'Should include the FirewallReset step in StepsRun' {
+            $result = Reset-NetworkStack -IncludeFirewall -Confirm:$false
+            $stepNames = $result.StepsRun | ForEach-Object { $_.Step }
+            $stepNames | Should -Contain 'FirewallReset'
+        }
+    }
+
+    Context 'Explicit remote machine with Credential propagation' {
+        BeforeEach {
+            Mock -ModuleName $script:ModuleName -CommandName 'Test-IsAdministrator' -MockWith { return $true }
+            Mock -ModuleName $script:ModuleName -CommandName 'Test-Path' -ParameterFilter {
+                $Path -like '*netsh*'
+            } -MockWith { $true }
+        }
+
+        It 'Should dispatch via Invoke-RemoteOrLocal with the target ComputerName and Credential' {
+            Mock -ModuleName $script:ModuleName -CommandName 'Invoke-RemoteOrLocal' -MockWith {
+                param($ComputerName, $ScriptBlock, $ArgumentList, $Credential)
+                [PSCustomObject]@{ StepsRun = @(); Success = $true }
+            }
+
+            $securePwd = ConvertTo-SecureString -String 'P@ssw0rd!' -AsPlainText -Force
+            $cred = [System.Management.Automation.PSCredential]::new('DOMAIN\svc', $securePwd)
+
+            $null = Reset-NetworkStack -ComputerName 'REMOTESRV01' -Credential $cred -Confirm:$false
+
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly -ParameterFilter {
+                $ComputerName -eq 'REMOTESRV01' -and $null -ne $Credential -and $Credential.UserName -eq 'DOMAIN\svc'
+            }
+        }
+    }
+
+    Context 'Pipeline - multiple machine names' {
+        BeforeEach {
+            Mock -ModuleName $script:ModuleName -CommandName 'Test-IsAdministrator' -MockWith { return $true }
+            Mock -ModuleName $script:ModuleName -CommandName 'Test-Path' -ParameterFilter {
+                $Path -like '*netsh*'
+            } -MockWith { $true }
+            Mock -ModuleName $script:ModuleName -CommandName 'Invoke-RemoteOrLocal' -MockWith {
+                param($ComputerName, $ScriptBlock, $ArgumentList, $Credential)
+                [PSCustomObject]@{ StepsRun = @([PSCustomObject]@{ Step = 'WinsockReset'; ExitCode = 0 }); Success = $true }
+            }
+        }
+
+        It 'Should produce one result object per machine and call Invoke-RemoteOrLocal for each' {
+            $results = 'REMOTE01', 'REMOTE02' | Reset-NetworkStack -Confirm:$false
+
+            $results.Count | Should -Be 2
+            ($results | Select-Object -ExpandProperty ComputerName) | Should -Be @('REMOTE01', 'REMOTE02')
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 2 -Exactly
+        }
+    }
+
+    Context 'Per-machine error isolation' {
+        BeforeEach {
+            Mock -ModuleName $script:ModuleName -CommandName 'Test-IsAdministrator' -MockWith { return $true }
+            Mock -ModuleName $script:ModuleName -CommandName 'Test-Path' -ParameterFilter {
+                $Path -like '*netsh*'
+            } -MockWith { $true }
+        }
+
+        It 'Should write an error for the failed machine but not throw' {
+            Mock -ModuleName $script:ModuleName -CommandName 'Invoke-RemoteOrLocal' -MockWith {
+                throw 'WinRM connection refused'
+            }
+
+            Reset-NetworkStack -ComputerName 'BADSRV01' -Confirm:$false -ErrorVariable err -ErrorAction SilentlyContinue
+
+            $err | Should -Not -BeNullOrEmpty
+            $errMessages = $err | ForEach-Object { $_.Exception.Message }
+            ($errMessages -like "*Failed on 'BADSRV01'*") | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Should continue processing remaining machines after a failure' {
+            Mock -ModuleName $script:ModuleName -CommandName 'Invoke-RemoteOrLocal' -MockWith {
+                param($ComputerName, $ScriptBlock, $ArgumentList, $Credential)
+                if ($ComputerName -eq 'BADSRV') {
+                    throw 'Connection refused'
+                }
+                [PSCustomObject]@{ StepsRun = @([PSCustomObject]@{ Step = 'WinsockReset'; ExitCode = 0 }); Success = $true }
+            }
+
+            { 'BADSRV', 'GOODSRV' | Reset-NetworkStack -Confirm:$false -ErrorAction SilentlyContinue } | Should -Not -Throw
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 2 -Exactly
+        }
+    }
+
+    Context 'Verbose output' {
+        BeforeAll {
+            Mock -ModuleName $script:ModuleName -CommandName 'Test-IsAdministrator' -MockWith { return $true }
+            Mock -ModuleName $script:ModuleName -CommandName 'Test-Path' -ParameterFilter {
+                $Path -like '*netsh*'
+            } -MockWith { $true }
+            Mock -ModuleName $script:ModuleName -CommandName 'Invoke-RemoteOrLocal' -MockWith {
+                [PSCustomObject]@{ StepsRun = @(); Success = $true }
+            }
+        }
+
+        It 'Should produce verbose messages including the function name' {
+            $script:verbose = Reset-NetworkStack -Confirm:$false -Verbose 4>&1 | Where-Object { $_ -is [System.Management.Automation.VerboseRecord] }
+            $script:verbose | Should -Not -BeNullOrEmpty
+            ($script:verbose.Message -join ' ') | Should -Match 'Reset-NetworkStack'
+        }
+    }
+}

--- a/Tests/Public/network/Reset-NetworkStack.Tests.ps1
+++ b/Tests/Public/network/Reset-NetworkStack.Tests.ps1
@@ -7,6 +7,7 @@ BeforeAll {
     $script:ModuleName = 'PSWinOps'
 
     function global:Clear-DnsClientCache {
+        [CmdletBinding()]
         param()
     }
 }

--- a/en-US/about_PSWinOps.help.txt
+++ b/en-US/about_PSWinOps.help.txt
@@ -109,7 +109,7 @@ FUNCTION DOMAINS
       Test-IISBindingCertificate
       Watch-IISLog
 
-  network (24 functions)
+  network (25 functions)
     Functions for network diagnostics, discovery,
     certificate inspection, and real-time monitoring.
 
@@ -129,6 +129,7 @@ FUNCTION DOMAINS
       Measure-NetworkLatency
       New-NetworkRoute
       Remove-NetworkRoute
+      Reset-NetworkStack
       Resolve-MACVendor
       Set-NetworkRoute
       Show-NetworkStatisticMonitor
@@ -312,7 +313,7 @@ REMOTE EXECUTION PATTERN
     in the pipeline continue to be processed.
 
 PSWINOPS TYPE REGISTRY
-    The following 99 PSTypeName values are defined by the
+    The following 100 PSTypeName values are defined by the
     module. Each corresponds to the output of one or more
     public functions.
 
@@ -377,6 +378,7 @@ PSWINOPS TYPE REGISTRY
       PSWinOps.NetworkConnection
       PSWinOps.NetworkLatency
       PSWinOps.NetworkRoute
+      PSWinOps.NetworkStackResetResult
       PSWinOps.NetworkStatistic
       PSWinOps.NtpConfiguration
       PSWinOps.NtpPeer


### PR DESCRIPTION
## Summary
Encapsulates the classic netsh network-repair sequence (netsh winsock reset and netsh int ip reset) plus a DNS client cache flush and ARP cache clear into one idempotent, ShouldProcess-guarded action. Returns a structured result listing each step that ran with its exit code, overall success, and RebootRequired (always true). Requires administrator privileges and ALWAYS needs a reboot to finalize. WARNING: on a remote target `netsh int ip reset` can drop the WinRM session mid-run, so verify results out-of-band after running remotely.

Closes #72

## Files touched
- `Public/network/Reset-NetworkStack.ps1` — implementation
- `Tests/Public/network/Reset-NetworkStack.Tests.ps1` — Pester v5 suite
- `PSWinOps.psd1` — FunctionsToExport, ModuleVersion (0.3.0 -> 0.4.0), ReleaseNotes
- `PSWinOps.Format.ps1xml` — new `<View>` (List) for `PSWinOps.NetworkStackResetResult`
- `en-US/about_PSWinOps.help.txt` — network count 24 -> 25, type registry entry added

## Conformance checklist (audited locally by fn-quality-gate)
- [x] UTF-8 BOM + CRLF on both new files
- [x] Approved PowerShell verb (Reset)
- [x] `FunctionsToExport` — Reset-NetworkStack present once, inserted in correct alphabetical position
- [x] `PSTypeName` consistent across .ps1 / Format.ps1xml / about help (`PSWinOps.NetworkStackResetResult`)
- [x] No `Write-Host`, no `ToString('o')`, no WMI cmdlets in the diff
- [x] `PSWinOps.Format.ps1xml` is valid XML with a matching `<View>`

## Verification
Dynamic verification (Test-ModuleManifest, PSScriptAnalyzer, Pester matrix) runs on the Windows CI for this PR. Merge once all required checks are green.