### PR TITLE
feat(network): add Get-ProcessByPort

### DIFF
--- a/.kdust/chains/get-processbyport-2607061309.yaml
+++ b/.kdust/chains/get-processbyport-2607061309.yaml
@@ -1,0 +1,7 @@
+chain: pswinops-function-author
+function: Get-ProcessByPort
+domain: network
+created: 2026-07-06T13:11:48Z
+created_by: pswinops-fn-spec-analyst
+chain_branch: kdust/chain/pswinops-fn-get-processbyport-2607061309
+spec_path: work/get-processbyport/spec.yaml

--- a/PSWinOps.Format.ps1xml
+++ b/PSWinOps.Format.ps1xml
@@ -1930,6 +1930,81 @@
         </TableRowEntries>
       </TableControl>
     </View>
+    <!-- PSWinOps.ProcessPort - Table -->
+    <View>
+      <Name>PSWinOps.ProcessPort</Name>
+      <ViewSelectedBy>
+        <TypeName>PSWinOps.ProcessPort</TypeName>
+      </ViewSelectedBy>
+      <TableControl>
+        <AutoSize />
+        <TableHeaders>
+          <TableColumnHeader>
+            <Label>ComputerName</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Protocol</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>LocalAddress</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>LocalPort</Label>
+            <Alignment>Right</Alignment>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>RemoteAddress</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>RemotePort</Label>
+            <Alignment>Right</Alignment>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>State</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>PID</Label>
+            <Alignment>Right</Alignment>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>ProcessName</Label>
+          </TableColumnHeader>
+        </TableHeaders>
+        <TableRowEntries>
+          <TableRowEntry>
+            <TableColumnItems>
+              <TableColumnItem>
+                <PropertyName>ComputerName</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>Protocol</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>LocalAddress</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>LocalPort</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>RemoteAddress</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>RemotePort</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>State</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>ProcessId</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>ProcessName</PropertyName>
+              </TableColumnItem>
+            </TableColumnItems>
+          </TableRowEntry>
+        </TableRowEntries>
+      </TableControl>
+    </View>
     <!-- PSWinOps.MACVendor - Table -->
     <View>
       <Name>PSWinOps.MACVendor</Name>

--- a/PSWinOps.psd1
+++ b/PSWinOps.psd1
@@ -12,7 +12,7 @@
     RootModule           = 'PSWinOps.psm1'
 
     # Version number of this module.
-    ModuleVersion        = '0.4.0'
+    ModuleVersion        = '0.5.0'
 
     # Supported PSEditions
     # Core is supported on Windows only; the module-level guard in PSWinOps.psm1 blocks
@@ -272,7 +272,11 @@
             # IconUri = ''
 
             # ReleaseNotes of this module
-            ReleaseNotes = '## 0.4.0 - 2026-07-06 UTC
+            ReleaseNotes = '## 0.5.0 - 2026-07-06 UTC
+### Added
+- Get-ProcessByPort: Correlate TCP/UDP endpoints with their owning process details
+
+## 0.4.0 - 2026-07-06 UTC
 ### Added
 - Reset-NetworkStack: Reset the Windows network stack (winsock, TCP/IP, DNS cache, ARP)
 

--- a/PSWinOps.psd1
+++ b/PSWinOps.psd1
@@ -146,6 +146,7 @@
         'Get-PendingReboot',
         'Get-RebootHistory',
         'Get-PrintServerHealth',
+        'Get-ProcessByPort',
         'Get-ProxyConfiguration',
         'Get-PublicIPAddress',
         'Get-RdpSession',

--- a/Public/network/Get-ProcessByPort.ps1
+++ b/Public/network/Get-ProcessByPort.ps1
@@ -1,0 +1,241 @@
+﻿#Requires -Version 5.1
+
+function Get-ProcessByPort {
+    <#
+        .SYNOPSIS
+            Correlate TCP/UDP endpoints with their owning process details
+
+        .DESCRIPTION
+            Joins listening and established TCP/UDP endpoints with the details of their
+            owning process (name, executable path, command line) in a single command.
+            Correlates each endpoint's OwningProcess with Win32_Process via CIM and works
+            against local or remote computers.
+
+            For remote computers, the query is executed via Invoke-Command.
+
+        .PARAMETER ComputerName
+            One or more computer names to query. Defaults to the local machine.
+            Accepts pipeline input by value and by property name.
+
+        .PARAMETER Credential
+            Optional credential for remote computer connections.
+
+        .PARAMETER Port
+            Filter on LocalPort. Accepts multiple values. When omitted, all Listen
+            and Established endpoints are returned.
+
+        .PARAMETER State
+            Filter TCP connections by state (Listen or Established). UDP endpoints
+            are excluded from the results when State is specified, since UDP is
+            stateless.
+
+        .EXAMPLE
+            Get-ProcessByPort
+
+            Returns all TCP/UDP endpoints on the local machine with owning process details.
+
+        .EXAMPLE
+            Get-ProcessByPort -Port 443 -State Listen
+
+            Shows which process is listening on TCP port 443 locally.
+
+        .EXAMPLE
+            Get-ProcessByPort -ComputerName 'SRV01' -Credential $cred
+
+            Shows all endpoints and owning processes on a remote server.
+
+        .EXAMPLE
+            'SRV01', 'SRV02' | Get-ProcessByPort -State Established
+
+            Shows established TCP connections and owning processes on two remote servers.
+
+        .OUTPUTS
+            PSWinOps.ProcessPort
+            One object per TCP/UDP endpoint, joined with owning process details.
+
+        .NOTES
+            Author: Franck SALLET
+            Version: 1.0.0
+            Last Modified: 2026-07-06
+            Requires: PowerShell 5.1+ / Windows only
+            Requires: Admin recommended for full process path/command line resolution
+
+        .LINK
+            https://github.com/k9fr4n/PSWinOps
+    #>
+    [CmdletBinding()]
+    [OutputType('PSWinOps.ProcessPort')]
+    param (
+        [Parameter(Mandatory = $false,
+            ValueFromPipeline = $true,
+            ValueFromPipelineByPropertyName = $true)]
+        [ValidateNotNullOrEmpty()]
+        [Alias('CN', 'Name', 'DNSHostName')]
+        [string[]]$ComputerName = $env:COMPUTERNAME,
+
+        [Parameter(Mandatory = $false)]
+        [PSCredential]$Credential,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateRange(1, 65535)]
+        [int[]]$Port,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateSet('Listen', 'Established')]
+        [string]$State
+    )
+
+    begin {
+        Write-Verbose "[$($MyInvocation.MyCommand)] Starting process-by-port query"
+
+        $queryScriptBlock = {
+            param([int[]]$FilterPorts, [string]$FilterState)
+
+            # Build process cache (cast to [int] — OwningProcess is UInt32,
+            # Win32_Process.ProcessId is UInt32; normalize before hashtable lookup)
+            $processCache = @{}
+            Get-CimInstance -ClassName Win32_Process -ErrorAction SilentlyContinue | ForEach-Object {
+                $pidKey = [int]$_.ProcessId
+                if (-not $processCache.ContainsKey($pidKey)) {
+                    $processCache[$pidKey] = [PSCustomObject]@{
+                        ProcessName = $_.Name
+                        ProcessPath = $_.ExecutablePath
+                        CommandLine = $_.CommandLine
+                    }
+                }
+            }
+
+            $results = [System.Collections.Generic.List[PSObject]]::new()
+
+            # TCP connections (Listen + Established, optionally narrowed by -State)
+            if (-not $FilterState -or $FilterState -in @('Listen', 'Established')) {
+                $tcpParams = @{ ErrorAction = 'SilentlyContinue' }
+                if ($FilterState) {
+                    $tcpParams['State'] = $FilterState
+                }
+
+                $tcpConnections = Get-NetTCPConnection @tcpParams | Where-Object { $_.State -in @('Listen', 'Established') }
+
+                foreach ($conn in $tcpConnections) {
+                    if ($FilterPorts -and $FilterPorts.Count -gt 0 -and $conn.LocalPort -notin $FilterPorts) {
+                        continue
+                    }
+
+                    $ownerPid = [int]$conn.OwningProcess
+                    $procInfo = $processCache[$ownerPid]
+
+                    $results.Add([PSCustomObject]@{
+                            Protocol      = 'TCP'
+                            LocalAddress  = $conn.LocalAddress
+                            LocalPort     = $conn.LocalPort
+                            RemoteAddress = $conn.RemoteAddress
+                            RemotePort    = $conn.RemotePort
+                            State         = $conn.State.ToString()
+                            ProcessId     = $ownerPid
+                            ProcessName   = if ($procInfo) {
+                                $procInfo.ProcessName
+                            } else {
+                                $null
+                            }
+                            ProcessPath   = if ($procInfo) {
+                                $procInfo.ProcessPath
+                            } else {
+                                $null
+                            }
+                            CommandLine   = if ($procInfo) {
+                                $procInfo.CommandLine
+                            } else {
+                                $null
+                            }
+                        })
+                }
+            }
+
+            # UDP endpoints (stateless — excluded entirely when -State is specified)
+            if (-not $FilterState) {
+                $udpEndpoints = Get-NetUDPEndpoint -ErrorAction SilentlyContinue
+
+                foreach ($ep in $udpEndpoints) {
+                    if ($FilterPorts -and $FilterPorts.Count -gt 0 -and $ep.LocalPort -notin $FilterPorts) {
+                        continue
+                    }
+
+                    $ownerPid = [int]$ep.OwningProcess
+                    $procInfo = $processCache[$ownerPid]
+
+                    $results.Add([PSCustomObject]@{
+                            Protocol      = 'UDP'
+                            LocalAddress  = $ep.LocalAddress
+                            LocalPort     = $ep.LocalPort
+                            RemoteAddress = $null
+                            RemotePort    = $null
+                            State         = $null
+                            ProcessId     = $ownerPid
+                            ProcessName   = if ($procInfo) {
+                                $procInfo.ProcessName
+                            } else {
+                                $null
+                            }
+                            ProcessPath   = if ($procInfo) {
+                                $procInfo.ProcessPath
+                            } else {
+                                $null
+                            }
+                            CommandLine   = if ($procInfo) {
+                                $procInfo.CommandLine
+                            } else {
+                                $null
+                            }
+                        })
+                }
+            }
+
+            return $results
+        }
+    }
+
+    process {
+        foreach ($targetComputer in $ComputerName) {
+            try {
+                $timestamp = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
+
+                Write-Verbose "[$($MyInvocation.MyCommand)] Querying process-by-port on '$targetComputer'"
+
+                $queryArgs = @(
+                    , $Port
+                    $(if ($PSBoundParameters.ContainsKey('State')) {
+                            $State
+                        } else {
+                            $null
+                        })
+                )
+
+                $rawResults = Invoke-RemoteOrLocal -ComputerName $targetComputer -ScriptBlock $queryScriptBlock -ArgumentList $queryArgs -Credential $Credential
+
+                foreach ($entry in $rawResults) {
+                    [PSCustomObject]@{
+                        PSTypeName    = 'PSWinOps.ProcessPort'
+                        ComputerName  = $targetComputer
+                        Protocol      = $entry.Protocol
+                        LocalAddress  = $entry.LocalAddress
+                        LocalPort     = $entry.LocalPort
+                        RemoteAddress = $entry.RemoteAddress
+                        RemotePort    = $entry.RemotePort
+                        State         = $entry.State
+                        ProcessId     = $entry.ProcessId
+                        ProcessName   = $entry.ProcessName
+                        ProcessPath   = $entry.ProcessPath
+                        CommandLine   = $entry.CommandLine
+                        Timestamp     = $timestamp
+                    }
+                }
+            } catch {
+                Write-Error "[$($MyInvocation.MyCommand)] Failed on '$targetComputer': $_"
+            }
+        }
+    }
+
+    end {
+        Write-Verbose "[$($MyInvocation.MyCommand)] Completed process-by-port query"
+    }
+}

--- a/Public/network/Get-ProcessByPort.ps1
+++ b/Public/network/Get-ProcessByPort.ps1
@@ -114,7 +114,9 @@ function Get-ProcessByPort {
                     $tcpParams['State'] = $FilterState
                 }
 
-                $tcpConnections = Get-NetTCPConnection @tcpParams | Where-Object { $_.State -in @('Listen', 'Established') }
+                $tcpConnections = Get-NetTCPConnection @tcpParams | Where-Object {
+                    $_.State -in @('Listen', 'Established') -and (-not $FilterState -or $_.State.ToString() -eq $FilterState)
+                }
 
                 foreach ($conn in $tcpConnections) {
                     if ($FilterPorts -and $FilterPorts.Count -gt 0 -and $conn.LocalPort -notin $FilterPorts) {

--- a/Tests/Public/network/Get-ProcessByPort.Tests.ps1
+++ b/Tests/Public/network/Get-ProcessByPort.Tests.ps1
@@ -1,0 +1,224 @@
+﻿BeforeAll {
+    # Stub Windows-only commands BEFORE module import so Pester can mock them
+    if (-not (Get-Command -Name 'Get-NetTCPConnection' -ErrorAction SilentlyContinue)) {
+        function global:Get-NetTCPConnection { param($State, $ErrorAction) }
+    }
+    if (-not (Get-Command -Name 'Get-NetUDPEndpoint' -ErrorAction SilentlyContinue)) {
+        function global:Get-NetUDPEndpoint { param($ErrorAction) }
+    }
+
+    $script:modulePath = Split-Path -Path (Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent) -Parent
+    Import-Module -Name (Join-Path -Path $script:modulePath -ChildPath 'PSWinOps.psd1') -Force
+    $script:ModuleName = 'PSWinOps'
+}
+
+Describe 'Get-ProcessByPort' {
+
+    Context 'Happy path - local TCP + UDP' {
+
+        BeforeEach {
+            Mock -ModuleName $script:ModuleName -CommandName 'Get-CimInstance' -MockWith {
+                @(
+                    [PSCustomObject]@{ ProcessId = [uint32]1234; Name = 'httpd'; ExecutablePath = 'C:\httpd.exe'; CommandLine = 'httpd.exe -k start' }
+                )
+            }
+            Mock -ModuleName $script:ModuleName -CommandName 'Get-NetTCPConnection' -MockWith {
+                @(
+                    [PSCustomObject]@{ LocalAddress = '0.0.0.0'; LocalPort = 80; RemoteAddress = '0.0.0.0'; RemotePort = 0; OwningProcess = [uint32]1234; State = 'Listen' }
+                )
+            }
+            Mock -ModuleName $script:ModuleName -CommandName 'Get-NetUDPEndpoint' -MockWith {
+                @(
+                    [PSCustomObject]@{ LocalAddress = '0.0.0.0'; LocalPort = 53; OwningProcess = [uint32]1234 }
+                )
+            }
+        }
+
+        It 'Should return typed objects with ComputerName, Timestamp and PSTypeName' {
+            $result = Get-ProcessByPort
+            $result.Count | Should -Be 2
+            $result[0].PSObject.TypeNames[0] | Should -Be 'PSWinOps.ProcessPort'
+            $result[0].ComputerName | Should -Be $env:COMPUTERNAME
+            $result[0].Timestamp | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Should join TCP connection with owning process details' {
+            $result = Get-ProcessByPort
+            $tcpRow = $result | Where-Object Protocol -eq 'TCP'
+            $tcpRow.ProcessName | Should -Be 'httpd'
+            $tcpRow.ProcessPath | Should -Be 'C:\httpd.exe'
+            $tcpRow.CommandLine | Should -Be 'httpd.exe -k start'
+            $tcpRow.State | Should -Be 'Listen'
+        }
+
+        It 'Should include UDP endpoint with State/RemoteAddress/RemotePort as null' {
+            $result = Get-ProcessByPort
+            $udpRow = $result | Where-Object Protocol -eq 'UDP'
+            $udpRow.State | Should -BeNullOrEmpty
+            $udpRow.RemoteAddress | Should -BeNullOrEmpty
+            $udpRow.RemotePort | Should -BeNullOrEmpty
+        }
+    }
+
+    Context 'Port filter (local)' {
+
+        BeforeEach {
+            Mock -ModuleName $script:ModuleName -CommandName 'Get-CimInstance' -MockWith {
+                @([PSCustomObject]@{ ProcessId = [uint32]100; Name = 'nginx'; ExecutablePath = 'C:\nginx.exe'; CommandLine = 'nginx.exe' })
+            }
+            Mock -ModuleName $script:ModuleName -CommandName 'Get-NetTCPConnection' -MockWith {
+                @(
+                    [PSCustomObject]@{ LocalAddress = '0.0.0.0'; LocalPort = 80; RemoteAddress = $null; RemotePort = $null; OwningProcess = [uint32]100; State = 'Listen' },
+                    [PSCustomObject]@{ LocalAddress = '0.0.0.0'; LocalPort = 443; RemoteAddress = $null; RemotePort = $null; OwningProcess = [uint32]100; State = 'Listen' }
+                )
+            }
+            Mock -ModuleName $script:ModuleName -CommandName 'Get-NetUDPEndpoint' -MockWith { @() }
+        }
+
+        It 'Should narrow results to the requested LocalPort' {
+            $result = Get-ProcessByPort -Port 443
+            $result | Should -HaveCount 1
+            $result[0].LocalPort | Should -Be 443
+        }
+    }
+
+    Context 'State filter (local)' {
+
+        BeforeEach {
+            Mock -ModuleName $script:ModuleName -CommandName 'Get-CimInstance' -MockWith {
+                @([PSCustomObject]@{ ProcessId = [uint32]100; Name = 'nginx'; ExecutablePath = 'C:\nginx.exe'; CommandLine = 'nginx.exe' })
+            }
+            Mock -ModuleName $script:ModuleName -CommandName 'Get-NetTCPConnection' -MockWith {
+                @(
+                    [PSCustomObject]@{ LocalAddress = '0.0.0.0'; LocalPort = 80; RemoteAddress = $null; RemotePort = $null; OwningProcess = [uint32]100; State = 'Listen' },
+                    [PSCustomObject]@{ LocalAddress = '10.0.0.5'; LocalPort = 51000; RemoteAddress = '1.2.3.4'; RemotePort = 443; OwningProcess = [uint32]100; State = 'Established' }
+                )
+            }
+            Mock -ModuleName $script:ModuleName -CommandName 'Get-NetUDPEndpoint' -MockWith {
+                @([PSCustomObject]@{ LocalAddress = '0.0.0.0'; LocalPort = 53; OwningProcess = [uint32]100 })
+            }
+        }
+
+        It 'Should narrow TCP connections to the requested State and exclude UDP' {
+            $result = Get-ProcessByPort -State Established
+            $result | Should -HaveCount 1
+            $result[0].Protocol | Should -Be 'TCP'
+            $result[0].State | Should -Be 'Established'
+        }
+    }
+
+    Context 'Process exited between queries (local)' {
+
+        BeforeEach {
+            Mock -ModuleName $script:ModuleName -CommandName 'Get-CimInstance' -MockWith { @() }
+            Mock -ModuleName $script:ModuleName -CommandName 'Get-NetTCPConnection' -MockWith {
+                @([PSCustomObject]@{ LocalAddress = '0.0.0.0'; LocalPort = 8080; RemoteAddress = $null; RemotePort = $null; OwningProcess = [uint32]9999; State = 'Listen' })
+            }
+            Mock -ModuleName $script:ModuleName -CommandName 'Get-NetUDPEndpoint' -MockWith { @() }
+        }
+
+        It 'Should keep the row with null process fields when the process is gone' {
+            $result = Get-ProcessByPort -Port 8080
+            $result | Should -HaveCount 1
+            $result[0].ProcessId | Should -Be 9999
+            $result[0].ProcessName | Should -BeNullOrEmpty
+            $result[0].ProcessPath | Should -BeNullOrEmpty
+            $result[0].CommandLine | Should -BeNullOrEmpty
+        }
+    }
+
+    Context 'Explicit remote machine' {
+
+        BeforeEach {
+            Mock -ModuleName $script:ModuleName -CommandName 'Invoke-Command' -MockWith {
+                @(
+                    [PSCustomObject]@{ Protocol = 'TCP'; LocalAddress = '0.0.0.0'; LocalPort = 3389; RemoteAddress = $null; RemotePort = $null; State = 'Listen'; ProcessId = 500; ProcessName = 'TermService'; ProcessPath = 'C:\svchost.exe'; CommandLine = 'svchost.exe -k termsvcs' }
+                )
+            }
+        }
+
+        It 'Should query the remote machine via Invoke-Command and stamp ComputerName' {
+            $result = Get-ProcessByPort -ComputerName 'REMOTE01'
+            $result.ComputerName | Should -Be 'REMOTE01'
+            $result[0].PSObject.TypeNames[0] | Should -Be 'PSWinOps.ProcessPort'
+            Should -Invoke -CommandName 'Invoke-Command' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+    }
+
+    Context 'Pipeline of multiple machines' {
+
+        BeforeEach {
+            Mock -ModuleName $script:ModuleName -CommandName 'Invoke-Command' -MockWith {
+                @([PSCustomObject]@{ Protocol = 'TCP'; LocalAddress = '0.0.0.0'; LocalPort = 22; RemoteAddress = $null; RemotePort = $null; State = 'Listen'; ProcessId = 1; ProcessName = 'sshd'; ProcessPath = $null; CommandLine = $null })
+            }
+        }
+
+        It 'Should query every machine received from the pipeline' {
+            'SRV01', 'SRV02' | Get-ProcessByPort
+            Should -Invoke -CommandName 'Invoke-Command' -ModuleName $script:ModuleName -Times 2 -Exactly
+        }
+    }
+
+    Context 'Credential propagation' {
+
+        BeforeEach {
+            Mock -ModuleName $script:ModuleName -CommandName 'Invoke-Command' -MockWith {
+                @([PSCustomObject]@{ Protocol = 'TCP'; LocalAddress = '0.0.0.0'; LocalPort = 3389; RemoteAddress = $null; RemotePort = $null; State = 'Listen'; ProcessId = 500; ProcessName = 'TermService'; ProcessPath = $null; CommandLine = $null })
+            }
+        }
+
+        It 'Should forward the Credential to Invoke-Command' {
+            $cred = [PSCredential]::new('user', (ConvertTo-SecureString 'pass' -AsPlainText -Force))
+            Get-ProcessByPort -ComputerName 'REMOTE01' -Credential $cred
+            Should -Invoke -CommandName 'Invoke-Command' -ModuleName $script:ModuleName -Times 1 -Exactly -ParameterFilter {
+                $Credential -eq $cred
+            }
+        }
+    }
+
+    Context 'Per-machine failure isolation' {
+
+        BeforeEach {
+            Mock -ModuleName $script:ModuleName -CommandName 'Invoke-Command' -MockWith {
+                @([PSCustomObject]@{ Protocol = 'TCP'; LocalAddress = '0.0.0.0'; LocalPort = 22; RemoteAddress = $null; RemotePort = $null; State = 'Listen'; ProcessId = 1; ProcessName = 'sshd'; ProcessPath = $null; CommandLine = $null })
+            }
+            Mock -ModuleName $script:ModuleName -CommandName 'Invoke-Command' -ParameterFilter {
+                $ComputerName -eq 'BADSERVER'
+            } -MockWith { throw 'Connection refused' }
+        }
+
+        It 'Should continue processing remaining machines after one fails' {
+            $result = Get-ProcessByPort -ComputerName 'SRV01', 'BADSERVER', 'SRV02' -ErrorAction SilentlyContinue
+            $result.Count | Should -Be 2
+        }
+
+        It 'Should write an error for the failing machine' {
+            $null = Get-ProcessByPort -ComputerName 'BADSERVER' -ErrorVariable err -ErrorAction SilentlyContinue
+            $err | Should -Not -BeNullOrEmpty
+        }
+    }
+
+    Context 'Parameter validation' {
+
+        It 'Should reject Port 0' {
+            { Get-ProcessByPort -Port 0 } | Should -Throw
+        }
+
+        It 'Should reject Port above 65535' {
+            { Get-ProcessByPort -Port 70000 } | Should -Throw
+        }
+
+        It 'Should reject an invalid State value' {
+            { Get-ProcessByPort -State 'Closed' } | Should -Throw
+        }
+
+        It 'Should reject an empty ComputerName' {
+            { Get-ProcessByPort -ComputerName '' } | Should -Throw
+        }
+
+        It 'Should support the CN alias for ComputerName' {
+            $cmd = Get-Command -Name 'Get-ProcessByPort'
+            $cmd.Parameters['ComputerName'].Aliases | Should -Contain 'CN'
+        }
+    }
+}

--- a/en-US/about_PSWinOps.help.txt
+++ b/en-US/about_PSWinOps.help.txt
@@ -109,7 +109,7 @@ FUNCTION DOMAINS
       Test-IISBindingCertificate
       Watch-IISLog
 
-  network (25 functions)
+  network (26 functions)
     Functions for network diagnostics, discovery,
     certificate inspection, and real-time monitoring.
 
@@ -123,6 +123,7 @@ FUNCTION DOMAINS
       Get-NetworkConnection
       Get-NetworkRoute
       Get-NetworkStatistic
+      Get-ProcessByPort
       Get-PublicIPAddress
       Get-SSLCertificate
       Get-SubnetInfo
@@ -388,6 +389,7 @@ PSWINOPS TYPE REGISTRY
       PSWinOps.PendingReboot
       PSWinOps.PortConnectivity
       PSWinOps.PrintServerHealth
+      PSWinOps.ProcessPort
       PSWinOps.ProxyConfiguration
       PSWinOps.ProxyTestResult
       PSWinOps.PublicIPAddress


### PR DESCRIPTION
## Summary
Joins listening and established TCP/UDP endpoints with the details of their owning process (name, executable path, command line) in a single command. Correlates each endpoint's OwningProcess with Win32_Process via CIM and works against local or remote computers.

Closes #71

## Files touched
- `Public/network/Get-ProcessByPort.ps1` — implementation
- `Tests/Public/network/Get-ProcessByPort.Tests.ps1` — Pester v5 suite
- `PSWinOps.psd1` — FunctionsToExport, ModuleVersion (0.4.0 -> 0.5.0), ReleaseNotes
- `PSWinOps.Format.ps1xml` — new `<View>` for `PSWinOps.ProcessPort`
- `en-US/about_PSWinOps.help.txt` — network domain count 25 -> 26, function list + type registry

## Conformance checklist (audited locally by fn-quality-gate)
- [x] UTF-8 BOM + CRLF on both new files
- [x] Approved PowerShell verb (Get)
- [x] `FunctionsToExport` entry present once, placed alphabetically between Get-PrintServerHealth and Get-ProxyConfiguration
- [x] `PSTypeName` (PSWinOps.ProcessPort) consistent across .ps1 / Format.ps1xml / about help
- [x] No `Write-Host`, no `ToString('o')`, no WMI cmdlets in the diff
- [x] `PSWinOps.Format.ps1xml` is valid XML with a matching `<View>`

## Verification
Dynamic verification (Test-ModuleManifest, PSScriptAnalyzer, Pester matrix) runs on the Windows CI for this PR. Merge once all required checks are green.

_Note: pre-existing `FunctionsToExport` ordering artifacts (`Get-RebootHistory` before `Get-PrintServerHealth`; `Get-Ad*`/`Get-AD*` case) exist on `main` and are out of scope for this PR._