### PR TITLE
feat(system): add Set-EnvironmentVariable

### DIFF
--- a/.kdust/chains/set-environmentvariable-2607061346.yaml
+++ b/.kdust/chains/set-environmentvariable-2607061346.yaml
@@ -1,0 +1,7 @@
+chain: pswinops-function-author
+function: Set-EnvironmentVariable
+domain: system
+created: 2026-07-06T13:46:37Z
+created_by: pswinops-fn-spec-analyst
+chain_branch: kdust/chain/pswinops-fn-set-environmentvariable-2607061346
+spec_path: work/set-environmentvariable/spec.yaml

--- a/PSWinOps.Format.ps1xml
+++ b/PSWinOps.Format.ps1xml
@@ -2549,7 +2549,7 @@
     </View>
     <!-- ============================================================ -->
     <!-- PSWinOps.EnvironmentVariable                                 -->
-    <!-- Used by: Get-EnvironmentVariable                             -->
+    <!-- Used by: Get-EnvironmentVariable, Set-EnvironmentVariable    -->
     <!-- ============================================================ -->
     <View>
       <Name>PSWinOps.EnvironmentVariable</Name>

--- a/PSWinOps.psd1
+++ b/PSWinOps.psd1
@@ -12,7 +12,7 @@
     RootModule           = 'PSWinOps.psm1'
 
     # Version number of this module.
-    ModuleVersion        = '0.5.0'
+    ModuleVersion        = '0.6.0'
 
     # Supported PSEditions
     # Core is supported on Windows only; the module-level guard in PSWinOps.psm1 blocks
@@ -273,7 +273,11 @@
             # IconUri = ''
 
             # ReleaseNotes of this module
-            ReleaseNotes = '## 0.5.0 - 2026-07-06 UTC
+            ReleaseNotes = '## 0.6.0 - 2026-07-06 UTC
+### Added
+- Set-EnvironmentVariable: Sets or deletes a Machine- or User-scoped environment variable on local or remote computers
+
+## 0.5.0 - 2026-07-06 UTC
 ### Added
 - Get-ProcessByPort: Correlate TCP/UDP endpoints with their owning process details
 

--- a/PSWinOps.psd1
+++ b/PSWinOps.psd1
@@ -186,6 +186,7 @@
         'Restore-ShadowCopyFile',
         'Save-WindowsUpdate',
         'Search-ADObject',
+        'Set-EnvironmentVariable',
         'Set-IISBindingCertificate',
         'Set-NetworkRoute',
         'Set-NTPClient',

--- a/Public/system/Set-EnvironmentVariable.ps1
+++ b/Public/system/Set-EnvironmentVariable.ps1
@@ -1,0 +1,161 @@
+﻿#Requires -Version 5.1
+function Set-EnvironmentVariable {
+    <#
+        .SYNOPSIS
+            Sets or deletes a Machine- or User-scoped environment variable on local or remote computers
+
+        .DESCRIPTION
+            Sets a Machine- or User-scoped environment variable using [Environment]::SetEnvironmentVariable,
+            the symmetric writer for Get-EnvironmentVariable. Supports -WhatIf/-Confirm (ConfirmImpact Medium).
+            An empty Value deletes the variable. User scope targets the executing account profile when run
+            remotely (the WinRM logon identity), not the console user; already-running processes will not
+            see the change until restarted regardless of scope.
+
+        .PARAMETER Name
+            Environment variable name to set or delete.
+
+        .PARAMETER Value
+            New value. An EMPTY string deletes the variable via
+            [Environment]::SetEnvironmentVariable($Name, $null, $Scope).
+
+        .PARAMETER Scope
+            Machine (default) or User scope. Writing Machine scope requires Administrator
+            privileges. User scope on a remote computer applies to the executing account's
+            profile (the WinRM logon identity), not the interactive console user.
+
+        .PARAMETER ComputerName
+            One or more computer names to target. Defaults to the local computer.
+            Accepts pipeline input by value and by property name.
+
+        .PARAMETER Credential
+            Optional PSCredential for authenticating to remote computers.
+            Not used for local operations.
+
+        .EXAMPLE
+            Set-EnvironmentVariable -Name 'FOO' -Value 'bar' -Scope Machine
+
+            Sets the Machine-scoped 'FOO' variable to 'bar' on the local computer.
+
+        .EXAMPLE
+            Set-EnvironmentVariable -Name 'FOO' -Value 'bar' -ComputerName 'SRV01' -Credential (Get-Credential)
+
+            Sets the Machine-scoped 'FOO' variable to 'bar' on SRV01 using explicit credentials.
+
+        .EXAMPLE
+            'SRV01', 'SRV02' | Set-EnvironmentVariable -Name 'FOO' -Value ''
+
+            Deletes the 'FOO' variable on both SRV01 and SRV02 via pipeline (empty Value = delete).
+
+        .OUTPUTS
+            PSWinOps.EnvironmentVariable
+            Returns one object per computer with the read-back Name/Value/Scope after the
+            operation. Value is an empty string when the variable was deleted.
+
+        .NOTES
+            Author: Franck SALLET
+            Version: 1.0.0
+            Last Modified: 2026-07-06
+            Requires: PowerShell 5.1+ / Windows only
+            Requires: Administrator privileges for Machine scope
+
+        .LINK
+            https://github.com/k9fr4n/PSWinOps
+
+        .LINK
+            https://learn.microsoft.com/en-us/windows/win32/procthread/environment-variables
+    #>
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
+    [OutputType('PSWinOps.EnvironmentVariable')]
+    param(
+        [Parameter(Mandatory = $true, Position = 0, ValueFromPipelineByPropertyName = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Name,
+
+        [Parameter(Mandatory = $true, Position = 1)]
+        [AllowEmptyString()]
+        [string]$Value,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateSet('Machine', 'User')]
+        [string]$Scope = 'Machine',
+
+        [Parameter(Mandatory = $false, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true, Position = 2)]
+        [ValidateNotNullOrEmpty()]
+        [Alias('CN', 'DNSHostName')]
+        [string[]]$ComputerName = $env:COMPUTERNAME,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateNotNull()]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential
+    )
+
+    begin {
+        Write-Verbose -Message "[$($MyInvocation.MyCommand)] Starting with Name='$Name', Scope=$Scope"
+
+        $isDelete = [string]::IsNullOrEmpty($Value)
+
+        $scriptBlock = {
+            param(
+                [string]$VariableName,
+                [string]$VariableValue,
+                [string]$VariableScope,
+                [bool]$DeleteRequested
+            )
+
+            $valueToSet = if ($DeleteRequested) {
+                $null
+            } else {
+                $VariableValue
+            }
+
+            [Environment]::SetEnvironmentVariable($VariableName, $valueToSet, $VariableScope)
+
+            $readBack = [Environment]::GetEnvironmentVariable($VariableName, $VariableScope)
+            if ($null -eq $readBack) {
+                $readBack = ''
+            }
+
+            [PSCustomObject]@{
+                Name  = $VariableName
+                Value = $readBack
+                Scope = $VariableScope
+            }
+        }
+    }
+
+    process {
+        foreach ($targetComputer in $ComputerName) {
+            Write-Verbose -Message "[$($MyInvocation.MyCommand)] Processing '$targetComputer'"
+
+            try {
+                $actionDescription = if ($isDelete) {
+                    "Delete $Scope environment variable '$Name'"
+                } else {
+                    "Set $Scope environment variable '$Name' = '$Value'"
+                }
+
+                if ($PSCmdlet.ShouldProcess($targetComputer, $actionDescription)) {
+                    $result = Invoke-RemoteOrLocal -ComputerName $targetComputer -ScriptBlock $scriptBlock -ArgumentList @($Name, $Value, $Scope, $isDelete) -Credential $Credential
+
+                    [PSCustomObject]@{
+                        PSTypeName   = 'PSWinOps.EnvironmentVariable'
+                        ComputerName = $targetComputer
+                        Name         = $result.Name
+                        Value        = $result.Value
+                        Scope        = $result.Scope
+                        Timestamp    = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
+                    }
+                }
+            } catch {
+                Write-Error -Message "[$($MyInvocation.MyCommand)] Failed on '${targetComputer}': $_"
+                continue
+            }
+        }
+    }
+
+    end {
+        Write-Verbose -Message "[$($MyInvocation.MyCommand)] Completed"
+    }
+}

--- a/Tests/Public/system/Set-EnvironmentVariable.Tests.ps1
+++ b/Tests/Public/system/Set-EnvironmentVariable.Tests.ps1
@@ -47,7 +47,7 @@ Describe 'Set-EnvironmentVariable' {
         }
 
         It -Name 'Should forward ComputerName and Credential to Invoke-RemoteOrLocal' -Test {
-            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -Times 1 -ParameterFilter {
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -Times 1 -Scope Context -ParameterFilter {
                 $ComputerName -eq 'SRV01' -and $Credential -eq $script:cred
             }
         }
@@ -83,7 +83,7 @@ Describe 'Set-EnvironmentVariable' {
         }
 
         It -Name 'Should call Invoke-RemoteOrLocal with DeleteRequested true in ArgumentList' -Test {
-            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -Times 1 -ParameterFilter {
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -Times 1 -Scope Context -ParameterFilter {
                 $ArgumentList[0] -eq 'FOO' -and $ArgumentList[3] -eq $true
             }
         }
@@ -103,7 +103,7 @@ Describe 'Set-EnvironmentVariable' {
         }
 
         It -Name 'Should not invoke Invoke-RemoteOrLocal' -Test {
-            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -Times 0
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -Times 0 -Scope Context
         }
 
         It -Name 'Should not return any output object' -Test {

--- a/Tests/Public/system/Set-EnvironmentVariable.Tests.ps1
+++ b/Tests/Public/system/Set-EnvironmentVariable.Tests.ps1
@@ -1,0 +1,150 @@
+﻿#Requires -Version 5.1
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+BeforeAll {
+    $script:modulePath = Split-Path -Path (Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent) -Parent
+    Import-Module -Name (Join-Path -Path $script:modulePath -ChildPath 'PSWinOps.psd1') -Force
+}
+
+Describe 'Set-EnvironmentVariable' {
+
+    Context 'Local happy path' {
+
+        BeforeAll {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -MockWith {
+                return [PSCustomObject]@{ Name = 'FOO'; Value = 'bar'; Scope = 'Machine' }
+            }
+            $script:result = Set-EnvironmentVariable -Name 'FOO' -Value 'bar' -Scope 'Machine' -Confirm:$false
+        }
+
+        It -Name 'Should return PSWinOps.EnvironmentVariable type' -Test {
+            $script:result.PSObject.TypeNames | Should -Contain 'PSWinOps.EnvironmentVariable'
+        }
+
+        It -Name 'Should set ComputerName to the local computer' -Test {
+            $script:result.ComputerName | Should -Be $env:COMPUTERNAME
+        }
+
+        It -Name 'Should return Name, Value and Scope from the read-back' -Test {
+            $script:result.Name | Should -Be 'FOO'
+            $script:result.Value | Should -Be 'bar'
+            $script:result.Scope | Should -Be 'Machine'
+        }
+
+        It -Name 'Should format Timestamp as yyyy-MM-dd HH:mm:ss' -Test {
+            $script:result.Timestamp | Should -Match "^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$"
+        }
+    }
+
+    Context 'Explicit remote machine with Credential' {
+
+        BeforeAll {
+            $script:cred = [System.Management.Automation.PSCredential]::new('user', (ConvertTo-SecureString -String 'p@ss' -AsPlainText -Force))
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -MockWith {
+                return [PSCustomObject]@{ Name = 'FOO'; Value = 'bar'; Scope = 'Machine' }
+            }
+            $script:remoteResult = Set-EnvironmentVariable -Name 'FOO' -Value 'bar' -ComputerName 'SRV01' -Credential $script:cred -Confirm:$false
+        }
+
+        It -Name 'Should forward ComputerName and Credential to Invoke-RemoteOrLocal' -Test {
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -Times 1 -ParameterFilter {
+                $ComputerName -eq 'SRV01' -and $Credential -eq $script:cred
+            }
+        }
+
+        It -Name 'Should set ComputerName to SRV01 on the returned object' -Test {
+            $script:remoteResult.ComputerName | Should -Be 'SRV01'
+        }
+    }
+
+    Context 'Pipeline of multiple machine names' {
+
+        BeforeAll {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -MockWith {
+                return [PSCustomObject]@{ Name = 'FOO'; Value = 'bar'; Scope = 'Machine' }
+            }
+            $script:pipelineResults = 'SRV01', 'SRV02' | Set-EnvironmentVariable -Name 'FOO' -Value 'bar' -Confirm:$false
+        }
+
+        It -Name 'Should return one object per machine' -Test {
+            @($script:pipelineResults).Count | Should -Be 2
+            $script:pipelineResults[0].ComputerName | Should -Be 'SRV01'
+            $script:pipelineResults[1].ComputerName | Should -Be 'SRV02'
+        }
+    }
+
+    Context 'Empty Value performs deletion' {
+
+        BeforeAll {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -MockWith {
+                return [PSCustomObject]@{ Name = 'FOO'; Value = ''; Scope = 'Machine' }
+            }
+            $script:deleteResult = Set-EnvironmentVariable -Name 'FOO' -Value '' -Confirm:$false
+        }
+
+        It -Name 'Should call Invoke-RemoteOrLocal with DeleteRequested true in ArgumentList' -Test {
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -Times 1 -ParameterFilter {
+                $ArgumentList[0] -eq 'FOO' -and $ArgumentList[3] -eq $true
+            }
+        }
+
+        It -Name 'Should emit an empty string Value' -Test {
+            $script:deleteResult.Value | Should -Be ''
+        }
+    }
+
+    Context 'WhatIf writes nothing' {
+
+        BeforeAll {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -MockWith {
+                return [PSCustomObject]@{ Name = 'FOO'; Value = 'bar'; Scope = 'Machine' }
+            }
+            $script:whatIfResult = Set-EnvironmentVariable -Name 'FOO' -Value 'bar' -WhatIf
+        }
+
+        It -Name 'Should not invoke Invoke-RemoteOrLocal' -Test {
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -Times 0
+        }
+
+        It -Name 'Should not return any output object' -Test {
+            $script:whatIfResult | Should -BeNullOrEmpty
+        }
+    }
+
+    Context 'Scope validation' {
+
+        It -Name 'Should reject an invalid Scope value' -Test {
+            { Set-EnvironmentVariable -Name 'FOO' -Value 'bar' -Scope 'InvalidScope' -Confirm:$false } | Should -Throw
+        }
+    }
+
+    Context 'Parameter validation' {
+
+        It -Name 'Should reject an empty or null Name' -Test {
+            { Set-EnvironmentVariable -Name '' -Value 'bar' -Confirm:$false } | Should -Throw
+        }
+
+        It -Name 'Should reject a null or empty ComputerName' -Test {
+            { Set-EnvironmentVariable -Name 'FOO' -Value 'bar' -ComputerName '' -Confirm:$false } | Should -Throw
+        }
+    }
+
+    Context 'Per-machine failure isolation' {
+
+        BeforeAll {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -MockWith {
+                if ($ComputerName -eq 'SRV01') {
+                    throw 'Access denied'
+                }
+                return [PSCustomObject]@{ Name = 'FOO'; Value = 'bar'; Scope = 'Machine' }
+            }
+        }
+
+        It -Name 'Should write an error for the failing machine and continue to the next one' -Test {
+            $script:isolationResults = 'SRV01', 'SRV02' | Set-EnvironmentVariable -Name 'FOO' -Value 'bar' -Confirm:$false -ErrorVariable errVar -ErrorAction SilentlyContinue
+            $errVar | Should -Not -BeNullOrEmpty
+            @($script:isolationResults).Count | Should -Be 1
+            $script:isolationResults[0].ComputerName | Should -Be 'SRV02'
+        }
+    }
+}

--- a/en-US/about_PSWinOps.help.txt
+++ b/en-US/about_PSWinOps.help.txt
@@ -177,7 +177,7 @@ FUNCTION DOMAINS
 
       Get-AuditPolicy
 
-  system (16 functions)
+  system (17 functions)
     Functions for general system information, state,
     disk cleanup, profile management, and real-time monitoring.
 
@@ -195,6 +195,7 @@ FUNCTION DOMAINS
       Get-StartupProgram
       Get-SystemSummary
       Remove-UserProfile
+      Set-EnvironmentVariable
       Set-PageFile
       Show-SystemMonitor
 


### PR DESCRIPTION
Closes #69

## Summary
Sets a Machine- or User-scoped environment variable using [Environment]::SetEnvironmentVariable, the symmetric writer for Get-EnvironmentVariable. Supports -WhatIf/-Confirm (ConfirmImpact Medium). An empty Value deletes the variable. User scope targets the executing account profile when run remotely; already-running processes will not see the change until restarted.

## Files touched
- `Public/system/Set-EnvironmentVariable.ps1` — implementation
- `Tests/Public/system/Set-EnvironmentVariable.Tests.ps1` — Pester v5 suite
- `PSWinOps.psd1` — FunctionsToExport, ModuleVersion (0.5.0 -> 0.6.0), ReleaseNotes
- `PSWinOps.Format.ps1xml` — reuses existing `<View>` for `PSWinOps.EnvironmentVariable` (comment updated; no new view)
- `en-US/about_PSWinOps.help.txt` — system domain count 16 -> 17, function list, type registry

## Conformance checklist (audited locally by fn-quality-gate)
- [x] UTF-8 BOM + CRLF on both new files
- [x] Approved PowerShell verb (Set)
- [x] `FunctionsToExport` present once; Set-EnvironmentVariable inserted alphabetically before Set-IISBindingCertificate/Set-PageFile
- [x] `PSTypeName` consistent across .ps1 / Format.ps1xml / about help (PSWinOps.EnvironmentVariable, reused)
- [x] No `Write-Host`, no `ToString('o')`, no WMI cmdlets in the diff
- [x] `PSWinOps.Format.ps1xml` is valid XML with a matching `<View>`

## Verification
Dynamic verification (Test-ModuleManifest, PSScriptAnalyzer, Pester matrix) runs on the Windows CI for this PR. Merge once all required checks are green.