### PR TITLE
feat(system): add Stop-ProcessTree

### DIFF
--- a/.kdust/chains/stop-processtree-2607061440.yaml
+++ b/.kdust/chains/stop-processtree-2607061440.yaml
@@ -1,0 +1,7 @@
+chain: pswinops-function-author
+function: Stop-ProcessTree
+domain: system
+created: 2026-07-06T14:43:59Z
+created_by: pswinops-fn-spec-analyst
+chain_branch: kdust/chain/pswinops-fn-stop-processtree-2607061440
+spec_path: work/stop-processtree/spec.yaml

--- a/PSWinOps.Format.ps1xml
+++ b/PSWinOps.Format.ps1xml
@@ -7761,5 +7761,71 @@
         </ListEntries>
       </ListControl>
     </View>
+    <!-- ============================================================ -->
+    <!-- PSWinOps.ProcessKillResult                                   -->
+    <!-- Used by: Stop-ProcessTree                                    -->
+    <!-- ============================================================ -->
+    <View>
+      <Name>PSWinOps.ProcessKillResult</Name>
+      <ViewSelectedBy>
+        <TypeName>PSWinOps.ProcessKillResult</TypeName>
+      </ViewSelectedBy>
+      <TableControl>
+        <AutoSize />
+        <TableHeaders>
+          <TableColumnHeader>
+            <Label>ComputerName</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>ProcessId</Label>
+            <Alignment>Right</Alignment>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Name</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>ParentProcessId</Label>
+            <Alignment>Right</Alignment>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Depth</Label>
+            <Alignment>Right</Alignment>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Killed</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Error</Label>
+          </TableColumnHeader>
+        </TableHeaders>
+        <TableRowEntries>
+          <TableRowEntry>
+            <TableColumnItems>
+              <TableColumnItem>
+                <PropertyName>ComputerName</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>ProcessId</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>Name</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>ParentProcessId</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>Depth</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>Killed</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>Error</PropertyName>
+              </TableColumnItem>
+            </TableColumnItems>
+          </TableRowEntry>
+        </TableRowEntries>
+      </TableControl>
+    </View>
   </ViewDefinitions>
 </Configuration>

--- a/PSWinOps.psd1
+++ b/PSWinOps.psd1
@@ -197,6 +197,7 @@
         'Show-PingMonitor',
         'Show-SystemMonitor',
         'Show-WindowsUpdate',
+        'Stop-ProcessTree',
         'Sync-NTPTime',
         'Test-DNSResolution',
         'Test-IISBindingCertificate',

--- a/PSWinOps.psd1
+++ b/PSWinOps.psd1
@@ -12,7 +12,7 @@
     RootModule           = 'PSWinOps.psm1'
 
     # Version number of this module.
-    ModuleVersion        = '0.6.0'
+    ModuleVersion        = '0.7.0'
 
     # Supported PSEditions
     # Core is supported on Windows only; the module-level guard in PSWinOps.psm1 blocks
@@ -274,7 +274,11 @@
             # IconUri = ''
 
             # ReleaseNotes of this module
-            ReleaseNotes = '## 0.6.0 - 2026-07-06 UTC
+            ReleaseNotes = '## 0.7.0 - 2026-07-06 UTC
+### Added
+- Stop-ProcessTree: Terminate a process and its entire descendant tree, leaves first
+
+## 0.6.0 - 2026-07-06 UTC
 ### Added
 - Set-EnvironmentVariable: Sets or deletes a Machine- or User-scoped environment variable on local or remote computers
 

--- a/Public/system/Stop-ProcessTree.ps1
+++ b/Public/system/Stop-ProcessTree.ps1
@@ -1,0 +1,256 @@
+﻿#Requires -Version 5.1
+function Stop-ProcessTree {
+    <#
+    .SYNOPSIS
+        Terminate a process and its entire descendant tree, leaves first
+
+    .DESCRIPTION
+        Builds the descendant tree of one or more root processes from
+        Win32_Process ParentProcessId and terminates every node, killing leaves
+        before the root. Select roots by -Id or -Name (mutually exclusive), target
+        local or remote machines, and preview with -WhatIf. Termination is
+        irreversible (ConfirmImpact High).
+
+    .PARAMETER ComputerName
+        One or more computer names to target. Defaults to the local computer.
+        Accepts pipeline input by value and by property name.
+
+    .PARAMETER Credential
+        Optional credential used to authenticate against remote computers.
+        Ignored when the target is the local computer.
+
+    .PARAMETER Id
+        Root process ID(s) whose descendant tree is terminated.
+        Mutually exclusive with -Name. Accepts pipeline input by property name.
+
+    .PARAMETER Name
+        Root process name(s), without the '.exe' extension.
+        Mutually exclusive with -Id. Accepts pipeline input by property name.
+
+    .EXAMPLE
+        Stop-ProcessTree -Id 1234
+
+        Terminates process 1234 and all of its descendants on the local computer.
+
+    .EXAMPLE
+        Stop-ProcessTree -Name 'chrome' -ComputerName 'SRV01'
+
+        Terminates every 'chrome' process tree found on SRV01.
+
+    .EXAMPLE
+        'SRV01', 'SRV02' | Stop-ProcessTree -Name 'notepad' -WhatIf
+
+        Previews termination of every 'notepad' process tree on SRV01 and SRV02
+        without actually terminating anything.
+
+    .OUTPUTS
+        PSWinOps.ProcessKillResult
+        Returns one object per process examined (root, descendant, or unresolved
+        root), including whether it was killed and any error encountered.
+
+    .NOTES
+        Author: Franck SALLET
+        Version: 1.0.0
+        Last Modified: 2026-07-06
+        Requires: PowerShell 5.1+ / Windows only
+        Requires: Sufficient privileges to terminate the target processes
+
+    .LINK
+        https://github.com/k9fr4n/PSWinOps
+    #>
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High', DefaultParameterSetName = 'ById')]
+    [OutputType('PSWinOps.ProcessKillResult')]
+    param(
+        [Parameter(Mandatory = $false, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]$ComputerName = @($env:COMPUTERNAME),
+
+        [Parameter(Mandatory = $false)]
+        [System.Management.Automation.PSCredential]$Credential,
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'ById', ValueFromPipelineByPropertyName = $true)]
+        [ValidateNotNullOrEmpty()]
+        [int[]]$Id,
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'ByName', ValueFromPipelineByPropertyName = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]$Name
+    )
+
+    begin {
+        Write-Verbose -Message "[$($MyInvocation.MyCommand)] Starting"
+
+        # --- Protected system PIDs never eligible for termination --------------
+        $protectedPids = @(0, 4)
+        $maxDepth = 100
+
+        # --- Scriptblocks executed locally or remotely via Invoke-RemoteOrLocal
+        $queryScriptBlock = {
+            Get-CimInstance -ClassName 'Win32_Process' -ErrorAction Stop |
+                Select-Object -Property ProcessId, ParentProcessId, Name
+        }
+
+        $terminateScriptBlock = {
+            param($targetPid)
+
+            $targetProcess = Get-CimInstance -ClassName 'Win32_Process' -Filter "ProcessId=$targetPid" -ErrorAction Stop
+            if (-not $targetProcess) {
+                throw "Process $targetPid no longer exists"
+            }
+            Invoke-CimMethod -InputObject $targetProcess -MethodName 'Terminate' -ErrorAction Stop
+        }
+    }
+
+    process {
+        foreach ($targetComputer in $ComputerName) {
+            Write-Verbose -Message "[$($MyInvocation.MyCommand)] Processing $targetComputer"
+
+            try {
+                $processList = Invoke-RemoteOrLocal -ComputerName $targetComputer -Credential $Credential -ScriptBlock $queryScriptBlock
+
+                # ===============================================================
+                # RESOLVE ROOT PROCESSES
+                # ===============================================================
+                $rootProcesses = [System.Collections.Generic.List[object]]::new()
+                $unresolvedRows = [System.Collections.Generic.List[object]]::new()
+
+                if ($PSCmdlet.ParameterSetName -eq 'ById') {
+                    foreach ($rootId in $Id) {
+                        $match = $processList | Where-Object -Property ProcessId -eq $rootId
+                        if ($match) {
+                            $rootProcesses.Add($match)
+                        } else {
+                            $unresolvedRows.Add([PSCustomObject]@{
+                                PSTypeName      = 'PSWinOps.ProcessKillResult'
+                                ComputerName    = $targetComputer
+                                ProcessId       = $rootId
+                                Name            = $null
+                                ParentProcessId = $null
+                                Depth           = 0
+                                Killed          = $false
+                                Error           = 'Process not found'
+                                Timestamp       = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
+                            })
+                        }
+                    }
+                } else {
+                    foreach ($rootName in $Name) {
+                        $expectedName = if ($rootName -like '*.exe') { $rootName } else { "$rootName.exe" }
+                        $matches = $processList | Where-Object -Property Name -eq $expectedName
+                        if ($matches) {
+                            foreach ($match in $matches) {
+                                $rootProcesses.Add($match)
+                            }
+                        } else {
+                            $unresolvedRows.Add([PSCustomObject]@{
+                                PSTypeName      = 'PSWinOps.ProcessKillResult'
+                                ComputerName    = $targetComputer
+                                ProcessId       = $null
+                                Name            = $rootName
+                                ParentProcessId = $null
+                                Depth           = 0
+                                Killed          = $false
+                                Error           = 'Process not found'
+                                Timestamp       = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
+                            })
+                        }
+                    }
+                }
+
+                foreach ($unresolvedRow in $unresolvedRows) {
+                    $unresolvedRow
+                }
+
+                # ===============================================================
+                # BUILD DESCENDANT TREE (breadth-first) AND KILL LEAVES FIRST
+                # ===============================================================
+                foreach ($rootProcess in $rootProcesses) {
+                    $treeNodes = [System.Collections.Generic.List[object]]::new()
+                    $visitedPids = [System.Collections.Generic.HashSet[int]]::new()
+                    $queue = [System.Collections.Generic.Queue[object]]::new()
+
+                    $null = $visitedPids.Add([int]$rootProcess.ProcessId)
+                    $queue.Enqueue([PSCustomObject]@{ Process = $rootProcess; Depth = 0 })
+
+                    while ($queue.Count -gt 0) {
+                        $current = $queue.Dequeue()
+                        $treeNodes.Add($current)
+
+                        if ($current.Depth -ge $maxDepth) {
+                            Write-Verbose -Message "[$($MyInvocation.MyCommand)] Depth bound ($maxDepth) reached at PID $($current.Process.ProcessId), stopping descent"
+                            continue
+                        }
+
+                        $children = $processList | Where-Object -Property ParentProcessId -eq $current.Process.ProcessId
+                        foreach ($child in $children) {
+                            $childPid = [int]$child.ProcessId
+                            if (-not $visitedPids.Contains($childPid)) {
+                                $null = $visitedPids.Add($childPid)
+                                $queue.Enqueue([PSCustomObject]@{ Process = $child; Depth = $current.Depth + 1 })
+                            }
+                        }
+                    }
+
+                    # Leaves first: deepest nodes terminated before their ancestors.
+                    $killOrder = $treeNodes | Sort-Object -Property Depth -Descending
+
+                    foreach ($node in $killOrder) {
+                        $nodePid = [int]$node.Process.ProcessId
+                        $nodeName = $node.Process.Name
+                        $nodeParentPid = $node.Process.ParentProcessId
+
+                        if ($nodePid -in $protectedPids) {
+                            [PSCustomObject]@{
+                                PSTypeName      = 'PSWinOps.ProcessKillResult'
+                                ComputerName    = $targetComputer
+                                ProcessId       = $nodePid
+                                Name            = $nodeName
+                                ParentProcessId = $nodeParentPid
+                                Depth           = $node.Depth
+                                Killed          = $false
+                                Error           = 'Refused: protected system process'
+                                Timestamp       = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
+                            }
+                            continue
+                        }
+
+                        if ($PSCmdlet.ShouldProcess("$targetComputer PID $nodePid ($nodeName)", 'Terminate process')) {
+                            $killed = $false
+                            $killError = $null
+
+                            try {
+                                $terminateResult = Invoke-RemoteOrLocal -ComputerName $targetComputer -Credential $Credential -ScriptBlock $terminateScriptBlock -ArgumentList @($nodePid)
+                                if ($terminateResult.ReturnValue -eq 0) {
+                                    $killed = $true
+                                } else {
+                                    $killError = "Terminate returned code $($terminateResult.ReturnValue)"
+                                }
+                            } catch {
+                                $killError = $_.Exception.Message
+                            }
+
+                            [PSCustomObject]@{
+                                PSTypeName      = 'PSWinOps.ProcessKillResult'
+                                ComputerName    = $targetComputer
+                                ProcessId       = $nodePid
+                                Name            = $nodeName
+                                ParentProcessId = $nodeParentPid
+                                Depth           = $node.Depth
+                                Killed          = $killed
+                                Error           = $killError
+                                Timestamp       = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
+                            }
+                        }
+                    }
+                }
+            } catch {
+                Write-Error -Message "[$($MyInvocation.MyCommand)] Failed on '$targetComputer': $_"
+                continue
+            }
+        }
+    }
+
+    end {
+        Write-Verbose -Message "[$($MyInvocation.MyCommand)] Completed"
+    }
+}

--- a/Public/system/Stop-ProcessTree.ps1
+++ b/Public/system/Stop-ProcessTree.ps1
@@ -136,9 +136,9 @@ function Stop-ProcessTree {
                 } else {
                     foreach ($rootName in $Name) {
                         $expectedName = if ($rootName -like '*.exe') { $rootName } else { "$rootName.exe" }
-                        $matches = $processList | Where-Object -Property Name -eq $expectedName
-                        if ($matches) {
-                            foreach ($match in $matches) {
+                        $nameMatches = $processList | Where-Object -Property Name -eq $expectedName
+                        if ($nameMatches) {
+                            foreach ($match in $nameMatches) {
                                 $rootProcesses.Add($match)
                             }
                         } else {

--- a/Public/system/Stop-ProcessTree.ps1
+++ b/Public/system/Stop-ProcessTree.ps1
@@ -181,6 +181,15 @@ function Stop-ProcessTree {
                             continue
                         }
 
+                        # Never descend into a protected system process: its descendants
+                        # are core kernel/session processes and terminating them would
+                        # crash the machine. The protected node itself is still emitted
+                        # as a refused row by the kill loop below.
+                        if ([int]$current.Process.ProcessId -in $protectedPids) {
+                            Write-Verbose -Message "[$($MyInvocation.MyCommand)] Protected PID $($current.Process.ProcessId) reached, not descending into its children"
+                            continue
+                        }
+
                         $children = $processList | Where-Object -Property ParentProcessId -eq $current.Process.ProcessId
                         foreach ($child in $children) {
                             $childPid = [int]$child.ProcessId

--- a/Tests/Public/system/Stop-ProcessTree.Tests.ps1
+++ b/Tests/Public/system/Stop-ProcessTree.Tests.ps1
@@ -1,0 +1,395 @@
+﻿#Requires -Version 5.1
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+BeforeAll {
+    $script:modulePath = Split-Path -Path (Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent) -Parent
+    Import-Module -Name (Join-Path -Path $script:modulePath -ChildPath 'PSWinOps.psd1') -Force
+}
+
+Describe 'Stop-ProcessTree' {
+    BeforeAll {
+        # ---- Reusable process fixtures ----
+        # 0/4  : protected system PIDs (no children in this fixture)
+        # 1000 : root -> 2000 -> 3000 (three-level tree)
+        # 5000 : standalone leaf, resolvable by -Name 'notepad'
+        $script:mockProcessList = @(
+            [PSCustomObject]@{ ProcessId = 0; ParentProcessId = 0; Name = 'System Idle Process' }
+            [PSCustomObject]@{ ProcessId = 4; ParentProcessId = 0; Name = 'System' }
+            [PSCustomObject]@{ ProcessId = 1000; ParentProcessId = 4; Name = 'parent.exe' }
+            [PSCustomObject]@{ ProcessId = 2000; ParentProcessId = 1000; Name = 'child.exe' }
+            [PSCustomObject]@{ ProcessId = 3000; ParentProcessId = 2000; Name = 'grandchild.exe' }
+            [PSCustomObject]@{ ProcessId = 5000; ParentProcessId = 1; Name = 'notepad.exe' }
+        )
+
+        # Two processes whose ParentProcessId points at each other (recycled/looping PIDs).
+        $script:cyclicProcessList = @(
+            [PSCustomObject]@{ ProcessId = 8000; ParentProcessId = 8001; Name = 'cyclea.exe' }
+            [PSCustomObject]@{ ProcessId = 8001; ParentProcessId = 8000; Name = 'cycleb.exe' }
+        )
+
+        function New-ChainProcessList {
+            param(
+                [int]$Count,
+                [int]$StartPid = 10000
+            )
+
+            $list = [System.Collections.Generic.List[object]]::new()
+            for ($i = 0; $i -lt $Count; $i++) {
+                $currentPid = $StartPid + $i
+                $parentPid = if ($i -eq 0) { 1 } else { $StartPid + $i - 1 }
+                $list.Add([PSCustomObject]@{ ProcessId = $currentPid; ParentProcessId = $parentPid; Name = "chain$i.exe" })
+            }
+            return $list
+        }
+    }
+
+    Context 'Local happy path by -Id: tree built, leaves terminated before root' {
+        BeforeAll {
+            $script:terminateOrder = [System.Collections.Generic.List[int]]::new()
+
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -MockWith {
+                param($ComputerName, $Credential, $ScriptBlock, $ArgumentList)
+
+                if ($ArgumentList -and $ArgumentList.Count -gt 0) {
+                    $targetPid = $ArgumentList[0]
+                    $script:terminateOrder.Add($targetPid)
+                    return [PSCustomObject]@{ ReturnValue = 0 }
+                }
+
+                return $script:mockProcessList
+            }
+
+            $script:idResult = Stop-ProcessTree -Id 1000 -Confirm:$false
+        }
+
+        It -Name 'Should return one row per node in the tree (root + 2 descendants)' -Test {
+            $script:idResult | Should -HaveCount 3
+        }
+
+        It -Name 'Should terminate the deepest descendant first' -Test {
+            $script:terminateOrder[0] | Should -Be 3000
+        }
+
+        It -Name 'Should terminate the root last' -Test {
+            $script:terminateOrder[-1] | Should -Be 1000
+        }
+
+        It -Name 'Should mark every node as Killed' -Test {
+            foreach ($row in $script:idResult) {
+                $row.Killed | Should -BeTrue
+            }
+        }
+
+        It -Name 'Should have PSTypeName PSWinOps.ProcessKillResult' -Test {
+            $script:idResult[0].PSObject.TypeNames[0] | Should -Be 'PSWinOps.ProcessKillResult'
+        }
+
+        It -Name 'Should set ComputerName to the local computer' -Test {
+            $script:idResult[0].ComputerName | Should -Be $env:COMPUTERNAME
+        }
+
+        It -Name 'Should include a Depth of 0 for the root node' -Test {
+            ($script:idResult | Where-Object -Property ProcessId -eq 1000).Depth | Should -Be 0
+        }
+
+        It -Name 'Should include a Depth of 2 for the grandchild node' -Test {
+            ($script:idResult | Where-Object -Property ProcessId -eq 3000).Depth | Should -Be 2
+        }
+
+        It -Name 'Should format Timestamp as yyyy-MM-dd HH:mm:ss' -Test {
+            $script:idResult[0].Timestamp | Should -Match "^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$"
+        }
+    }
+
+    Context 'By -Name resolves root PID(s)' {
+        BeforeAll {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -MockWith {
+                param($ComputerName, $Credential, $ScriptBlock, $ArgumentList)
+
+                if ($ArgumentList -and $ArgumentList.Count -gt 0) {
+                    return [PSCustomObject]@{ ReturnValue = 0 }
+                }
+
+                return $script:mockProcessList
+            }
+
+            $script:nameResult = Stop-ProcessTree -Name 'notepad' -Confirm:$false
+        }
+
+        It -Name 'Should resolve the root PID from the process name' -Test {
+            $script:nameResult | Should -HaveCount 1
+            $script:nameResult[0].ProcessId | Should -Be 5000
+        }
+
+        It -Name 'Should terminate the resolved root' -Test {
+            $script:nameResult[0].Killed | Should -BeTrue
+        }
+
+        It -Name 'Should return an unresolved row when the name does not match any process' -Test {
+            $unresolved = Stop-ProcessTree -Name 'doesnotexist' -Confirm:$false
+            $unresolved | Should -HaveCount 1
+            $unresolved[0].Killed | Should -BeFalse
+            $unresolved[0].Error | Should -Be 'Process not found'
+        }
+    }
+
+    Context 'Explicit remote machine via -ComputerName' {
+        BeforeAll {
+            $script:remoteCalls = [System.Collections.Generic.List[object]]::new()
+
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -MockWith {
+                param($ComputerName, $Credential, $ScriptBlock, $ArgumentList)
+
+                $script:remoteCalls.Add([PSCustomObject]@{ ComputerName = $ComputerName; Credential = $Credential })
+
+                if ($ArgumentList -and $ArgumentList.Count -gt 0) {
+                    return [PSCustomObject]@{ ReturnValue = 0 }
+                }
+
+                return $script:mockProcessList
+            }
+
+            $script:cred = [System.Management.Automation.PSCredential]::new(
+                'DOMAIN\svc', (ConvertTo-SecureString -String 'p@ssw0rd' -AsPlainText -Force)
+            )
+            $script:remoteResult = Stop-ProcessTree -Id 5000 -ComputerName 'SRV01' -Credential $script:cred -Confirm:$false
+        }
+
+        It -Name 'Should set ComputerName to the remote machine on the output rows' -Test {
+            $script:remoteResult[0].ComputerName | Should -Be 'SRV01'
+        }
+
+        It -Name 'Should call Invoke-RemoteOrLocal against the remote machine' -Test {
+            $script:remoteCalls | Where-Object -Property ComputerName -eq 'SRV01' | Should -Not -BeNullOrEmpty
+        }
+
+        It -Name 'Should propagate the supplied Credential to Invoke-RemoteOrLocal' -Test {
+            foreach ($call in $script:remoteCalls) {
+                $call.Credential | Should -Be $script:cred
+            }
+        }
+
+        It -Name 'Should call Invoke-RemoteOrLocal for the query and the terminate step' -Test {
+            Stop-ProcessTree -Id 5000 -ComputerName 'SRV01' -Confirm:$false
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -Times 2 -Exactly
+        }
+    }
+
+    Context 'Pipeline of multiple machine names' {
+        BeforeAll {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -MockWith {
+                param($ComputerName, $Credential, $ScriptBlock, $ArgumentList)
+
+                if ($ArgumentList -and $ArgumentList.Count -gt 0) {
+                    return [PSCustomObject]@{ ReturnValue = 0 }
+                }
+
+                return $script:mockProcessList
+            }
+
+            $script:pipeResults = 'SRV01', 'SRV02' | Stop-ProcessTree -Id 5000 -Confirm:$false
+        }
+
+        It -Name 'Should process each computer from the pipeline' -Test {
+            $script:pipeResults | Should -HaveCount 2
+        }
+
+        It -Name 'Should return correct ComputerName for the first server' -Test {
+            $script:pipeResults[0].ComputerName | Should -Be 'SRV01'
+        }
+
+        It -Name 'Should return correct ComputerName for the second server' -Test {
+            $script:pipeResults[1].ComputerName | Should -Be 'SRV02'
+        }
+    }
+
+    Context 'Per-machine failure: mock throws, function continues and writes error' {
+        BeforeAll {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -MockWith {
+                param($ComputerName, $Credential, $ScriptBlock, $ArgumentList)
+
+                if ($ComputerName -eq 'BADHOST') {
+                    throw 'Connection failed'
+                }
+
+                if ($ArgumentList -and $ArgumentList.Count -gt 0) {
+                    return [PSCustomObject]@{ ReturnValue = 0 }
+                }
+
+                return $script:mockProcessList
+            }
+        }
+
+        It -Name 'Should write an error for the failing machine but still process the next one' -Test {
+            $script:mixedResults = 'BADHOST', 'GOODHOST' |
+                Stop-ProcessTree -Id 5000 -Confirm:$false -ErrorAction SilentlyContinue -ErrorVariable script:capturedError
+
+            $script:capturedError | Should -Not -BeNullOrEmpty
+            $script:mixedResults | Should -HaveCount 1
+            $script:mixedResults[0].ComputerName | Should -Be 'GOODHOST'
+        }
+    }
+
+    Context 'Process gone between enum and kill: Killed=$false, Error set, continues' {
+        BeforeAll {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -MockWith {
+                param($ComputerName, $Credential, $ScriptBlock, $ArgumentList)
+
+                if ($ArgumentList -and $ArgumentList.Count -gt 0) {
+                    $targetPid = $ArgumentList[0]
+                    if ($targetPid -eq 2000) {
+                        throw "Process $targetPid no longer exists"
+                    }
+                    return [PSCustomObject]@{ ReturnValue = 0 }
+                }
+
+                return $script:mockProcessList
+            }
+
+            $script:raceResult = Stop-ProcessTree -Id 1000 -Confirm:$false
+        }
+
+        It -Name 'Should mark the vanished process as not killed with an Error message' -Test {
+            $vanished = $script:raceResult | Where-Object -Property ProcessId -eq 2000
+            $vanished.Killed | Should -BeFalse
+            $vanished.Error | Should -BeLike '*no longer exists*'
+        }
+
+        It -Name 'Should still terminate the sibling nodes in the tree' -Test {
+            ($script:raceResult | Where-Object -Property ProcessId -eq 3000).Killed | Should -BeTrue
+            ($script:raceResult | Where-Object -Property ProcessId -eq 1000).Killed | Should -BeTrue
+        }
+
+        It -Name 'Should not throw and should return a row for every node' -Test {
+            $script:raceResult | Should -HaveCount 3
+        }
+    }
+
+    Context 'Protected PID 0/4 refused (never terminated)' {
+        BeforeAll {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -MockWith {
+                param($ComputerName, $Credential, $ScriptBlock, $ArgumentList)
+
+                if ($ArgumentList -and $ArgumentList.Count -gt 0) {
+                    $targetPid = $ArgumentList[0]
+                    if ($targetPid -in @(0, 4)) {
+                        throw 'Terminate must never be called on a protected PID'
+                    }
+                    return [PSCustomObject]@{ ReturnValue = 0 }
+                }
+
+                return $script:mockProcessList
+            }
+        }
+
+        It -Name 'Should refuse to terminate PID 0 (System Idle Process)' -Test {
+            $result = Stop-ProcessTree -Id 0 -Confirm:$false
+            $result | Should -HaveCount 1
+            $result[0].Killed | Should -BeFalse
+            $result[0].Error | Should -Be 'Refused: protected system process'
+        }
+
+        It -Name 'Should refuse to terminate PID 4 (System)' -Test {
+            $result = Stop-ProcessTree -Id 4 -Confirm:$false
+            $result | Should -HaveCount 1
+            $result[0].Killed | Should -BeFalse
+            $result[0].Error | Should -Be 'Refused: protected system process'
+        }
+    }
+
+    Context 'Loop/recycled PID guard: visited set prevents infinite walk on a cycle' {
+        BeforeAll {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -MockWith {
+                param($ComputerName, $Credential, $ScriptBlock, $ArgumentList)
+
+                if ($ArgumentList -and $ArgumentList.Count -gt 0) {
+                    return [PSCustomObject]@{ ReturnValue = 0 }
+                }
+
+                return $script:cyclicProcessList
+            }
+
+            $script:cyclicResult = Stop-ProcessTree -Id 8000 -Confirm:$false
+        }
+
+        It -Name 'Should visit each PID in the cycle exactly once and terminate' -Test {
+            $script:cyclicResult | Should -HaveCount 2
+        }
+
+        It -Name 'Should not revisit the already-seen root PID as a child of its own child' -Test {
+            ($script:cyclicResult | Select-Object -ExpandProperty ProcessId | Sort-Object -Unique) | Should -Be @(8000, 8001)
+        }
+    }
+
+    Context 'Loop/recycled PID guard: hard depth bound stops runaway chains' {
+        BeforeAll {
+            $script:deepChain = New-ChainProcessList -Count 150 -StartPid 10000
+
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -MockWith {
+                param($ComputerName, $Credential, $ScriptBlock, $ArgumentList)
+
+                if ($ArgumentList -and $ArgumentList.Count -gt 0) {
+                    return [PSCustomObject]@{ ReturnValue = 0 }
+                }
+
+                return $script:deepChain
+            }
+
+            $script:chainResult = Stop-ProcessTree -Id 10000 -Confirm:$false
+        }
+
+        It -Name 'Should stop descending once the depth bound (100) is reached' -Test {
+            $script:chainResult | Should -HaveCount 101
+        }
+
+        It -Name 'Should not produce a node with a Depth greater than 100' -Test {
+            ($script:chainResult | Measure-Object -Property Depth -Maximum).Maximum | Should -Be 100
+        }
+    }
+
+    Context '-WhatIf lists tree without calling Invoke-CimMethod Terminate' {
+        BeforeAll {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -MockWith {
+                param($ComputerName, $Credential, $ScriptBlock, $ArgumentList)
+
+                if ($ArgumentList -and $ArgumentList.Count -gt 0) {
+                    throw 'Terminate must never be invoked under -WhatIf'
+                }
+
+                return $script:mockProcessList
+            }
+        }
+
+        It -Name 'Should not throw and should not terminate anything with -WhatIf' -Test {
+            { Stop-ProcessTree -Id 1000 -WhatIf } | Should -Not -Throw
+        }
+
+        It -Name 'Should not produce any Killed=$true rows with -WhatIf' -Test {
+            $whatIfResult = Stop-ProcessTree -Id 1000 -WhatIf
+            $whatIfResult | Where-Object -Property Killed -eq $true | Should -BeNullOrEmpty
+        }
+
+        It -Name 'Should call Invoke-RemoteOrLocal only for the read-only query, never for terminate' -Test {
+            Stop-ProcessTree -Id 1000 -WhatIf
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -Times 1 -Exactly
+        }
+    }
+
+    Context 'Parameter set validation: -Id and -Name are mutually exclusive' {
+        It -Name 'Should throw when both -Id and -Name are supplied' -Test {
+            { Stop-ProcessTree -Id 1000 -Name 'notepad' -Confirm:$false } | Should -Throw
+        }
+
+        It -Name 'Should throw when -Id is an empty array' -Test {
+            { Stop-ProcessTree -Id @() -Confirm:$false } | Should -Throw
+        }
+
+        It -Name 'Should throw when -Name is an empty string' -Test {
+            { Stop-ProcessTree -Name '' -Confirm:$false } | Should -Throw
+        }
+
+        It -Name 'Should throw when neither -Id nor -Name is supplied' -Test {
+            { Stop-ProcessTree -Confirm:$false } | Should -Throw
+        }
+    }
+}

--- a/en-US/about_PSWinOps.help.txt
+++ b/en-US/about_PSWinOps.help.txt
@@ -177,7 +177,7 @@ FUNCTION DOMAINS
 
       Get-AuditPolicy
 
-  system (17 functions)
+  system (18 functions)
     Functions for general system information, state,
     disk cleanup, profile management, and real-time monitoring.
 
@@ -198,6 +198,7 @@ FUNCTION DOMAINS
       Set-EnvironmentVariable
       Set-PageFile
       Show-SystemMonitor
+      Stop-ProcessTree
 
   windowsupdate (4 functions)
     Functions for querying and managing Windows Update
@@ -390,6 +391,7 @@ PSWINOPS TYPE REGISTRY
       PSWinOps.PendingReboot
       PSWinOps.PortConnectivity
       PSWinOps.PrintServerHealth
+      PSWinOps.ProcessKillResult
       PSWinOps.ProcessPort
       PSWinOps.ProxyConfiguration
       PSWinOps.ProxyTestResult


### PR DESCRIPTION
## Summary
Builds the descendant tree of one or more root processes from Win32_Process ParentProcessId and terminates every node, killing leaves before the root. Select roots by -Id or -Name (mutually exclusive), target local or remote machines, and preview with -WhatIf. Termination is irreversible (ConfirmImpact High).

Closes #70.

## Files touched
- `Public/system/Stop-ProcessTree.ps1` — implementation
- `Tests/Public/system/Stop-ProcessTree.Tests.ps1` — Pester v5 suite
- `PSWinOps.psd1` — FunctionsToExport, ModuleVersion, ReleaseNotes
- `PSWinOps.Format.ps1xml` — new `<View>` for `PSWinOps.ProcessKillResult`
- `en-US/about_PSWinOps.help.txt` — counters bumped

## Conformance checklist (audited locally by fn-quality-gate)
- [x] UTF-8 BOM + CRLF on both new files
- [x] Approved PowerShell verb (Stop)
- [x] `FunctionsToExport` present once, inserted at the correct sorted position
- [x] `PSTypeName` consistent across .ps1 / Format.ps1xml / about help (`PSWinOps.ProcessKillResult`)
- [x] No `Write-Host`, no `ToString('o')`, no WMI cmdlets in the diff
- [x] `PSWinOps.Format.ps1xml` is valid XML with a matching Table `<View>`

## Verification
Dynamic verification (Test-ModuleManifest, PSScriptAnalyzer, Pester matrix) runs on the Windows CI for this PR. Merge once all required checks are green.
