### PR TITLE
feat(system): add Get-ServiceAccount

### DIFF
--- a/.kdust/chains/get-serviceaccount-2607062004.yaml
+++ b/.kdust/chains/get-serviceaccount-2607062004.yaml
@@ -1,0 +1,7 @@
+chain: pswinops-function-author
+function: Get-ServiceAccount
+domain: system
+created: 2026-07-06T20:05:12Z
+created_by: pswinops-fn-spec-analyst
+chain_branch: kdust/chain/pswinops-fn-get-serviceaccount-2607062004
+spec_path: work/get-serviceaccount/spec.yaml

--- a/PSWinOps.Format.ps1xml
+++ b/PSWinOps.Format.ps1xml
@@ -2710,6 +2710,75 @@
       </TableControl>
     </View>
     <!-- ============================================================ -->
+    <!-- PSWinOps.ServiceAccount                                      -->
+    <!-- Used by: Get-ServiceAccount                                  -->
+    <!-- ============================================================ -->
+    <View>
+      <Name>PSWinOps.ServiceAccount</Name>
+      <ViewSelectedBy>
+        <TypeName>PSWinOps.ServiceAccount</TypeName>
+      </ViewSelectedBy>
+      <TableControl>
+        <AutoSize />
+        <TableHeaders>
+          <TableColumnHeader>
+            <Label>ComputerName</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>ServiceName</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>DisplayName</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>StartName</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>StartMode</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>DelayedAutoStart</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>State</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>PathName</Label>
+          </TableColumnHeader>
+        </TableHeaders>
+        <TableRowEntries>
+          <TableRowEntry>
+            <TableColumnItems>
+              <TableColumnItem>
+                <PropertyName>ComputerName</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>ServiceName</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>DisplayName</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>StartName</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>StartMode</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>DelayedAutoStart</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>State</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>PathName</PropertyName>
+              </TableColumnItem>
+            </TableColumnItems>
+          </TableRowEntry>
+        </TableRowEntries>
+      </TableControl>
+    </View>
+    <!-- ============================================================ -->
     <!-- PSWinOps.ScheduledTaskDetail                                 -->
     <!-- Used by: Get-ScheduledTaskDetail                             -->
     <!-- ============================================================ -->

--- a/PSWinOps.psd1
+++ b/PSWinOps.psd1
@@ -12,7 +12,7 @@
     RootModule           = 'PSWinOps.psm1'
 
     # Version number of this module.
-    ModuleVersion        = '0.8.0'
+    ModuleVersion        = '0.9.0'
 
     # Supported PSEditions
     # Core is supported on Windows only; the module-level guard in PSWinOps.psm1 blocks
@@ -276,7 +276,11 @@
             # IconUri = ''
 
             # ReleaseNotes of this module
-            ReleaseNotes = '## 0.8.0 - 2026-07-06 UTC
+            ReleaseNotes = '## 0.9.0 - 2026-07-06 UTC
+### Added
+- Get-ServiceAccount: Audit service logon accounts across local or remote computers
+
+## 0.8.0 - 2026-07-06 UTC
 ### Added
 - Get-LogonFailure: Aggregate and decode Windows Security 4625 failed-logon events
 

--- a/PSWinOps.psd1
+++ b/PSWinOps.psd1
@@ -155,6 +155,7 @@
         'Get-RdpSessionLock',
         'Get-RDSHealth',
         'Get-ScheduledTaskDetail',
+        'Get-ServiceAccount',
         'Get-ServiceHealth',
         'Get-ShadowCopy',
         'Get-ShadowCopyStorage',

--- a/Public/system/Get-ServiceAccount.ps1
+++ b/Public/system/Get-ServiceAccount.ps1
@@ -1,0 +1,155 @@
+﻿#Requires -Version 5.1
+function Get-ServiceAccount {
+    <#
+    .SYNOPSIS
+        Audit service logon accounts across local or remote computers
+
+    .DESCRIPTION
+        Projects Win32_Service into a security-oriented view of service logon accounts,
+        reporting which account (Log On As / StartName) runs each service, its start mode,
+        delayed auto-start flag, current state, and full binary path. Supports wildcard
+        filtering by account and exclusion of built-in system accounts for multi-machine
+        service-account auditing.
+
+    .PARAMETER ComputerName
+        One or more computer names to target. Defaults to the local computer.
+        Accepts pipeline input by value and by property name.
+
+    .PARAMETER Account
+        Wildcard filter (-like) applied to StartName, e.g. 'DOMAIN\svc-*'. When omitted,
+        all service accounts are returned. Case-insensitive (PowerShell -like default).
+
+    .PARAMETER NonSystemOnly
+        Excludes built-in system logon accounts (LocalSystem, NT AUTHORITY\LocalService,
+        NT AUTHORITY\NetworkService, and their short forms) to isolate custom service
+        accounts. Comparison is case-insensitive. A null or empty StartName is treated
+        as a system account and excluded.
+
+    .PARAMETER Credential
+        Optional PSCredential object for authenticating to remote computers.
+        Not used for local queries.
+
+    .EXAMPLE
+        Get-ServiceAccount
+
+        Retrieves the logon account for every service on the local computer.
+
+    .EXAMPLE
+        Get-ServiceAccount -ComputerName 'SRV01' -Account 'CONTOSO\svc-*' -Credential (Get-Credential)
+
+        Retrieves services on SRV01 whose logon account matches 'CONTOSO\svc-*' using alternate credentials.
+
+    .EXAMPLE
+        'SRV01', 'SRV02' | Get-ServiceAccount -NonSystemOnly
+
+        Retrieves custom (non built-in) service accounts from multiple servers via pipeline.
+
+    .OUTPUTS
+        PSWinOps.ServiceAccount
+        Returns one object per matching service, with ComputerName, ServiceName,
+        DisplayName, StartName, StartMode, DelayedAutoStart, State, PathName, and Timestamp.
+
+    .NOTES
+        Author: Franck SALLET
+        Version: 1.0.0
+        Last Modified: 2026-07-06
+        Requires: PowerShell 5.1+ / Windows only
+
+    .LINK
+        https://github.com/k9fr4n/PSWinOps
+
+    .LINK
+        https://learn.microsoft.com/en-us/windows/win32/cimwin32prov/win32-service
+    #>
+    [CmdletBinding()]
+    [OutputType('PSWinOps.ServiceAccount')]
+    param(
+        [Parameter(Mandatory = $false, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [ValidateNotNullOrEmpty()]
+        [Alias('CN', 'DNSHostName')]
+        [string[]]$ComputerName = $env:COMPUTERNAME,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Account,
+
+        [Parameter(Mandatory = $false)]
+        [switch]$NonSystemOnly,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateNotNull()]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential
+    )
+
+    begin {
+        Write-Verbose "[$($MyInvocation.MyCommand)] Starting"
+
+        $excludedSystemAccounts = @(
+            'LocalSystem',
+            'NT AUTHORITY\LocalService',
+            'NT AUTHORITY\NetworkService',
+            'LocalService',
+            'NetworkService'
+        )
+
+        $scriptBlock = {
+            Get-CimInstance -ClassName Win32_Service -ErrorAction Stop |
+                Select-Object -Property Name, DisplayName, StartName, StartMode, DelayedAutoStart, State, PathName
+        }
+    }
+
+    process {
+        foreach ($computer in $ComputerName) {
+            Write-Verbose "[$($MyInvocation.MyCommand)] Processing $computer"
+
+            try {
+                $services = Invoke-RemoteOrLocal -ComputerName $computer -ScriptBlock $scriptBlock -Credential $Credential
+
+                foreach ($service in $services) {
+                    $startName = $service.StartName
+
+                    if ($Account -and ($startName -notlike $Account)) {
+                        continue
+                    }
+
+                    if ($NonSystemOnly) {
+                        $isSystemAccount = [string]::IsNullOrEmpty($startName)
+                        if (-not $isSystemAccount) {
+                            foreach ($excludedAccount in $excludedSystemAccounts) {
+                                if ($startName -eq $excludedAccount) {
+                                    $isSystemAccount = $true
+                                    break
+                                }
+                            }
+                        }
+                        if ($isSystemAccount) {
+                            continue
+                        }
+                    }
+
+                    [PSCustomObject]@{
+                        PSTypeName       = 'PSWinOps.ServiceAccount'
+                        ComputerName     = $computer
+                        ServiceName      = $service.Name
+                        DisplayName      = $service.DisplayName
+                        StartName        = $startName
+                        StartMode        = $service.StartMode
+                        DelayedAutoStart = $service.DelayedAutoStart
+                        State            = $service.State
+                        PathName         = $service.PathName
+                        Timestamp        = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
+                    }
+                }
+            } catch {
+                Write-Error "[$($MyInvocation.MyCommand)] Failed to query service accounts on ${computer}: $_"
+                continue
+            }
+        }
+    }
+
+    end {
+        Write-Verbose "[$($MyInvocation.MyCommand)] Completed"
+    }
+}

--- a/Tests/Public/system/Get-ServiceAccount.Tests.ps1
+++ b/Tests/Public/system/Get-ServiceAccount.Tests.ps1
@@ -1,0 +1,283 @@
+﻿#Requires -Version 5.1
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+
+param()
+
+BeforeAll {
+    $script:modulePath = Split-Path -Path (Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent) -Parent
+    Import-Module -Name (Join-Path -Path $script:modulePath -ChildPath 'PSWinOps.psd1') -Force
+
+    function global:Get-CimInstance {
+        param($ClassName, $ErrorAction)
+    }
+
+    $script:mockServices = @(
+        [PSCustomObject]@{
+            Name             = 'wuauserv'
+            DisplayName      = 'Windows Update'
+            StartName        = 'LocalSystem'
+            StartMode        = 'Manual'
+            DelayedAutoStart = $false
+            State            = 'Running'
+            PathName         = 'C:\Windows\System32\svchost.exe -k netsvcs -p'
+        },
+        [PSCustomObject]@{
+            Name             = 'MyCustomApp'
+            DisplayName      = 'Custom App Service'
+            StartName        = 'CONTOSO\svc-app'
+            StartMode        = 'Auto'
+            DelayedAutoStart = $true
+            State            = 'Running'
+            PathName         = '"C:\Program Files\App\app.exe" -config "C:\config.xml" --verbose'
+        },
+        [PSCustomObject]@{
+            Name             = 'netsvc'
+            DisplayName      = 'Network Service Host'
+            StartName        = 'NT AUTHORITY\NetworkService'
+            StartMode        = 'Auto'
+            DelayedAutoStart = $false
+            State            = 'Stopped'
+            PathName         = 'C:\Windows\System32\svchost.exe -k netsvcs'
+        },
+        [PSCustomObject]@{
+            Name             = 'localsvc'
+            DisplayName      = 'Local Service Host'
+            StartName        = 'nt authority\localservice'
+            StartMode        = 'Auto'
+            DelayedAutoStart = $false
+            State            = 'Running'
+            PathName         = 'C:\Windows\System32\svchost.exe -k localservice'
+        }
+    )
+}
+
+Describe -Name 'Get-ServiceAccount' -Fixture {
+
+    Context -Name 'Local happy path' -Fixture {
+
+        BeforeAll {
+            Mock -CommandName 'Get-CimInstance' -ModuleName 'PSWinOps' -MockWith {
+                return $script:mockServices
+            }
+        }
+
+        It -Name 'Should return a PSWinOps.ServiceAccount typed object for each service' -Test {
+            $result = Get-ServiceAccount
+            foreach ($item in $result) {
+                $item.PSObject.TypeNames[0] | Should -Be 'PSWinOps.ServiceAccount'
+            }
+        }
+
+        It -Name 'Should return all required output properties' -Test {
+            $result = Get-ServiceAccount
+            $props = $result[0].PSObject.Properties.Name
+            $props | Should -Contain 'ComputerName'
+            $props | Should -Contain 'ServiceName'
+            $props | Should -Contain 'DisplayName'
+            $props | Should -Contain 'StartName'
+            $props | Should -Contain 'StartMode'
+            $props | Should -Contain 'DelayedAutoStart'
+            $props | Should -Contain 'State'
+            $props | Should -Contain 'PathName'
+            $props | Should -Contain 'Timestamp'
+        }
+
+        It -Name 'Should set ComputerName to the local machine' -Test {
+            $result = Get-ServiceAccount
+            $result[0].ComputerName | Should -Be $env:COMPUTERNAME
+        }
+
+        It -Name 'Should map ServiceName from Win32_Service.Name' -Test {
+            $result = Get-ServiceAccount
+            ($result | Select-Object -ExpandProperty ServiceName) | Should -Contain 'wuauserv'
+            ($result | Select-Object -ExpandProperty ServiceName) | Should -Contain 'MyCustomApp'
+        }
+
+        It -Name 'Should format Timestamp as yyyy-MM-dd HH:mm:ss' -Test {
+            $result = Get-ServiceAccount
+            $result[0].Timestamp | Should -Match "^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$"
+        }
+
+        It -Name 'Should return one object per mocked service when no filter is applied' -Test {
+            $result = @(Get-ServiceAccount)
+            $result.Count | Should -Be 4
+        }
+    }
+
+    Context -Name 'Explicit remote machine' -Fixture {
+
+        BeforeAll {
+            Mock -CommandName 'Invoke-Command' -ModuleName 'PSWinOps' -MockWith {
+                return $script:mockServices
+            }
+        }
+
+        It -Name 'Should dispatch via Invoke-Command for a remote machine' -Test {
+            $result = Get-ServiceAccount -ComputerName 'SRV01'
+            Should -Invoke -CommandName 'Invoke-Command' -ModuleName 'PSWinOps' -Times 1 -Exactly
+            $result[0].ComputerName | Should -Be 'SRV01'
+        }
+
+        It -Name 'Should propagate Credential to Invoke-Command' -Test {
+            $securePwd = ConvertTo-SecureString -String 'P@ssw0rd123!' -AsPlainText -Force
+            $cred = [System.Management.Automation.PSCredential]::new('DOMAIN\svc', $securePwd)
+            Get-ServiceAccount -ComputerName 'SRV01' -Credential $cred | Out-Null
+            Should -Invoke -CommandName 'Invoke-Command' -ModuleName 'PSWinOps' -Times 1 -Exactly -ParameterFilter {
+                $Credential -eq $cred
+            }
+        }
+    }
+
+    Context -Name 'Pipeline of multiple machine names' -Fixture {
+
+        BeforeAll {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -MockWith {
+                $script:mockServices | ForEach-Object {
+                    [PSCustomObject]@{
+                        Name             = $_.Name
+                        DisplayName      = $_.DisplayName
+                        StartName        = $_.StartName
+                        StartMode        = $_.StartMode
+                        DelayedAutoStart = $_.DelayedAutoStart
+                        State            = $_.State
+                        PathName         = $_.PathName
+                    }
+                }
+            }
+        }
+
+        It -Name 'Should call Invoke-RemoteOrLocal once per machine and return results for each' -Test {
+            $result = 'SRV01', 'SRV02' | Get-ServiceAccount
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -Times 2 -Exactly
+            ($result | Select-Object -ExpandProperty ComputerName -Unique) | Should -Contain 'SRV01'
+            ($result | Select-Object -ExpandProperty ComputerName -Unique) | Should -Contain 'SRV02'
+        }
+    }
+
+    Context -Name 'Per-machine failure continues processing remaining machines' -Fixture {
+
+        BeforeAll {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -MockWith {
+                if ($ComputerName -eq 'BADHOST') {
+                    throw 'Simulated access denied on BADHOST'
+                }
+                return $script:mockServices
+            }
+            $script:perMachineOutput    = 'BADHOST', 'SRV02' |
+                Get-ServiceAccount -ErrorAction Continue 2>&1
+            $script:perMachineErrors    = @($script:perMachineOutput | Where-Object {
+                $_ -is [System.Management.Automation.ErrorRecord]
+            })
+            $script:perMachineSuccesses = @($script:perMachineOutput | Where-Object {
+                $_ -isnot [System.Management.Automation.ErrorRecord]
+            })
+        }
+
+        It -Name 'Should write an error for the failing machine' -Test {
+            $script:perMachineErrors.Count | Should -BeGreaterThan 0
+        }
+
+        It -Name 'Should still return results for the succeeding machine' -Test {
+            $script:perMachineSuccesses.Count | Should -Be 4
+            ($script:perMachineSuccesses | Select-Object -ExpandProperty ComputerName -Unique) | Should -Be 'SRV02'
+        }
+    }
+
+    Context -Name '-Account wildcard filter narrows StartName results' -Fixture {
+
+        BeforeAll {
+            Mock -CommandName 'Get-CimInstance' -ModuleName 'PSWinOps' -MockWith {
+                return $script:mockServices
+            }
+        }
+
+        It -Name 'Should return only services whose StartName matches the wildcard' -Test {
+            $result = @(Get-ServiceAccount -Account 'CONTOSO\svc-*')
+            $result.Count | Should -Be 1
+            $result[0].StartName | Should -Be 'CONTOSO\svc-app'
+        }
+
+        It -Name 'Should return all services when Account filter is absent' -Test {
+            $result = @(Get-ServiceAccount)
+            $result.Count | Should -Be 4
+        }
+    }
+
+    Context -Name '-NonSystemOnly excludes built-in system logon accounts' -Fixture {
+
+        BeforeAll {
+            Mock -CommandName 'Get-CimInstance' -ModuleName 'PSWinOps' -MockWith {
+                return $script:mockServices
+            }
+        }
+
+        It -Name 'Should exclude LocalSystem, NetworkService and LocalService case-insensitively' -Test {
+            $result = @(Get-ServiceAccount -NonSystemOnly)
+            $result.Count | Should -Be 1
+            $result[0].StartName | Should -Be 'CONTOSO\svc-app'
+        }
+
+        It -Name 'Should exclude a lowercase NT AUTHORITY\LocalService variant' -Test {
+            $result = @(Get-ServiceAccount -NonSystemOnly)
+            ($result | Select-Object -ExpandProperty StartName) | Should -Not -Contain 'nt authority\localservice'
+        }
+
+        It -Name 'Should include all services when NonSystemOnly is not specified' -Test {
+            $result = @(Get-ServiceAccount)
+            $result.Count | Should -Be 4
+        }
+    }
+
+    Context -Name 'PathName is preserved verbatim including arguments' -Fixture {
+
+        BeforeAll {
+            Mock -CommandName 'Get-CimInstance' -ModuleName 'PSWinOps' -MockWith {
+                return $script:mockServices
+            }
+        }
+
+        It -Name 'Should preserve quoted path and arguments exactly' -Test {
+            $result = @(Get-ServiceAccount -Account 'CONTOSO\svc-*')
+            $result[0].PathName | Should -Be '"C:\Program Files\App\app.exe" -config "C:\config.xml" --verbose'
+        }
+
+        It -Name 'Should preserve service host arguments exactly' -Test {
+            $result = @(Get-ServiceAccount -Account 'LocalSystem')
+            $result[0].PathName | Should -Be 'C:\Windows\System32\svchost.exe -k netsvcs -p'
+        }
+    }
+
+    Context -Name 'Parameter validation' -Fixture {
+
+        It -Name 'Should throw when ComputerName is an empty string' -Test {
+            { Get-ServiceAccount -ComputerName '' } | Should -Throw
+        }
+
+        It -Name 'Should throw when ComputerName is null' -Test {
+            { Get-ServiceAccount -ComputerName $null } | Should -Throw
+        }
+
+        It -Name 'Should throw when Account is an empty string' -Test {
+            { Get-ServiceAccount -Account '' } | Should -Throw
+        }
+
+        It -Name 'Should expose ComputerName with pipeline support by value and by property name' -Test {
+            $cmd = Get-Command -Name 'Get-ServiceAccount'
+            $attr = $cmd.Parameters['ComputerName'].Attributes.Where({ $_ -is [System.Management.Automation.ParameterAttribute] })[0]
+            $attr.ValueFromPipeline | Should -Be $true
+            $attr.ValueFromPipelineByPropertyName | Should -Be $true
+        }
+
+        It -Name 'Should expose ComputerName aliases CN and DNSHostName' -Test {
+            $cmd = Get-Command -Name 'Get-ServiceAccount'
+            $aliases = $cmd.Parameters['ComputerName'].Aliases
+            $aliases | Should -Contain 'CN'
+            $aliases | Should -Contain 'DNSHostName'
+        }
+
+        It -Name 'Should not support ShouldProcess (read-only auditing function)' -Test {
+            $cmd = Get-Command -Name 'Get-ServiceAccount'
+            $cmd.Parameters.ContainsKey('WhatIf') | Should -Be $false
+        }
+    }
+}

--- a/en-US/about_PSWinOps.help.txt
+++ b/en-US/about_PSWinOps.help.txt
@@ -179,7 +179,7 @@ FUNCTION DOMAINS
 
       Get-AuditPolicy
 
-  system (18 functions)
+  system (19 functions)
     Functions for general system information, state,
     disk cleanup, profile management, and real-time monitoring.
 
@@ -194,6 +194,7 @@ FUNCTION DOMAINS
       Get-PendingReboot
       Get-RebootHistory
       Get-ScheduledTaskDetail
+      Get-ServiceAccount
       Get-StartupProgram
       Get-SystemSummary
       Remove-UserProfile
@@ -405,6 +406,7 @@ PSWINOPS TYPE REGISTRY
       PSWinOps.RDSHealth
       PSWinOps.RebootHistory
       PSWinOps.ScheduledTaskDetail
+      PSWinOps.ServiceAccount
       PSWinOps.ServiceHealth
       PSWinOps.ShadowCopy
       PSWinOps.ShadowCopyRemoveResult


### PR DESCRIPTION
## Summary
Projects Win32_Service into a security-oriented view of service logon accounts, reporting which account (Log On As / StartName) runs each service, its start mode, delayed auto-start flag, current state, and full binary path. Supports wildcard filtering by account and exclusion of built-in system accounts for multi-machine service-account auditing.

Closes #68

## Files touched
- `Public/system/Get-ServiceAccount.ps1` — implementation
- `Tests/Public/system/Get-ServiceAccount.Tests.ps1` — Pester v5 suite
- `PSWinOps.psd1` — FunctionsToExport, ModuleVersion (0.8.0 -> 0.9.0), ReleaseNotes
- `PSWinOps.Format.ps1xml` — new `<View>` for `PSWinOps.ServiceAccount`
- `en-US/about_PSWinOps.help.txt` — system count 18 -> 19, function list + type registry

## Conformance checklist (audited locally by fn-quality-gate)
- [x] UTF-8 BOM + CRLF on both new files
- [x] Approved PowerShell verb (Get)
- [x] `FunctionsToExport` entry present once, correctly placed (Get-ScheduledTaskDetail -> Get-ServiceAccount -> Get-StartupProgram)
- [x] `PSTypeName` (PSWinOps.ServiceAccount) consistent across .ps1 / Format.ps1xml / about help
- [x] No `Write-Host`, no `ToString('o')`, no WMI cmdlets in the diff
- [x] `PSWinOps.Format.ps1xml` is valid XML with a matching Table `<View>`

## Verification
Dynamic verification (Test-ModuleManifest, PSScriptAnalyzer, Pester matrix) runs on the Windows CI for this PR. Merge once all required checks are green.