### PR TITLE
feat(eventlog): add Get-ServiceCrashEvent

### DIFF
--- a/.kdust/chains/get-servicecrashevent-2607062038.yaml
+++ b/.kdust/chains/get-servicecrashevent-2607062038.yaml
@@ -1,0 +1,7 @@
+chain: pswinops-function-author
+function: Get-ServiceCrashEvent
+domain: eventlog
+created: 2026-07-06T20:39:14Z
+created_by: pswinops-fn-spec-analyst
+chain_branch: kdust/chain/pswinops-fn-get-servicecrashevent-2607062038
+spec_path: work/get-servicecrashevent/spec.yaml

--- a/PSWinOps.Format.ps1xml
+++ b/PSWinOps.Format.ps1xml
@@ -7741,6 +7741,71 @@
       </TableControl>
     </View>
     <!-- ============================================================ -->
+    <!-- PSWinOps.ServiceCrashEvent                                   -->
+    <!-- Used by: Get-ServiceCrashEvent                               -->
+    <!-- ============================================================ -->
+    <View>
+      <Name>PSWinOps.ServiceCrashEvent</Name>
+      <ViewSelectedBy>
+        <TypeName>PSWinOps.ServiceCrashEvent</TypeName>
+      </ViewSelectedBy>
+      <TableControl>
+        <AutoSize />
+        <TableHeaders>
+          <TableColumnHeader>
+            <Label>ComputerName</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>EventTime</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>EventId</Label>
+            <Alignment>Right</Alignment>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>ServiceName</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>ExitCode</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>CrashCount</Label>
+            <Alignment>Right</Alignment>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>RecoveryAction</Label>
+          </TableColumnHeader>
+        </TableHeaders>
+        <TableRowEntries>
+          <TableRowEntry>
+            <TableColumnItems>
+              <TableColumnItem>
+                <PropertyName>ComputerName</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>EventTime</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>EventId</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>ServiceName</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>ExitCode</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>CrashCount</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>RecoveryAction</PropertyName>
+              </TableColumnItem>
+            </TableColumnItems>
+          </TableRowEntry>
+        </TableRowEntries>
+      </TableControl>
+    </View>
+    <!-- ============================================================ -->
     <!-- PSWinOps.CrashDump                                           -->
     <!-- Used by: Get-CrashDump                                       -->
     <!-- ============================================================ -->

--- a/PSWinOps.psd1
+++ b/PSWinOps.psd1
@@ -156,6 +156,7 @@
         'Get-RDSHealth',
         'Get-ScheduledTaskDetail',
         'Get-ServiceAccount',
+        'Get-ServiceCrashEvent',
         'Get-ServiceHealth',
         'Get-ShadowCopy',
         'Get-ShadowCopyStorage',

--- a/PSWinOps.psd1
+++ b/PSWinOps.psd1
@@ -12,7 +12,7 @@
     RootModule           = 'PSWinOps.psm1'
 
     # Version number of this module.
-    ModuleVersion        = '0.9.0'
+    ModuleVersion        = '0.9.1'
 
     # Supported PSEditions
     # Core is supported on Windows only; the module-level guard in PSWinOps.psm1 blocks
@@ -277,7 +277,11 @@
             # IconUri = ''
 
             # ReleaseNotes of this module
-            ReleaseNotes = '## 0.9.0 - 2026-07-06 UTC
+            ReleaseNotes = '## 0.9.1 - 2026-07-06 UTC
+### Added
+- Get-ServiceCrashEvent: Aggregate Service Control Manager crash events per service with counts and exit codes
+
+## 0.9.0 - 2026-07-06 UTC
 ### Added
 - Get-ServiceAccount: Audit service logon accounts across local or remote computers
 

--- a/Public/eventlog/Get-ServiceCrashEvent.ps1
+++ b/Public/eventlog/Get-ServiceCrashEvent.ps1
@@ -1,0 +1,302 @@
+﻿#Requires -Version 5.1
+
+function Get-ServiceCrashEvent {
+    <#
+    .SYNOPSIS
+        Aggregate Service Control Manager crash events per service with counts and exit codes
+
+    .DESCRIPTION
+        Queries the Windows System event log for Service Control Manager crash/abnormal-stop
+        events (IDs 7000, 7009, 7011, 7024, 7031, 7034) over a look-back window and reports one
+        row per event with the resolved service name, display name, last exit code, configured
+        recovery action, and a per-service crash count aggregated over the window. Local and
+        remote targets are dispatched through Invoke-RemoteOrLocal; machines with no matching
+        events return nothing and per-machine failures do not stop the remaining targets.
+
+    .PARAMETER ComputerName
+        One or more computer names to target. Defaults to the local computer.
+        Accepts pipeline input by value and by property name.
+
+    .PARAMETER Credential
+        Optional PSCredential for authenticating to remote machines. Ignored for
+        local machine queries.
+
+    .PARAMETER Days
+        Look-back window in days used to bound the event log scan. StartTime is
+        computed as (Get-Date).AddDays(-Days). Valid range is 1 to 3650. Defaults to 7.
+
+    .PARAMETER MaxEvents
+        Maximum number of Service Control Manager crash events returned per machine,
+        newest first. This value is forwarded to Get-WinEvent -MaxEvents and also caps
+        the number of rows emitted. Valid range is 1 to 10000. Defaults to 200.
+
+    .PARAMETER ServiceName
+        Optional filter on the resolved ServiceName. Comparison is case-insensitive
+        equality, applied after decoding (the real service name lives in the event
+        Properties, not a FilterHashtable key, so it cannot be pushed into the query).
+        Empty or absent means no filter.
+
+    .EXAMPLE
+        Get-ServiceCrashEvent -Days 7
+
+        Returns Service Control Manager crash events for the local machine over the
+        last 7 days.
+
+    .EXAMPLE
+        Get-ServiceCrashEvent -ComputerName SRV01 -ServiceName Spooler -Days 30
+
+        Returns crash events for the 'Spooler' service on SRV01 over the last 30
+        days via WinRM.
+
+    .EXAMPLE
+        'SRV01','SRV02' | Get-ServiceCrashEvent -MaxEvents 100
+
+        Returns up to 100 crash events per machine for SRV01 and SRV02 via pipeline.
+
+    .OUTPUTS
+        PSWinOps.ServiceCrashEvent
+        One object per Service Control Manager crash event (7000, 7009, 7011, 7024,
+        7031, 7034), newest first, with resolved service name, exit code, window-level
+        crash count and configured recovery action.
+
+    .NOTES
+        Author: Franck SALLET
+        Version: 1.0.0
+        Last Modified: 2026-07-06
+        Requires: PowerShell 5.1+ / Windows only
+        Requires: WinRM enabled on target machines for remote queries
+
+    .LINK
+        https://github.com/k9fr4n/PSWinOps
+
+    .LINK
+        Source of truth: Windows System event log (provider 'Service Control Manager', IDs 7000/7009/7011/7024/7031/7034)
+    #>
+    [CmdletBinding(SupportsShouldProcess = $false, ConfirmImpact = 'None')]
+    [OutputType('PSWinOps.ServiceCrashEvent')]
+    param(
+        [Parameter(Mandatory = $false, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [ValidateNotNullOrEmpty()]
+        [Alias('CN', 'Name', 'DNSHostName')]
+        [string[]]$ComputerName = $env:COMPUTERNAME,
+
+        [Parameter(Mandatory = $false)]
+        [System.Management.Automation.PSCredential]$Credential,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateRange(1, 3650)]
+        [int]$Days = 7,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateRange(1, 10000)]
+        [int]$MaxEvents = 200,
+
+        [Parameter(Mandatory = $false)]
+        [string]$ServiceName = ''
+    )
+
+    begin {
+        Write-Verbose "[$($MyInvocation.MyCommand)] Starting service crash event query"
+
+        $startTime = (Get-Date).AddDays(-$Days)
+
+        $scriptBlock = {
+            param(
+                [datetime]$ScanStartTime,
+                [int]$MaxEvts,
+                [string]$ServiceNameFilter
+            )
+
+            $filter = @{
+                LogName      = 'System'
+                ProviderName = 'Service Control Manager'
+                Id           = @(7000, 7009, 7011, 7024, 7031, 7034)
+                StartTime    = $ScanStartTime
+            }
+
+            $events = @()
+            try {
+                $events = @(Get-WinEvent -FilterHashtable $filter -MaxEvents $MaxEvts -ErrorAction Stop)
+            } catch {
+                if ($_.Exception.Message -notmatch 'No events were found') {
+                    throw
+                }
+            }
+
+            $events = @($events | Sort-Object -Property TimeCreated -Descending)
+
+            # Cache DisplayName -> ServiceName resolution once per invocation (best-effort)
+            $serviceNameMap = @{}
+            try {
+                Get-CimInstance -ClassName Win32_Service -ErrorAction Stop | ForEach-Object {
+                    if (-not [string]::IsNullOrEmpty($_.DisplayName)) {
+                        $serviceNameMap[$_.DisplayName] = $_.Name
+                    }
+                }
+            } catch {
+                Write-Verbose "Could not enumerate Win32_Service for name resolution: $_"
+            }
+
+            $recoveryActionTypeMap = @{
+                0 = 'TakeNoAction'
+                1 = 'Restart'
+                2 = 'Reboot'
+                3 = 'RunProgram'
+            }
+
+            # Cache the configured SCM recovery action per distinct resolved ServiceName
+            $recoveryActionCache = @{}
+
+            function Get-ScmRecoveryAction {
+                param(
+                    [string]$Name,
+                    [int]$FallbackCode
+                )
+
+                if ([string]::IsNullOrEmpty($Name)) { return '' }
+                if ($recoveryActionCache.ContainsKey($Name)) { return $recoveryActionCache[$Name] }
+
+                $resolvedAction = ''
+                try {
+                    $regPath = "HKLM:\SYSTEM\CurrentControlSet\Services\$Name"
+                    $bytes = (Get-ItemProperty -Path $regPath -Name 'FailureActions' -ErrorAction Stop).FailureActions
+                    if ($bytes -and $bytes.Count -ge 20) {
+                        $numActions = [System.BitConverter]::ToUInt32($bytes, 12)
+                        if ($numActions -ge 1) {
+                            $actionType = [int]([System.BitConverter]::ToUInt32($bytes, 16))
+                            $resolvedAction = if ($recoveryActionTypeMap.ContainsKey($actionType)) { $recoveryActionTypeMap[$actionType] } else { "Unknown($actionType)" }
+                        }
+                    }
+                } catch {
+                    Write-Verbose "Could not resolve configured recovery action for '$Name': $_"
+                }
+
+                if ([string]::IsNullOrEmpty($resolvedAction) -and $FallbackCode -ge 0) {
+                    $resolvedAction = if ($recoveryActionTypeMap.ContainsKey($FallbackCode)) { $recoveryActionTypeMap[$FallbackCode] } else { "Unknown($FallbackCode)" }
+                }
+
+                $recoveryActionCache[$Name] = $resolvedAction
+                return $resolvedAction
+            }
+
+            $rows = [System.Collections.Generic.List[psobject]]::new()
+
+            foreach ($evt in $events) {
+                $props = $evt.Properties
+                $displayName    = ''
+                $exitCode       = ''
+                $eventActionCode = -1
+
+                switch ($evt.Id) {
+                    7000 {
+                        # Service failed to start; Properties[0]=display name, Properties[1] may carry an error code
+                        $displayName = if ($props.Count -ge 1) { [string]$props[0].Value } else { '' }
+                        if ($props.Count -ge 2) {
+                            try { $exitCode = [string]([int64]$props[1].Value) } catch { $exitCode = '' }
+                        }
+                    }
+                    7009 {
+                        # Start timeout; property order for timeout ms / display name varies by build
+                        if ($props.Count -ge 2) {
+                            $val0 = [string]$props[0].Value
+                            $val1 = [string]$props[1].Value
+                            $displayName = if ($val0 -match '^\d+$') { $val1 } else { $val0 }
+                        } elseif ($props.Count -ge 1) {
+                            $displayName = [string]$props[0].Value
+                        }
+                    }
+                    7011 {
+                        # Transaction response timeout; Properties[0]=display name
+                        $displayName = if ($props.Count -ge 1) { [string]$props[0].Value } else { '' }
+                    }
+                    7024 {
+                        # Service-specific error / exit code; Properties[0]=display name, Properties[1]=exit code
+                        $displayName = if ($props.Count -ge 1) { [string]$props[0].Value } else { '' }
+                        if ($props.Count -ge 2) {
+                            try { $exitCode = [string]([int64]$props[1].Value) } catch { $exitCode = [string]$props[1].Value }
+                        }
+                    }
+                    7031 {
+                        # Unexpected termination; Properties: [0]=display name, [1]=count, [2]=restart window,
+                        # [3]=recovery action code, [4]=restart command
+                        $displayName = if ($props.Count -ge 1) { [string]$props[0].Value } else { '' }
+                        if ($props.Count -ge 4) {
+                            try { $eventActionCode = [int]$props[3].Value } catch { $eventActionCode = -1 }
+                        }
+                    }
+                    7034 {
+                        # Unexpected termination; Properties: [0]=display name, [1]=count
+                        $displayName = if ($props.Count -ge 1) { [string]$props[0].Value } else { '' }
+                    }
+                }
+
+                $resolvedServiceName = if ($serviceNameMap.ContainsKey($displayName)) { $serviceNameMap[$displayName] } else { $displayName }
+                $recoveryAction = Get-ScmRecoveryAction -Name $resolvedServiceName -FallbackCode $eventActionCode
+
+                $rows.Add([PSCustomObject]@{
+                    EventTime          = $evt.TimeCreated.ToString('yyyy-MM-dd HH:mm:ss')
+                    EventId            = $evt.Id
+                    ServiceName        = $resolvedServiceName
+                    ServiceDisplayName = $displayName
+                    ExitCode           = $exitCode
+                    RecoveryAction     = $recoveryAction
+                    Message            = $evt.Message
+                })
+            }
+
+            # Window-level CrashCount tally per distinct ServiceName, computed over ALL read events
+            # before the -ServiceName filter is applied.
+            $crashTally = @{}
+            foreach ($row in $rows) {
+                if ($crashTally.ContainsKey($row.ServiceName)) {
+                    $crashTally[$row.ServiceName]++
+                } else {
+                    $crashTally[$row.ServiceName] = 1
+                }
+            }
+
+            $results = [System.Collections.Generic.List[psobject]]::new()
+
+            foreach ($row in $rows) {
+                if ($results.Count -ge $MaxEvts) { break }
+
+                if (-not [string]::IsNullOrWhiteSpace($ServiceNameFilter) -and $row.ServiceName -ne $ServiceNameFilter) {
+                    continue
+                }
+
+                $results.Add([PSCustomObject]@{
+                    PSTypeName         = 'PSWinOps.ServiceCrashEvent'
+                    ComputerName       = $env:COMPUTERNAME
+                    EventTime          = $row.EventTime
+                    EventId            = $row.EventId
+                    ServiceName        = $row.ServiceName
+                    ServiceDisplayName = $row.ServiceDisplayName
+                    ExitCode           = $row.ExitCode
+                    CrashCount         = $crashTally[$row.ServiceName]
+                    RecoveryAction     = $row.RecoveryAction
+                    Message            = $row.Message
+                    Timestamp          = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
+                })
+            }
+
+            $results
+        }
+    }
+
+    process {
+        foreach ($targetComputer in $ComputerName) {
+            try {
+                Write-Verbose "[$($MyInvocation.MyCommand)] Querying service crash events on '$targetComputer'"
+                Invoke-RemoteOrLocal -ComputerName $targetComputer -Credential $Credential `
+                    -ScriptBlock $scriptBlock `
+                    -ArgumentList @($startTime, $MaxEvents, $ServiceName)
+            } catch {
+                Write-Error "[$($MyInvocation.MyCommand)] Failed on '$targetComputer': $_"
+            }
+        }
+    }
+
+    end {
+        Write-Verbose "[$($MyInvocation.MyCommand)] Completed service crash event query"
+    }
+}

--- a/Public/eventlog/Get-ServiceCrashEvent.ps1
+++ b/Public/eventlog/Get-ServiceCrashEvent.ps1
@@ -147,10 +147,13 @@ function Get-ServiceCrashEvent {
             # Cache the configured SCM recovery action per distinct resolved ServiceName
             $recoveryActionCache = @{}
 
-            function Get-ScmRecoveryAction {
+            # Resolve only the SCM-configured recovery action from the registry. This value
+            # is per-service, so it is safe to cache by name. The per-event fallback code is
+            # deliberately NOT handled here: caching it would let one event's (absent) code
+            # poison a later event for the same service.
+            function Get-ScmConfiguredRecoveryAction {
                 param(
-                    [string]$Name,
-                    [int]$FallbackCode
+                    [string]$Name
                 )
 
                 if ([string]::IsNullOrEmpty($Name)) { return '' }
@@ -171,11 +174,23 @@ function Get-ServiceCrashEvent {
                     Write-Verbose "Could not resolve configured recovery action for '$Name': $_"
                 }
 
+                $recoveryActionCache[$Name] = $resolvedAction
+                return $resolvedAction
+            }
+
+            # Combine the cached SCM-configured action with the per-event fallback code.
+            function Get-ScmRecoveryAction {
+                param(
+                    [string]$Name,
+                    [int]$FallbackCode
+                )
+
+                $resolvedAction = Get-ScmConfiguredRecoveryAction -Name $Name
+
                 if ([string]::IsNullOrEmpty($resolvedAction) -and $FallbackCode -ge 0) {
                     $resolvedAction = if ($recoveryActionTypeMap.ContainsKey($FallbackCode)) { $recoveryActionTypeMap[$FallbackCode] } else { "Unknown($FallbackCode)" }
                 }
 
-                $recoveryActionCache[$Name] = $resolvedAction
                 return $resolvedAction
             }
 

--- a/Tests/Public/eventlog/Get-ServiceCrashEvent.Tests.ps1
+++ b/Tests/Public/eventlog/Get-ServiceCrashEvent.Tests.ps1
@@ -1,0 +1,381 @@
+﻿#Requires -Version 5.1
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+
+param()
+
+BeforeAll {
+    $script:modulePath = Split-Path -Path (Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent) -Parent
+    Import-Module -Name (Join-Path -Path $script:modulePath -ChildPath 'PSWinOps.psd1') -Force
+
+    function New-FakeCrashEvent {
+        param(
+            [int]$Id,
+            [datetime]$TimeCreated,
+            [object[]]$PropertyValues = @(),
+            [string]$Message = 'Simulated crash event message'
+        )
+        $props = [System.Collections.Generic.List[object]]::new()
+        foreach ($v in $PropertyValues) {
+            $props.Add([PSCustomObject]@{ Value = $v })
+        }
+        [PSCustomObject]@{
+            Id          = $Id
+            TimeCreated = $TimeCreated
+            Properties  = $props.ToArray()
+            Message     = $Message
+        }
+    }
+
+    function New-FakeServiceCimEntry {
+        param(
+            [string]$Name,
+            [string]$DisplayName
+        )
+        [PSCustomObject]@{
+            Name        = $Name
+            DisplayName = $DisplayName
+        }
+    }
+}
+
+Describe -Name 'Get-ServiceCrashEvent' -Fixture {
+
+    Context -Name 'Local happy path - mixed crash events' -Fixture {
+
+        BeforeAll {
+            $script:evt7024 = New-FakeCrashEvent -Id 7024 -TimeCreated (Get-Date '2026-07-01 10:00:00') `
+                -PropertyValues @('Print Spooler', 3489660929)
+            $script:evt7031 = New-FakeCrashEvent -Id 7031 -TimeCreated (Get-Date '2026-07-01 09:00:00') `
+                -PropertyValues @('Print Spooler', 1, 60, 1, '')
+            $script:evt7034 = New-FakeCrashEvent -Id 7034 -TimeCreated (Get-Date '2026-07-01 08:00:00') `
+                -PropertyValues @('World Wide Web Publishing Service', 1)
+            $script:evt7000 = New-FakeCrashEvent -Id 7000 -TimeCreated (Get-Date '2026-07-01 07:00:00') `
+                -PropertyValues @('World Wide Web Publishing Service')
+
+            Mock -CommandName 'Get-WinEvent' -ModuleName 'PSWinOps' -MockWith {
+                return @($script:evt7024, $script:evt7031, $script:evt7034, $script:evt7000)
+            }
+            Mock -CommandName 'Get-CimInstance' -ModuleName 'PSWinOps' -MockWith {
+                return @(
+                    (New-FakeServiceCimEntry -Name 'Spooler' -DisplayName 'Print Spooler'),
+                    (New-FakeServiceCimEntry -Name 'W3SVC' -DisplayName 'World Wide Web Publishing Service')
+                )
+            }
+        }
+
+        It -Name 'Should return one row per crash event' -Test {
+            $result = Get-ServiceCrashEvent
+            $result.Count | Should -Be 4
+        }
+
+        It -Name 'Should return a PSWinOps.ServiceCrashEvent typed object' -Test {
+            $result = Get-ServiceCrashEvent
+            $result[0].PSObject.TypeNames[0] | Should -Be 'PSWinOps.ServiceCrashEvent'
+        }
+
+        It -Name 'Should return all required output properties' -Test {
+            $result = Get-ServiceCrashEvent
+            $props = $result[0].PSObject.Properties.Name
+            $props | Should -Contain 'ComputerName'
+            $props | Should -Contain 'EventTime'
+            $props | Should -Contain 'EventId'
+            $props | Should -Contain 'ServiceName'
+            $props | Should -Contain 'ServiceDisplayName'
+            $props | Should -Contain 'ExitCode'
+            $props | Should -Contain 'CrashCount'
+            $props | Should -Contain 'RecoveryAction'
+            $props | Should -Contain 'Message'
+            $props | Should -Contain 'Timestamp'
+        }
+
+        It -Name 'Should set ComputerName to the local machine' -Test {
+            $result = Get-ServiceCrashEvent
+            $result[0].ComputerName | Should -Be $env:COMPUTERNAME
+        }
+
+        It -Name 'Should format EventTime and Timestamp as yyyy-MM-dd HH:mm:ss' -Test {
+            $result = Get-ServiceCrashEvent
+            $result[0].EventTime | Should -Match "^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$"
+            $result[0].Timestamp | Should -Match "^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$"
+        }
+
+        It -Name 'Should sort events newest first' -Test {
+            $result = Get-ServiceCrashEvent
+            $sorted = $result.EventTime | Sort-Object -Descending
+            [string[]]$result.EventTime | Should -Be ([string[]]$sorted)
+        }
+
+        It -Name 'Should resolve ServiceName from DisplayName via Get-CimInstance' -Test {
+            $result = Get-ServiceCrashEvent
+            $row = $result | Where-Object { $_.EventId -eq 7024 }
+            $row.ServiceName | Should -Be 'Spooler'
+            $row.ServiceDisplayName | Should -Be 'Print Spooler'
+        }
+
+        It -Name 'Should extract ExitCode from a 7024 event' -Test {
+            $result = Get-ServiceCrashEvent
+            $row = $result | Where-Object { $_.EventId -eq 7024 }
+            $row.ExitCode | Should -Be '3489660929'
+        }
+
+        It -Name 'Should leave ExitCode empty for a 7000 event with no error code property' -Test {
+            $result = Get-ServiceCrashEvent
+            $row = $result | Where-Object { $_.EventId -eq 7000 }
+            $row.ExitCode | Should -Be ''
+        }
+
+        It -Name 'Should derive RecoveryAction from the 7031 embedded action code as a fallback' -Test {
+            $result = Get-ServiceCrashEvent
+            $row = $result | Where-Object { $_.EventId -eq 7031 }
+            $row.RecoveryAction | Should -Be 'Restart'
+        }
+    }
+
+    Context -Name 'No matching events on the machine' -Fixture {
+
+        BeforeAll {
+            Mock -CommandName 'Get-WinEvent' -ModuleName 'PSWinOps' -MockWith {
+                return $null
+            }
+            Mock -CommandName 'Get-CimInstance' -ModuleName 'PSWinOps' -MockWith {
+                return @()
+            }
+        }
+
+        It -Name 'Should emit nothing for that machine without error' -Test {
+            $result = @(Get-ServiceCrashEvent -ErrorAction Stop)
+            $result.Count | Should -Be 0
+        }
+    }
+
+    Context -Name 'Explicit remote machine' -Fixture {
+
+        BeforeAll {
+            Mock -CommandName 'Invoke-Command' -ModuleName 'PSWinOps' -MockWith {
+                [PSCustomObject]@{
+                    PSTypeName         = 'PSWinOps.ServiceCrashEvent'
+                    ComputerName       = 'SRV01'
+                    EventTime          = '2026-07-01 10:00:00'
+                    EventId            = 7031
+                    ServiceName        = 'Spooler'
+                    ServiceDisplayName = 'Print Spooler'
+                    ExitCode           = ''
+                    CrashCount         = 1
+                    RecoveryAction     = 'Restart'
+                    Message            = 'Simulated crash event message'
+                    Timestamp          = '2026-07-05 12:00:00'
+                }
+            }
+        }
+
+        It -Name 'Should dispatch via Invoke-Command for a remote machine' -Test {
+            $result = Get-ServiceCrashEvent -ComputerName 'SRV01'
+            Should -Invoke -CommandName 'Invoke-Command' -ModuleName 'PSWinOps' -Times 1 -Exactly
+            $result.ComputerName | Should -Be 'SRV01'
+        }
+
+        It -Name 'Should propagate Credential to Invoke-Command' -Test {
+            $securePwd = ConvertTo-SecureString -String 'P@ssw0rd123!' -AsPlainText -Force
+            $cred = [System.Management.Automation.PSCredential]::new('DOMAIN\svc', $securePwd)
+            Get-ServiceCrashEvent -ComputerName 'SRV01' -Credential $cred
+            Should -Invoke -CommandName 'Invoke-Command' -ModuleName 'PSWinOps' -Times 1 -Exactly -ParameterFilter {
+                $Credential -eq $cred
+            }
+        }
+    }
+
+    Context -Name 'Pipeline of multiple machine names' -Fixture {
+
+        BeforeAll {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -MockWith {
+                [PSCustomObject]@{
+                    PSTypeName         = 'PSWinOps.ServiceCrashEvent'
+                    ComputerName       = $ComputerName
+                    EventTime          = '2026-07-01 10:00:00'
+                    EventId            = 7034
+                    ServiceName        = 'W3SVC'
+                    ServiceDisplayName = 'World Wide Web Publishing Service'
+                    ExitCode           = ''
+                    CrashCount         = 1
+                    RecoveryAction     = ''
+                    Message            = 'Simulated crash event message'
+                    Timestamp          = '2026-07-05 12:00:00'
+                }
+            }
+        }
+
+        It -Name 'Should call Invoke-RemoteOrLocal once per machine and return a result for each' -Test {
+            $result = 'SRV01', 'SRV02' | Get-ServiceCrashEvent
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -Times 2 -Exactly
+            ($result | Select-Object -ExpandProperty ComputerName) | Should -Contain 'SRV01'
+            ($result | Select-Object -ExpandProperty ComputerName) | Should -Contain 'SRV02'
+        }
+    }
+
+    Context -Name 'Per-machine failure - continues processing remaining machines' -Fixture {
+
+        BeforeAll {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -MockWith {
+                if ($ComputerName -eq 'SRV01') {
+                    throw 'Simulated WinRM failure on SRV01'
+                }
+                [PSCustomObject]@{
+                    PSTypeName         = 'PSWinOps.ServiceCrashEvent'
+                    ComputerName       = $ComputerName
+                    EventTime          = '2026-07-01 10:00:00'
+                    EventId            = 7034
+                    ServiceName        = 'W3SVC'
+                    ServiceDisplayName = 'World Wide Web Publishing Service'
+                    ExitCode           = ''
+                    CrashCount         = 1
+                    RecoveryAction     = ''
+                    Message            = 'Simulated crash event message'
+                    Timestamp          = '2026-07-05 12:00:00'
+                }
+            }
+            $script:perMachineOutput    = 'SRV01', 'SRV02' |
+                Get-ServiceCrashEvent -ErrorAction Continue 2>&1
+            $script:perMachineErrors    = @($script:perMachineOutput | Where-Object {
+                $_ -is [System.Management.Automation.ErrorRecord]
+            })
+            $script:perMachineSuccesses = @($script:perMachineOutput | Where-Object {
+                $_ -isnot [System.Management.Automation.ErrorRecord]
+            })
+        }
+
+        It -Name 'Should write an error for the failing machine' -Test {
+            $script:perMachineErrors.Count | Should -BeGreaterThan 0
+        }
+
+        It -Name 'Should still return a result for the succeeding machine' -Test {
+            $script:perMachineSuccesses.Count | Should -Be 1
+            $script:perMachineSuccesses[0].ComputerName | Should -Be 'SRV02'
+        }
+    }
+
+    Context -Name '-ServiceName post-read filter narrows rows' -Fixture {
+
+        BeforeAll {
+            $script:evtSpooler = New-FakeCrashEvent -Id 7031 -TimeCreated (Get-Date '2026-07-01 10:00:00') `
+                -PropertyValues @('Print Spooler', 1, 60, 1, '')
+            $script:evtW3svc = New-FakeCrashEvent -Id 7034 -TimeCreated (Get-Date '2026-07-01 09:00:00') `
+                -PropertyValues @('World Wide Web Publishing Service', 1)
+
+            Mock -CommandName 'Get-WinEvent' -ModuleName 'PSWinOps' -MockWith {
+                return @($script:evtSpooler, $script:evtW3svc)
+            }
+            Mock -CommandName 'Get-CimInstance' -ModuleName 'PSWinOps' -MockWith {
+                return @(
+                    (New-FakeServiceCimEntry -Name 'Spooler' -DisplayName 'Print Spooler'),
+                    (New-FakeServiceCimEntry -Name 'W3SVC' -DisplayName 'World Wide Web Publishing Service')
+                )
+            }
+        }
+
+        It -Name 'Should only return rows matching the requested ServiceName' -Test {
+            $result = @(Get-ServiceCrashEvent -ServiceName 'Spooler')
+            $result.Count | Should -Be 1
+            $result[0].ServiceName | Should -Be 'Spooler'
+        }
+
+        It -Name 'Should be case-insensitive when matching ServiceName' -Test {
+            $result = @(Get-ServiceCrashEvent -ServiceName 'SPOOLER')
+            $result.Count | Should -Be 1
+            $result[0].ServiceName | Should -Be 'Spooler'
+        }
+
+        It -Name 'Should return all rows when ServiceName is not specified' -Test {
+            $result = @(Get-ServiceCrashEvent)
+            $result.Count | Should -Be 2
+        }
+    }
+
+    Context -Name 'CrashCount aggregated per ServiceName over the window' -Fixture {
+
+        BeforeAll {
+            $script:evtSpooler1 = New-FakeCrashEvent -Id 7031 -TimeCreated (Get-Date '2026-07-01 12:00:00') `
+                -PropertyValues @('Print Spooler', 3, 60, 1, '')
+            $script:evtSpooler2 = New-FakeCrashEvent -Id 7034 -TimeCreated (Get-Date '2026-07-01 11:00:00') `
+                -PropertyValues @('Print Spooler', 2)
+            $script:evtSpooler3 = New-FakeCrashEvent -Id 7034 -TimeCreated (Get-Date '2026-07-01 10:00:00') `
+                -PropertyValues @('Print Spooler', 1)
+            $script:evtW3svc = New-FakeCrashEvent -Id 7034 -TimeCreated (Get-Date '2026-07-01 09:00:00') `
+                -PropertyValues @('World Wide Web Publishing Service', 1)
+
+            Mock -CommandName 'Get-WinEvent' -ModuleName 'PSWinOps' -MockWith {
+                return @($script:evtSpooler1, $script:evtSpooler2, $script:evtSpooler3, $script:evtW3svc)
+            }
+            Mock -CommandName 'Get-CimInstance' -ModuleName 'PSWinOps' -MockWith {
+                return @(
+                    (New-FakeServiceCimEntry -Name 'Spooler' -DisplayName 'Print Spooler'),
+                    (New-FakeServiceCimEntry -Name 'W3SVC' -DisplayName 'World Wide Web Publishing Service')
+                )
+            }
+        }
+
+        It -Name 'Should stamp the window-level crash count on every row for that service' -Test {
+            $result = Get-ServiceCrashEvent
+            $spoolerRows = @($result | Where-Object { $_.ServiceName -eq 'Spooler' })
+            $spoolerRows.Count | Should -Be 3
+            foreach ($row in $spoolerRows) {
+                $row.CrashCount | Should -Be 3
+            }
+        }
+
+        It -Name 'Should compute distinct CrashCount tallies per ServiceName' -Test {
+            $result = Get-ServiceCrashEvent
+            $w3svcRow = $result | Where-Object { $_.ServiceName -eq 'W3SVC' }
+            $w3svcRow.CrashCount | Should -Be 1
+        }
+
+        It -Name 'Should keep the window-level tally unchanged when -ServiceName narrows the emitted rows' -Test {
+            $result = @(Get-ServiceCrashEvent -ServiceName 'Spooler')
+            $result.Count | Should -Be 3
+            foreach ($row in $result) {
+                $row.CrashCount | Should -Be 3
+            }
+        }
+    }
+
+    Context -Name 'Parameter validation' -Fixture {
+
+        It -Name 'Should throw when ComputerName is an empty string' -Test {
+            { Get-ServiceCrashEvent -ComputerName '' } | Should -Throw
+        }
+
+        It -Name 'Should throw when ComputerName is null' -Test {
+            { Get-ServiceCrashEvent -ComputerName $null } | Should -Throw
+        }
+
+        It -Name 'Should throw when Days is below the valid range' -Test {
+            { Get-ServiceCrashEvent -Days 0 } | Should -Throw
+        }
+
+        It -Name 'Should throw when Days is above the valid range' -Test {
+            { Get-ServiceCrashEvent -Days 3651 } | Should -Throw
+        }
+
+        It -Name 'Should throw when MaxEvents is below the valid range' -Test {
+            { Get-ServiceCrashEvent -MaxEvents 0 } | Should -Throw
+        }
+
+        It -Name 'Should throw when MaxEvents is above the valid range' -Test {
+            { Get-ServiceCrashEvent -MaxEvents 10001 } | Should -Throw
+        }
+
+        It -Name 'Should expose ComputerName with pipeline support by value and by property name' -Test {
+            $cmd = Get-Command -Name 'Get-ServiceCrashEvent'
+            $attr = $cmd.Parameters['ComputerName'].Attributes.Where({ $_ -is [System.Management.Automation.ParameterAttribute] })[0]
+            $attr.ValueFromPipeline | Should -Be $true
+            $attr.ValueFromPipelineByPropertyName | Should -Be $true
+        }
+
+        It -Name 'Should expose ComputerName aliases CN, Name and DNSHostName' -Test {
+            $cmd = Get-Command -Name 'Get-ServiceCrashEvent'
+            $aliases = $cmd.Parameters['ComputerName'].Aliases
+            $aliases | Should -Contain 'CN'
+            $aliases | Should -Contain 'Name'
+            $aliases | Should -Contain 'DNSHostName'
+        }
+    }
+}

--- a/Tests/Public/eventlog/Get-ServiceCrashEvent.Tests.ps1
+++ b/Tests/Public/eventlog/Get-ServiceCrashEvent.Tests.ps1
@@ -55,6 +55,9 @@ Describe -Name 'Get-ServiceCrashEvent' -Fixture {
             Mock -CommandName 'Get-WinEvent' -ModuleName 'PSWinOps' -MockWith {
                 return @($script:evt7024, $script:evt7031, $script:evt7034, $script:evt7000)
             }
+            Mock -CommandName 'Get-ItemProperty' -ModuleName 'PSWinOps' -MockWith {
+                throw 'FailureActions not configured'
+            }
             Mock -CommandName 'Get-CimInstance' -ModuleName 'PSWinOps' -MockWith {
                 return @(
                     (New-FakeServiceCimEntry -Name 'Spooler' -DisplayName 'Print Spooler'),
@@ -136,6 +139,9 @@ Describe -Name 'Get-ServiceCrashEvent' -Fixture {
         BeforeAll {
             Mock -CommandName 'Get-WinEvent' -ModuleName 'PSWinOps' -MockWith {
                 return $null
+            }
+            Mock -CommandName 'Get-ItemProperty' -ModuleName 'PSWinOps' -MockWith {
+                throw 'FailureActions not configured'
             }
             Mock -CommandName 'Get-CimInstance' -ModuleName 'PSWinOps' -MockWith {
                 return @()
@@ -264,6 +270,9 @@ Describe -Name 'Get-ServiceCrashEvent' -Fixture {
             Mock -CommandName 'Get-WinEvent' -ModuleName 'PSWinOps' -MockWith {
                 return @($script:evtSpooler, $script:evtW3svc)
             }
+            Mock -CommandName 'Get-ItemProperty' -ModuleName 'PSWinOps' -MockWith {
+                throw 'FailureActions not configured'
+            }
             Mock -CommandName 'Get-CimInstance' -ModuleName 'PSWinOps' -MockWith {
                 return @(
                     (New-FakeServiceCimEntry -Name 'Spooler' -DisplayName 'Print Spooler'),
@@ -304,6 +313,9 @@ Describe -Name 'Get-ServiceCrashEvent' -Fixture {
 
             Mock -CommandName 'Get-WinEvent' -ModuleName 'PSWinOps' -MockWith {
                 return @($script:evtSpooler1, $script:evtSpooler2, $script:evtSpooler3, $script:evtW3svc)
+            }
+            Mock -CommandName 'Get-ItemProperty' -ModuleName 'PSWinOps' -MockWith {
+                throw 'FailureActions not configured'
             }
             Mock -CommandName 'Get-CimInstance' -ModuleName 'PSWinOps' -MockWith {
                 return @(

--- a/en-US/about_PSWinOps.help.txt
+++ b/en-US/about_PSWinOps.help.txt
@@ -62,13 +62,15 @@ FUNCTION DOMAINS
       Search-ADObject
       Unlock-ADUserAccount
 
-  eventlog (2 functions)
+  eventlog (3 functions)
     Functions for correlating Windows System event log
     entries into shutdown/restart history, cause and
-    initiator reporting, and decoding Security log
-    failed-logon events.
+    initiator reporting, decoding Security log
+    failed-logon events, and aggregating Service Control
+    Manager crash events per service.
 
       Get-LogonFailure
+      Get-ServiceCrashEvent
       Get-UnexpectedShutdown
 
   healthcheck (16 functions)
@@ -407,6 +409,7 @@ PSWINOPS TYPE REGISTRY
       PSWinOps.RebootHistory
       PSWinOps.ScheduledTaskDetail
       PSWinOps.ServiceAccount
+      PSWinOps.ServiceCrashEvent
       PSWinOps.ServiceHealth
       PSWinOps.ShadowCopy
       PSWinOps.ShadowCopyRemoveResult


### PR DESCRIPTION
## Summary
Queries the Windows System event log for Service Control Manager crash/abnormal-stop events (IDs 7000, 7009, 7011, 7024, 7031, 7034) over a look-back window and reports one row per event with the resolved service name, display name, last exit code, configured recovery action, and a per-service crash count aggregated over the window. Local and remote targets are dispatched through Invoke-RemoteOrLocal; machines with no matching events return nothing and per-machine failures do not stop the remaining targets.

Closes #65

## Files touched
- `Public/eventlog/Get-ServiceCrashEvent.ps1` — implementation
- `Tests/Public/eventlog/Get-ServiceCrashEvent.Tests.ps1` — Pester v5 suite
- `PSWinOps.psd1` — FunctionsToExport, ModuleVersion (0.9.0 -> 0.9.1), ReleaseNotes
- `PSWinOps.Format.ps1xml` — new `<View>` for `PSWinOps.ServiceCrashEvent`
- `en-US/about_PSWinOps.help.txt` — eventlog count (2 -> 3), function list, type registry

## Conformance checklist (audited locally by fn-quality-gate)
- [x] UTF-8 BOM + CRLF on both new files
- [x] Approved PowerShell verb (Get)
- [x] `FunctionsToExport` alphabetically sorted, present once
- [x] `PSTypeName` consistent across .ps1 / Format.ps1xml / about help (PSWinOps.ServiceCrashEvent)
- [x] No `Write-Host`, no `ToString('o')`, no WMI cmdlets in the diff
- [x] `PSWinOps.Format.ps1xml` is valid XML with a matching `<View>`

## Verification
Dynamic verification (Test-ModuleManifest, PSScriptAnalyzer, Pester matrix) runs on the Windows CI for this PR. Merge once all required checks are green.
