### PR TITLE
feat(system): add Get-DriverInventory (#67)

### DIFF
--- a/PSWinOps.Format.ps1xml
+++ b/PSWinOps.Format.ps1xml
@@ -2485,6 +2485,75 @@
       </TableControl>
     </View>
     <!-- ============================================================ -->
+    <!-- PSWinOps.DriverInventory                                     -->
+    <!-- Used by: Get-DriverInventory                                -->
+    <!-- ============================================================ -->
+    <View>
+      <Name>PSWinOps.DriverInventory</Name>
+      <ViewSelectedBy>
+        <TypeName>PSWinOps.DriverInventory</TypeName>
+      </ViewSelectedBy>
+      <TableControl>
+        <AutoSize />
+        <TableHeaders>
+          <TableColumnHeader>
+            <Label>ComputerName</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>DeviceName</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Class</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Manufacturer</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Version</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Date</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Signed</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>InfName</Label>
+          </TableColumnHeader>
+        </TableHeaders>
+        <TableRowEntries>
+          <TableRowEntry>
+            <TableColumnItems>
+              <TableColumnItem>
+                <PropertyName>ComputerName</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>DeviceName</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>DeviceClass</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>Manufacturer</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>DriverVersion</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>DriverDate</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>IsSigned</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>InfName</PropertyName>
+              </TableColumnItem>
+            </TableColumnItems>
+          </TableRowEntry>
+        </TableRowEntries>
+      </TableControl>
+    </View>
+    <!-- ============================================================ -->
     <!-- PSWinOps.ServiceHealth                                       -->
     <!-- Used by: Get-ServiceHealth                                   -->
     <!-- ============================================================ -->

--- a/PSWinOps.psd1
+++ b/PSWinOps.psd1
@@ -12,7 +12,7 @@
     RootModule           = 'PSWinOps.psm1'
 
     # Version number of this module.
-    ModuleVersion        = '0.9.1'
+    ModuleVersion        = '0.10.0'
 
     # Supported PSEditions
     # Core is supported on Windows only; the module-level guard in PSWinOps.psm1 blocks
@@ -121,6 +121,7 @@
         'Get-DiskCleanupInfo',
         'Get-DiskSpace',
         'Get-DnsServerHealth',
+        'Get-DriverInventory',
         'Get-EnvironmentVariable',
         'Get-ExchangeServerHealth',
         'Get-FileServerHealth',
@@ -277,7 +278,11 @@
             # IconUri = ''
 
             # ReleaseNotes of this module
-            ReleaseNotes = '## 0.9.1 - 2026-07-06 UTC
+            ReleaseNotes = '## 0.10.0 - 2026-08-11 UTC
+### Added
+- Get-DriverInventory: Structured signed-driver inventory via Win32_PnPSignedDriver, filterable by class or unsigned-only, local or remote
+
+## 0.9.1 - 2026-07-06 UTC
 ### Added
 - Get-ServiceCrashEvent: Aggregate Service Control Manager crash events per service with counts and exit codes
 

--- a/Public/system/Get-DriverInventory.ps1
+++ b/Public/system/Get-DriverInventory.ps1
@@ -1,0 +1,134 @@
+#Requires -Version 5.1
+function Get-DriverInventory {
+    <#
+        .SYNOPSIS
+            Retrieves a structured inventory of signed drivers from local or remote computers
+
+        .DESCRIPTION
+            Queries Win32_PnPSignedDriver via CIM to return an inventory of installed device
+            drivers, including device name, class, manufacturer, version, date, signature
+            state, and INF file. Results can be filtered by device class or restricted to
+            unsigned drivers only, and the function supports multiple machines with per-machine
+            error isolation.
+
+        .PARAMETER ComputerName
+            One or more computer names to query. Defaults to the local computer.
+            Accepts pipeline input by value and by property name.
+
+        .PARAMETER DeviceClass
+            Optional device class to filter on (case-insensitive), for example 'Net',
+            'Display', or 'System'. When omitted, drivers of all classes are returned.
+
+        .PARAMETER UnsignedOnly
+            When specified, only drivers that are not digitally signed are returned.
+
+        .PARAMETER Credential
+            Optional PSCredential for authenticating to remote computers.
+            Not used for local queries.
+
+        .EXAMPLE
+            Get-DriverInventory
+
+            Retrieves the full driver inventory from the local computer.
+
+        .EXAMPLE
+            Get-DriverInventory -ComputerName 'SRV01' -DeviceClass 'Net'
+
+            Retrieves only network-class drivers from SRV01.
+
+        .EXAMPLE
+            'SRV01', 'SRV02' | Get-DriverInventory -UnsignedOnly
+
+            Retrieves only unsigned drivers from multiple servers via pipeline.
+
+        .OUTPUTS
+            PSWinOps.DriverInventory
+            Returns one object per driver with device name, class, manufacturer, version,
+            date, signature state, and INF file name.
+
+        .NOTES
+            Author: Franck SALLET
+            Version: 1.0.0
+            Last Modified: 2026-08-11
+            Requires: PowerShell 5.1+ / Windows only
+
+        .LINK
+            https://github.com/k9fr4n/PSWinOps
+
+        .LINK
+            https://learn.microsoft.com/en-us/windows/win32/cimwin32prov/win32-pnpsigneddriver
+    #>
+    [CmdletBinding()]
+    [OutputType('PSWinOps.DriverInventory')]
+    param(
+        [Parameter(Mandatory = $false, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [ValidateNotNullOrEmpty()]
+        [Alias('CN', 'DNSHostName')]
+        [string[]]$ComputerName = $env:COMPUTERNAME,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateNotNullOrEmpty()]
+        [string]$DeviceClass,
+
+        [Parameter(Mandatory = $false)]
+        [switch]$UnsignedOnly,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateNotNull()]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential
+    )
+
+    begin {
+        Write-Verbose -Message "[$($MyInvocation.MyCommand)] Starting"
+
+        $scriptBlock = {
+            @(Get-CimInstance -ClassName 'Win32_PnPSignedDriver' -ErrorAction Stop)
+        }
+    }
+
+    process {
+        foreach ($machine in $ComputerName) {
+            try {
+                Write-Verbose -Message "[$($MyInvocation.MyCommand)] Querying Win32_PnPSignedDriver on '$machine'"
+                $drivers = @(Invoke-RemoteOrLocal -ComputerName $machine -ScriptBlock $scriptBlock -Credential $Credential)
+
+                if ($PSBoundParameters.ContainsKey('DeviceClass')) {
+                    $drivers = @($drivers | Where-Object { $_.DeviceClass -eq $DeviceClass })
+                }
+
+                $displayName = $machine
+
+                foreach ($driver in $drivers) {
+                    $isSigned = [bool]$driver.IsSigned
+
+                    if ($UnsignedOnly -and $isSigned) {
+                        continue
+                    }
+
+                    [PSCustomObject]@{
+                        PSTypeName    = 'PSWinOps.DriverInventory'
+                        ComputerName  = $displayName
+                        DeviceName    = $driver.DeviceName
+                        DeviceClass   = $driver.DeviceClass
+                        Manufacturer  = $driver.Manufacturer
+                        DriverVersion = $driver.DriverVersion
+                        DriverDate    = $driver.DriverDate
+                        IsSigned      = $isSigned
+                        InfName       = $driver.InfName
+                        Timestamp     = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
+                    }
+                }
+            }
+            catch {
+                Write-Error -Message "[$($MyInvocation.MyCommand)] Failed on '${machine}': $_"
+                continue
+            }
+        }
+    }
+
+    end {
+        Write-Verbose -Message "[$($MyInvocation.MyCommand)] Completed"
+    }
+}

--- a/Tests/Public/system/Get-DriverInventory.Tests.ps1
+++ b/Tests/Public/system/Get-DriverInventory.Tests.ps1
@@ -1,0 +1,205 @@
+#Requires -Version 5.1
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+BeforeAll {
+    $script:modulePath = Split-Path -Path (Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent) -Parent
+    Import-Module -Name (Join-Path -Path $script:modulePath -ChildPath 'PSWinOps.psd1') -Force
+}
+
+Describe 'Get-DriverInventory' {
+
+    BeforeAll {
+        $script:mockDrivers = @(
+            [PSCustomObject]@{
+                DeviceName    = 'Intel Ethernet Adapter'
+                DeviceClass   = 'Net'
+                Manufacturer  = 'Intel'
+                DriverVersion = '12.18.9.23'
+                DriverDate    = [datetime]'2021-05-14'
+                IsSigned      = $true
+                InfName       = 'oem12.inf'
+            },
+            [PSCustomObject]@{
+                DeviceName    = 'Legacy Widget Controller'
+                DeviceClass   = 'System'
+                Manufacturer  = 'Acme'
+                DriverVersion = $null
+                DriverDate    = $null
+                IsSigned      = $false
+                InfName       = 'oem34.inf'
+            }
+        )
+    }
+
+    Context 'Happy path - local' {
+
+        BeforeAll {
+            Mock -CommandName 'Get-CimInstance' -ModuleName 'PSWinOps' -MockWith {
+                return $script:mockDrivers
+            }
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -MockWith {
+                if ($ArgumentList) {
+                    & $ScriptBlock @ArgumentList
+                } else {
+                    & $ScriptBlock
+                }
+            }
+            $script:result = Get-DriverInventory
+        }
+
+        It -Name 'Should return PSWinOps.DriverInventory type' -Test {
+            $script:result[0].PSObject.TypeNames | Should -Contain 'PSWinOps.DriverInventory'
+        }
+
+        It -Name 'Should return one object per driver' -Test {
+            $script:result | Should -HaveCount 2
+        }
+
+        It -Name 'Should map ComputerName to the local computer' -Test {
+            $script:result[0].ComputerName | Should -Be $env:COMPUTERNAME
+        }
+
+        It -Name 'Should map driver fields correctly' -Test {
+            $script:result[0].DeviceName | Should -Be 'Intel Ethernet Adapter'
+            $script:result[0].DeviceClass | Should -Be 'Net'
+            $script:result[0].Manufacturer | Should -Be 'Intel'
+            $script:result[0].DriverVersion | Should -Be '12.18.9.23'
+            $script:result[0].InfName | Should -Be 'oem12.inf'
+        }
+
+        It -Name 'Should emit IsSigned as a boolean' -Test {
+            $script:result[0].IsSigned | Should -BeOfType [bool]
+            $script:result[0].IsSigned | Should -BeTrue
+            $script:result[1].IsSigned | Should -BeFalse
+        }
+
+        It -Name 'Should tolerate null version and date without excluding the row' -Test {
+            $script:result[1].DriverVersion | Should -BeNullOrEmpty
+            $script:result[1].DriverDate | Should -BeNullOrEmpty
+        }
+    }
+
+    Context 'DeviceClass filter - case insensitive' {
+
+        BeforeAll {
+            Mock -CommandName 'Get-CimInstance' -ModuleName 'PSWinOps' -MockWith {
+                return $script:mockDrivers
+            }
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -MockWith {
+                if ($ArgumentList) {
+                    & $ScriptBlock @ArgumentList
+                } else {
+                    & $ScriptBlock
+                }
+            }
+            $script:result = Get-DriverInventory -DeviceClass 'net'
+        }
+
+        It -Name 'Should return only drivers of the requested class regardless of case' -Test {
+            $script:result | Should -HaveCount 1
+            $script:result[0].DeviceClass | Should -Be 'Net'
+        }
+    }
+
+    Context 'UnsignedOnly filter' {
+
+        BeforeAll {
+            Mock -CommandName 'Get-CimInstance' -ModuleName 'PSWinOps' -MockWith {
+                return $script:mockDrivers
+            }
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -MockWith {
+                if ($ArgumentList) {
+                    & $ScriptBlock @ArgumentList
+                } else {
+                    & $ScriptBlock
+                }
+            }
+            $script:result = Get-DriverInventory -UnsignedOnly
+        }
+
+        It -Name 'Should return only unsigned drivers' -Test {
+            $script:result | Should -HaveCount 1
+            $script:result[0].IsSigned | Should -BeFalse
+            $script:result[0].DeviceName | Should -Be 'Legacy Widget Controller'
+        }
+    }
+
+    Context 'Remote single machine' {
+
+        BeforeAll {
+            Mock -CommandName 'Get-CimInstance' -ModuleName 'PSWinOps' -MockWith {
+                return $script:mockDrivers
+            }
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -MockWith {
+                if ($ArgumentList) {
+                    & $ScriptBlock @ArgumentList
+                } else {
+                    & $ScriptBlock
+                }
+            }
+            $script:result = Get-DriverInventory -ComputerName 'SRV01'
+        }
+
+        It -Name 'Should return ComputerName SRV01' -Test {
+            $script:result[0].ComputerName | Should -Be 'SRV01'
+        }
+
+        It -Name 'Should return valid DriverInventory objects for remote machine' -Test {
+            $script:result[0].PSObject.TypeNames | Should -Contain 'PSWinOps.DriverInventory'
+            $script:result[0].DeviceName | Should -Be 'Intel Ethernet Adapter'
+        }
+    }
+
+    Context 'Pipeline multiple machines' {
+
+        BeforeAll {
+            Mock -CommandName 'Get-CimInstance' -ModuleName 'PSWinOps' -MockWith {
+                return $script:mockDrivers
+            }
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -MockWith {
+                if ($ArgumentList) {
+                    & $ScriptBlock @ArgumentList
+                } else {
+                    & $ScriptBlock
+                }
+            }
+            $script:results = 'SRV01', 'SRV02' | Get-DriverInventory
+        }
+
+        It -Name 'Should return results for both machines' -Test {
+            $script:results | Should -HaveCount 4
+        }
+
+        It -Name 'Should return distinct ComputerName per machine' -Test {
+            ($script:results | Where-Object { $_.ComputerName -eq 'SRV01' }) | Should -HaveCount 2
+            ($script:results | Where-Object { $_.ComputerName -eq 'SRV02' }) | Should -HaveCount 2
+        }
+    }
+
+    Context 'Per-machine failure' {
+
+        BeforeAll {
+        }
+
+        It -Name 'Should write error with ErrorAction Stop' -Test {
+            { Get-DriverInventory -ComputerName 'BADHOST' -ErrorAction Stop } |
+                Should -Throw -ExpectedMessage '*BADHOST*'
+        }
+
+        It -Name 'Should return no output for failed machine' -Test {
+            $script:failResult = Get-DriverInventory -ComputerName 'BADHOST' -ErrorAction SilentlyContinue
+            $script:failResult | Should -BeNullOrEmpty
+        }
+    }
+
+    Context 'Parameter validation' {
+
+        It -Name 'Should throw when ComputerName is empty' -Test {
+            { Get-DriverInventory -ComputerName '' } | Should -Throw
+        }
+
+        It -Name 'Should throw when ComputerName is null' -Test {
+            { Get-DriverInventory -ComputerName $null } | Should -Throw
+        }
+    }
+}

--- a/en-US/about_PSWinOps.help.txt
+++ b/en-US/about_PSWinOps.help.txt
@@ -181,7 +181,7 @@ FUNCTION DOMAINS
 
       Get-AuditPolicy
 
-  system (19 functions)
+  system (20 functions)
     Functions for general system information, state,
     disk cleanup, profile management, and real-time monitoring.
 
@@ -190,6 +190,7 @@ FUNCTION DOMAINS
       Get-CrashDump
       Get-DiskCleanupInfo
       Get-DiskSpace
+      Get-DriverInventory
       Get-EnvironmentVariable
       Get-InstalledSoftware
       Get-PageFileConfiguration
@@ -364,6 +365,7 @@ PSWINOPS TYPE REGISTRY
       PSWinOps.DiskSpace
       PSWinOps.DnsResolution
       PSWinOps.DnsServerHealth
+      PSWinOps.DriverInventory
       PSWinOps.EnvironmentVariable
       PSWinOps.ExchangeServerHealth
       PSWinOps.FileServerHealth


### PR DESCRIPTION
## Summary

Adds `Get-DriverInventory` to the `system` domain — a structured, filterable, multi-machine inventory of installed drivers via `Win32_PnPSignedDriver` (Rule 5 CIM), replacing ad-hoc `driverquery.exe` text and raw `Get-CimInstance` re-projection.

- **Signature:** `Get-DriverInventory [[-ComputerName] <string[]>] [-DeviceClass <string>] [-UnsignedOnly] [-Credential <pscredential>]`
- **Output:** `PSWinOps.DriverInventory` (Table view) — `ComputerName, DeviceName, DeviceClass, Manufacturer, DriverVersion, DriverDate, IsSigned, InfName, Timestamp`
- `-DeviceClass` filters case-insensitively; `-UnsignedOnly` keeps only `IsSigned = $false`; missing version/date are emitted as `$null` (no exclusion).
- Remote `-ComputerName`/`-Credential` via `Invoke-RemoteOrLocal`, per-machine error isolation (Rule 12).

## Changes
- `Public/system/Get-DriverInventory.ps1` (full comment-based help, 3 examples)
- `PSWinOps.Format.ps1xml` — `PSWinOps.DriverInventory` table view
- `PSWinOps.psd1` — `FunctionsToExport` entry, `ModuleVersion` 0.9.1 → 0.10.0, release notes
- `en-US/about_PSWinOps.help.txt` — domain count (19→20), function list, type registry (Rule 14)
- `Tests/Public/system/Get-DriverInventory.Tests.ps1` — Pester v5 (local/remote/pipeline/filters/per-machine failure/param validation)

## Verification
Module is Windows-only and cannot execute on the Linux/ARM dev host; validated locally: PS syntax parse, format XML well-formedness, manifest data load + export placement. PSScriptAnalyzer + Pester run in CI.

Closes #67