### PR TITLE
feat(certificate): add Get-ExpiringCertificate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,7 @@ jobs:
         suite:
           - "Private"
           - "Public/activedirectory"
+          - "Public/certificate"
           - "Public/healthcheck"
           - "Public/iis"
           - "Public/network"

--- a/.kdust/chains/get-expiringcertificate-2609041454.yaml
+++ b/.kdust/chains/get-expiringcertificate-2609041454.yaml
@@ -1,0 +1,7 @@
+chain: pswinops-function-author
+function: Get-ExpiringCertificate
+domain: certificate
+created: 2026-09-04T14:54:16Z
+created_by: pswinops-fn-spec-analyst
+chain_branch: kdust/chain/pswinops-fn-get-expiringcertificate-2609041454
+spec_path: work/get-expiringcertificate/spec.yaml

--- a/PSWinOps.Format.ps1xml
+++ b/PSWinOps.Format.ps1xml
@@ -8099,5 +8099,81 @@
         </TableRowEntries>
       </TableControl>
     </View>
+    <!-- ============================================================ -->
+    <!-- PSWinOps.ExpiringCertificate                                 -->
+    <!-- Used by: Get-ExpiringCertificate                             -->
+    <!-- ============================================================ -->
+    <View>
+      <Name>PSWinOps.ExpiringCertificate</Name>
+      <ViewSelectedBy>
+        <TypeName>PSWinOps.ExpiringCertificate</TypeName>
+      </ViewSelectedBy>
+      <TableControl>
+        <AutoSize />
+        <TableHeaders>
+          <TableColumnHeader>
+            <Label>ComputerName</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>StoreName</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Subject</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Issuer</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Thumbprint</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>NotAfter</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>DaysRemaining</Label>
+            <Alignment>Right</Alignment>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>HasPrivateKey</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>EnhancedKeyUsage</Label>
+          </TableColumnHeader>
+        </TableHeaders>
+        <TableRowEntries>
+          <TableRowEntry>
+            <TableColumnItems>
+              <TableColumnItem>
+                <PropertyName>ComputerName</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>StoreName</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>Subject</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>Issuer</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>Thumbprint</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>NotAfter</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>DaysRemaining</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>HasPrivateKey</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <ScriptBlock>$_.EnhancedKeyUsage -join ', '</ScriptBlock>
+              </TableColumnItem>
+            </TableColumnItems>
+          </TableRowEntry>
+        </TableRowEntries>
+      </TableControl>
+    </View>
   </ViewDefinitions>
 </Configuration>

--- a/PSWinOps.psd1
+++ b/PSWinOps.psd1
@@ -124,6 +124,7 @@
         'Get-DriverInventory',
         'Get-EnvironmentVariable',
         'Get-ExchangeServerHealth',
+        'Get-ExpiringCertificate',
         'Get-FileServerHealth',
         'Get-HyperVHostHealth',
         'Get-IISAppPoolHistory',

--- a/PSWinOps.psd1
+++ b/PSWinOps.psd1
@@ -12,7 +12,7 @@
     RootModule           = 'PSWinOps.psm1'
 
     # Version number of this module.
-    ModuleVersion        = '0.10.0'
+    ModuleVersion        = '0.11.0'
 
     # Supported PSEditions
     # Core is supported on Windows only; the module-level guard in PSWinOps.psm1 blocks
@@ -279,7 +279,11 @@
             # IconUri = ''
 
             # ReleaseNotes of this module
-            ReleaseNotes = '## 0.10.0 - 2026-08-11 UTC
+            ReleaseNotes = '## 0.11.0 - 2026-09-04 UTC
+### Added
+- Get-ExpiringCertificate: Find local-store certificates expiring within a threshold of days
+
+## 0.10.0 - 2026-08-11 UTC
 ### Added
 - Get-DriverInventory: Structured signed-driver inventory via Win32_PnPSignedDriver, filterable by class or unsigned-only, local or remote
 

--- a/Public/certificate/Get-ExpiringCertificate.ps1
+++ b/Public/certificate/Get-ExpiringCertificate.ps1
@@ -1,0 +1,184 @@
+﻿#Requires -Version 5.1
+function Get-ExpiringCertificate {
+    <#
+    .SYNOPSIS
+        Find local-store certificates expiring within a threshold of days
+
+    .DESCRIPTION
+        Scans one or more local machine certificate stores (My, WebHosting, CA, ...) on one or
+        more computers and returns the certificates whose NotAfter falls within the given number
+        of days, sorted by expiry date ascending. Optionally includes already-expired
+        certificates. Complements Get-SSLCertificate (network endpoints) and
+        Get-IISCertificateBinding (IIS bindings) on the local-store side.
+
+    .PARAMETER ComputerName
+        One or more computer names to target. Defaults to the local computer.
+        Accepts pipeline input by value and by property name.
+
+    .PARAMETER Credential
+        Optional PSCredential for authenticating to remote computers.
+        Not used for local queries.
+
+    .PARAMETER DaysUntilExpiration
+        Threshold in days. Certificates whose NotAfter is on or before
+        (Get-Date).AddDays($DaysUntilExpiration) are returned. Defaults to 30.
+
+    .PARAMETER StoreName
+        One or more certificate store names to scan under LocalMachine (for example My,
+        WebHosting, CA, Root). Defaults to 'My'. A store that does not exist on the target
+        machine triggers a warning and is skipped; other stores and machines still process.
+
+    .PARAMETER IncludeExpired
+        Also include certificates whose NotAfter has already passed. DaysRemaining is negative
+        for those certificates.
+
+    .EXAMPLE
+        Get-ExpiringCertificate -DaysUntilExpiration 30
+
+        Local usage example.
+
+    .EXAMPLE
+        Get-ExpiringCertificate -ComputerName 'SRV01' -StoreName 'My','WebHosting' -DaysUntilExpiration 60
+
+        Remote single-machine example.
+
+    .EXAMPLE
+        'SRV01','SRV02' | Get-ExpiringCertificate -IncludeExpired
+
+        Pipeline usage example.
+
+    .OUTPUTS
+        PSWinOps.ExpiringCertificate
+        One object per matching certificate, sorted by NotAfter ascending per machine.
+
+    .NOTES
+        Author: Franck SALLET
+        Version: 1.0.0
+        Last Modified: 2026-09-04
+        Requires: PowerShell 5.1+ / Windows only
+
+    .LINK
+        https://github.com/k9fr4n/PSWinOps
+
+    .LINK
+        https://learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.x509certificates.x509store
+    #>
+    [CmdletBinding(SupportsShouldProcess = $false, ConfirmImpact = 'None')]
+    [OutputType('PSWinOps.ExpiringCertificate')]
+    param(
+        [Parameter(Mandatory = $false, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]$ComputerName = $env:COMPUTERNAME,
+
+        [Parameter(Mandatory = $false)]
+        [System.Management.Automation.PSCredential]$Credential,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateRange(0, [int]::MaxValue)]
+        [int]$DaysUntilExpiration = 30,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]$StoreName = @('My'),
+
+        [Parameter(Mandatory = $false)]
+        [switch]$IncludeExpired
+    )
+
+    begin {
+        Write-Verbose -Message "[$($MyInvocation.MyCommand)] Starting"
+
+        $scriptBlock = {
+            param(
+                [string[]]$StoreNames,
+                [int]$Threshold,
+                [bool]$IncludeExpiredCerts
+            )
+
+            $results = [System.Collections.Generic.List[hashtable]]::new()
+            $now = Get-Date
+            $tsNow = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
+
+            foreach ($sn in $StoreNames) {
+                try {
+                    $certs = @(Get-ChildItem -Path "Cert:\LocalMachine\$sn" -ErrorAction Stop)
+                }
+                catch {
+                    Write-Warning -Message "Certificate store '$sn' not found on '$env:COMPUTERNAME': $($_.Exception.Message)"
+                    continue
+                }
+
+                foreach ($cert in $certs) {
+                    $isExpired = $cert.NotAfter -lt $now
+                    if ($isExpired -and -not $IncludeExpiredCerts) {
+                        continue
+                    }
+                    if ($cert.NotAfter -gt $now.AddDays($Threshold)) {
+                        continue
+                    }
+
+                    $daysRemaining = [int][math]::Floor(($cert.NotAfter - $now).TotalDays)
+                    $eku = @($cert.EnhancedKeyUsageList | ForEach-Object { $_.FriendlyName })
+
+                    $results.Add(@{
+                        ComputerName     = $env:COMPUTERNAME
+                        StoreName        = $sn
+                        Subject          = $cert.Subject
+                        Issuer           = $cert.Issuer
+                        Thumbprint       = $cert.Thumbprint
+                        NotAfter         = $cert.NotAfter
+                        DaysRemaining    = $daysRemaining
+                        HasPrivateKey    = $cert.HasPrivateKey
+                        EnhancedKeyUsage = $eku
+                        Timestamp        = $tsNow
+                    })
+                }
+            }
+
+            return @($results | Sort-Object -Property { $_.NotAfter })
+        }
+    }
+
+    process {
+        foreach ($targetComputer in $ComputerName) {
+            try {
+                $invokeParams = @{
+                    ComputerName = $targetComputer
+                    ScriptBlock  = $scriptBlock
+                    ArgumentList = @(
+                        $StoreName,
+                        $DaysUntilExpiration,
+                        $IncludeExpired.IsPresent
+                    )
+                }
+                if ($Credential) {
+                    $invokeParams['Credential'] = $Credential
+                }
+
+                $rawResults = Invoke-RemoteOrLocal @invokeParams
+                foreach ($r in $rawResults) {
+                    [PSCustomObject]([ordered]@{
+                        PSTypeName       = 'PSWinOps.ExpiringCertificate'
+                        ComputerName     = $r.ComputerName
+                        StoreName        = $r.StoreName
+                        Subject          = $r.Subject
+                        Issuer           = $r.Issuer
+                        Thumbprint       = $r.Thumbprint
+                        NotAfter         = $r.NotAfter
+                        DaysRemaining    = $r.DaysRemaining
+                        HasPrivateKey    = $r.HasPrivateKey
+                        EnhancedKeyUsage = $r.EnhancedKeyUsage
+                        Timestamp        = $r.Timestamp
+                    })
+                }
+            }
+            catch {
+                Write-Error -Message "[$($MyInvocation.MyCommand)] Failed on '$targetComputer': $_"
+            }
+        }
+    }
+
+    end {
+        Write-Verbose -Message "[$($MyInvocation.MyCommand)] Completed"
+    }
+}

--- a/Tests/Public/certificate/Get-ExpiringCertificate.Tests.ps1
+++ b/Tests/Public/certificate/Get-ExpiringCertificate.Tests.ps1
@@ -1,0 +1,270 @@
+﻿#Requires -Version 5.1
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSUseDeclaredVarsMoreThanAssignments', '',
+    Justification = 'Script-scoped variables are assigned in BeforeAll and referenced across nested It scopes'
+)]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSAvoidUsingConvertToSecureStringWithPlainText', '',
+    Justification = 'Test fixture only — not a real credential'
+)]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSAvoidUsingComputerNameHardcoded', '',
+    Justification = 'Fake target names used exclusively in test fixtures — no real machines are contacted'
+)]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSReviewUnusedParameter', '',
+    Justification = 'Stub parameters are declared to satisfy the Pester mock engine (PR #42) but have no body'
+)]
+param()
+
+BeforeAll {
+    $script:modulePath = Split-Path -Path (Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent) -Parent
+    Import-Module -Name (Join-Path -Path $script:modulePath -ChildPath 'PSWinOps.psd1') -Force
+
+    $script:ModuleName = 'PSWinOps'
+    $script:Host1       = 'SRV01'
+    $script:Host2       = 'SRV02'
+    $script:FailHost    = 'FAILHOST'
+
+    # ── Helper: build a fake certificate object ────────────────────────────────
+    function script:New-FakeCert {
+        param(
+            [string]$Subject,
+            [string]$Issuer,
+            [string]$Thumbprint,
+            [datetime]$NotAfter,
+            [bool]$HasPrivateKey = $true,
+            [string[]]$Eku = @('Server Authentication')
+        )
+        [PSCustomObject]@{
+            Subject             = $Subject
+            Issuer              = $Issuer
+            Thumbprint          = $Thumbprint
+            NotAfter            = $NotAfter
+            HasPrivateKey       = $HasPrivateKey
+            EnhancedKeyUsageList = @($Eku | ForEach-Object { [PSCustomObject]@{ FriendlyName = $_ } })
+        }
+    }
+
+    # Certs used for local-path tests (real scriptblock executed via Invoke-RemoteOrLocal,
+    # only Get-ChildItem is mocked at the module boundary).
+    $script:certSoon = New-FakeCert -Subject 'CN=soon.contoso.com' -Issuer 'CN=Contoso CA' `
+        -Thumbprint 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' -NotAfter (Get-Date).AddDays(10)
+    $script:certFar = New-FakeCert -Subject 'CN=far.contoso.com' -Issuer 'CN=Contoso CA' `
+        -Thumbprint 'BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB' -NotAfter (Get-Date).AddDays(365)
+    $script:certExpired = New-FakeCert -Subject 'CN=expired.contoso.com' -Issuer 'CN=Contoso CA' `
+        -Thumbprint 'CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC' -NotAfter (Get-Date).AddDays(-30)
+    $script:certSooner = New-FakeCert -Subject 'CN=sooner.contoso.com' -Issuer 'CN=Contoso CA' `
+        -Thumbprint 'DDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD' -NotAfter (Get-Date).AddDays(3)
+
+    # Raw rows used for remote-path tests (Invoke-RemoteOrLocal itself is mocked,
+    # so these already look like the flattened hashtables the scriptblock returns).
+    $script:mockRemoteRow = @(
+        @{
+            ComputerName     = 'SRV01'
+            StoreName        = 'My'
+            Subject          = 'CN=remote.contoso.com'
+            Issuer           = 'CN=Contoso CA'
+            Thumbprint       = 'EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE'
+            NotAfter         = (Get-Date).AddDays(15)
+            DaysRemaining    = 15
+            HasPrivateKey    = $true
+            EnhancedKeyUsage = @('Server Authentication')
+            Timestamp        = '2026-05-16 12:00:00'
+        }
+    )
+    $script:mockRemoteRowHost2 = @(
+        @{
+            ComputerName     = 'SRV02'
+            StoreName        = 'My'
+            Subject          = 'CN=remote2.contoso.com'
+            Issuer           = 'CN=Contoso CA'
+            Thumbprint       = 'FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF'
+            NotAfter         = (Get-Date).AddDays(20)
+            DaysRemaining    = 20
+            HasPrivateKey    = $false
+            EnhancedKeyUsage = @()
+            Timestamp        = '2026-05-16 12:00:00'
+        }
+    )
+}
+
+Describe 'Get-ExpiringCertificate' {
+
+    # ── Context 1: Local happy path ─────────────────────────────────────────
+    Context 'Local happy path: certs under threshold returned, sorted ascending' {
+
+        It 'Should return certs under threshold sorted by NotAfter ascending, with correct PSTypeName' {
+            Mock -CommandName 'Get-ChildItem' -ModuleName $script:ModuleName `
+                -ParameterFilter { $Path -eq 'Cert:\LocalMachine\My' } `
+                -MockWith { return @($script:certSoon, $script:certFar, $script:certSooner) }
+
+            $result = Get-ExpiringCertificate -DaysUntilExpiration 30
+
+            $result.Count                 | Should -Be 2
+            $result[0].Thumbprint         | Should -Be 'DDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD'
+            $result[1].Thumbprint         | Should -Be 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
+            $result[0].PSObject.TypeNames[0] | Should -Be 'PSWinOps.ExpiringCertificate'
+            $result[0].ComputerName       | Should -Be $env:COMPUTERNAME
+            Should -Invoke -CommandName 'Get-ChildItem' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+
+        It 'Should set Timestamp matching the yyyy-MM-dd HH:mm:ss format pattern' {
+            Mock -CommandName 'Get-ChildItem' -ModuleName $script:ModuleName `
+                -ParameterFilter { $Path -eq 'Cert:\LocalMachine\My' } `
+                -MockWith { return @($script:certSoon) }
+
+            $result = Get-ExpiringCertificate -DaysUntilExpiration 30
+            "$($result.Timestamp)" | Should -Match "^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$"
+        }
+
+        It 'Should populate EnhancedKeyUsage as a string array' {
+            Mock -CommandName 'Get-ChildItem' -ModuleName $script:ModuleName `
+                -ParameterFilter { $Path -eq 'Cert:\LocalMachine\My' } `
+                -MockWith { return @($script:certSoon) }
+
+            $result = Get-ExpiringCertificate -DaysUntilExpiration 30
+            $result.EnhancedKeyUsage | Should -Contain 'Server Authentication'
+        }
+    }
+
+    # ── Context 2: Explicit remote machine with Credential ───────────────────
+    Context 'Explicit remote machine with Credential' {
+
+        It 'Should return the remote result and propagate the supplied credential' {
+            $securePwd = ConvertTo-SecureString -String 'P@ssw0rd!' -AsPlainText -Force
+            $cred = [System.Management.Automation.PSCredential]::new('CONTOSO\svc', $securePwd)
+
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName `
+                -MockWith {
+                    param($ComputerName, $ScriptBlock, $ArgumentList, $Credential)
+                    $script:capturedCredential = $Credential
+                    return $script:mockRemoteRow
+                }
+
+            $result = Get-ExpiringCertificate -ComputerName $script:Host1 -Credential $cred
+
+            $result.ComputerName          | Should -Be 'SRV01'
+            $result.Thumbprint            | Should -Be 'EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE'
+            $script:capturedCredential    | Should -Be $cred
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 1 -Exactly
+        }
+    }
+
+    # ── Context 3: Pipeline of multiple machine names ─────────────────────────
+    Context 'Pipeline of multiple machine names' {
+
+        It 'Should invoke once per machine and return combined results' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName `
+                -MockWith {
+                    param($ComputerName, $ScriptBlock, $ArgumentList, $Credential)
+                    if ($ComputerName -eq 'SRV01') { return $script:mockRemoteRow }
+                    if ($ComputerName -eq 'SRV02') { return $script:mockRemoteRowHost2 }
+                }
+
+            $result = @($script:Host1, $script:Host2) | Get-ExpiringCertificate
+
+            $result.Count | Should -Be 2
+            ($result.ComputerName | Sort-Object) | Should -Be @('SRV01', 'SRV02')
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 2 -Exactly
+        }
+    }
+
+    # ── Context 4: Per-machine error isolation ────────────────────────────────
+    Context 'Per-machine failure: continues to next machine and writes an error' {
+
+        It 'Should write an error for the failing machine but still return the other machine result' {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName `
+                -MockWith {
+                    param($ComputerName, $ScriptBlock, $ArgumentList, $Credential)
+                    if ($ComputerName -eq $script:FailHost) {
+                        throw 'WinRM connection refused'
+                    }
+                    return $script:mockRemoteRow
+                }
+
+            $result = @($script:FailHost, $script:Host1) | Get-ExpiringCertificate -ErrorVariable errs -ErrorAction SilentlyContinue
+
+            $result.ComputerName | Should -Be 'SRV01'
+            $errs.Count           | Should -BeGreaterThan 0
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName $script:ModuleName -Times 2 -Exactly
+        }
+    }
+
+    # ── Context 5: Non-existent StoreName ─────────────────────────────────────
+    Context 'Non-existent StoreName: warns and skips, does not throw' {
+
+        It 'Should write a warning for the missing store and still return certs from the other store' {
+            Mock -CommandName 'Get-ChildItem' -ModuleName $script:ModuleName `
+                -ParameterFilter { $Path -eq 'Cert:\LocalMachine\Bogus' } `
+                -MockWith { throw [System.Management.Automation.ItemNotFoundException]::new('Cannot find path') }
+            Mock -CommandName 'Get-ChildItem' -ModuleName $script:ModuleName `
+                -ParameterFilter { $Path -eq 'Cert:\LocalMachine\My' } `
+                -MockWith { return @($script:certSoon) }
+
+            $result = Get-ExpiringCertificate -StoreName 'Bogus', 'My' -DaysUntilExpiration 30 -WarningVariable warnings -WarningAction SilentlyContinue
+
+            $result.Thumbprint | Should -Be 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
+            $warnings.Count    | Should -BeGreaterThan 0
+        }
+    }
+
+    # ── Context 6: IncludeExpired toggle ──────────────────────────────────────
+    Context 'IncludeExpired toggles expired certs in/out' {
+
+        It 'Should exclude expired certs by default' {
+            Mock -CommandName 'Get-ChildItem' -ModuleName $script:ModuleName `
+                -ParameterFilter { $Path -eq 'Cert:\LocalMachine\My' } `
+                -MockWith { return @($script:certExpired, $script:certSoon) }
+
+            $result = Get-ExpiringCertificate -DaysUntilExpiration 30
+
+            $result.Count      | Should -Be 1
+            $result.Thumbprint | Should -Be 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
+        }
+
+        It 'Should include expired certs with negative DaysRemaining when -IncludeExpired is set' {
+            Mock -CommandName 'Get-ChildItem' -ModuleName $script:ModuleName `
+                -ParameterFilter { $Path -eq 'Cert:\LocalMachine\My' } `
+                -MockWith { return @($script:certExpired, $script:certSoon) }
+
+            $result = Get-ExpiringCertificate -DaysUntilExpiration 30 -IncludeExpired
+
+            $result.Count | Should -Be 2
+            ($result | Where-Object { $_.Thumbprint -eq 'CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC' }).DaysRemaining | Should -BeLessThan 0
+        }
+    }
+
+    # ── Context 7: Empty result ────────────────────────────────────────────────
+    Context 'Empty result: no cert under threshold' {
+
+        It 'Should emit nothing and no error when no certificate is under threshold' {
+            Mock -CommandName 'Get-ChildItem' -ModuleName $script:ModuleName `
+                -ParameterFilter { $Path -eq 'Cert:\LocalMachine\My' } `
+                -MockWith { return @($script:certFar) }
+
+            $result = Get-ExpiringCertificate -DaysUntilExpiration 30 -ErrorVariable errs
+
+            $result       | Should -BeNullOrEmpty
+            $errs.Count   | Should -Be 0
+        }
+    }
+
+    # ── Context 8: Parameter validation ───────────────────────────────────────
+    Context 'Parameter validation' {
+
+        It 'Should throw for a negative DaysUntilExpiration' {
+            { Get-ExpiringCertificate -DaysUntilExpiration -1 } | Should -Throw
+        }
+
+        It 'Should throw for an empty StoreName array' {
+            { Get-ExpiringCertificate -StoreName @() } | Should -Throw
+        }
+
+        It 'Should throw for an empty ComputerName value' {
+            { Get-ExpiringCertificate -ComputerName '' } | Should -Throw
+        }
+    }
+}

--- a/en-US/about_PSWinOps.help.txt
+++ b/en-US/about_PSWinOps.help.txt
@@ -1,4 +1,4 @@
-TOPIC
+﻿TOPIC
     about_PSWinOps
 
 SHORT DESCRIPTION
@@ -12,7 +12,7 @@ LONG DESCRIPTION
     PSWinOps is a comprehensive toolbox designed for Windows
     system administrators running PowerShell 5.1 or later.
     It provides a curated collection of functions organized
-    into thirteen functional domains, covering everything from
+    into fourteen functional domains, covering everything from
     Active Directory inventory and security auditing,
     service health monitoring, network troubleshooting,
     NTP synchronization, proxy management, RDP session
@@ -31,7 +31,7 @@ LONG DESCRIPTION
     Requires    : PowerShell 5.1+ / Windows only
 
 FUNCTION DOMAINS
-    PSWinOps organizes its functions into thirteen domains.
+    PSWinOps organizes its functions into fourteen domains.
 
   activedirectory (21 functions)
     Functions for Active Directory inventory, user and
@@ -61,6 +61,12 @@ FUNCTION DOMAINS
       Reset-ADUserPassword
       Search-ADObject
       Unlock-ADUserAccount
+
+  certificate (1 function)
+    Functions for auditing local machine certificate stores
+    for certificates nearing or past expiration.
+
+      Get-ExpiringCertificate
 
   eventlog (3 functions)
     Functions for correlating Windows System event log
@@ -322,7 +328,7 @@ REMOTE EXECUTION PATTERN
     in the pipeline continue to be processed.
 
 PSWINOPS TYPE REGISTRY
-    The following 101 PSTypeName values are defined by the
+    The following 102 PSTypeName values are defined by the
     module. Each corresponds to the output of one or more
     public functions.
 
@@ -368,6 +374,7 @@ PSWINOPS TYPE REGISTRY
       PSWinOps.DriverInventory
       PSWinOps.EnvironmentVariable
       PSWinOps.ExchangeServerHealth
+      PSWinOps.ExpiringCertificate
       PSWinOps.FileServerHealth
       PSWinOps.HyperVHostHealth
       PSWinOps.IISAppPoolHistoryEvent


### PR DESCRIPTION
## Summary
Scans one or more local machine certificate stores (My, WebHosting, CA, ...) on one or more computers and returns the certificates whose NotAfter falls within the given number of days, sorted by expiry date ascending. Optionally includes already-expired certificates. Complements Get-SSLCertificate (network endpoints) and Get-IISCertificateBinding (IIS bindings) on the local-store side.

Implements #74 (new `certificate` domain). Closes #74.

## Files touched
- `Public/certificate/Get-ExpiringCertificate.ps1` — implementation
- `Tests/Public/certificate/Get-ExpiringCertificate.Tests.ps1` — Pester v5 suite
- `PSWinOps.psd1` — FunctionsToExport, ModuleVersion (0.10.0 -> 0.11.0, minor), ReleaseNotes
- `PSWinOps.Format.ps1xml` — new `<View>` for `PSWinOps.ExpiringCertificate`
- `en-US/about_PSWinOps.help.txt` — new `certificate` domain section, domain/type counters bumped
- `.github/workflows/ci.yml` — matrix updated with `Public/certificate` (new domain)

## Conformance checklist (audited locally by fn-quality-gate)
- [x] UTF-8 BOM + CRLF on both new files
- [x] Approved PowerShell verb (`Get`)
- [x] `FunctionsToExport` — new entry present once, correctly placed alphabetically
- [x] `PSTypeName` consistent across .ps1 / Format.ps1xml / about help (`PSWinOps.ExpiringCertificate`)
- [x] No `Write-Host`, no `ToString('o')`, no WMI cmdlets in the diff
- [x] `PSWinOps.Format.ps1xml` is valid XML with a matching `<View>`

## Verification
Dynamic verification (Test-ModuleManifest, PSScriptAnalyzer, Pester matrix) runs on the Windows CI for this PR. Merge once all required checks are green.
