### PR TITLE
feat(eventlog): add disk error event reporting (#89)

### DIFF
--- a/PSWinOps.Format.ps1xml
+++ b/PSWinOps.Format.ps1xml
@@ -7996,6 +7996,90 @@
       </TableControl>
     </View>
     <!-- ============================================================ -->
+    <!-- PSWinOps.DiskErrorEvent                                      -->
+    <!-- Used by: Get-DiskErrorEvent                                  -->
+    <!-- ============================================================ -->
+    <View>
+      <Name>PSWinOps.DiskErrorEvent</Name>
+      <ViewSelectedBy>
+        <TypeName>PSWinOps.DiskErrorEvent</TypeName>
+      </ViewSelectedBy>
+      <TableControl>
+        <AutoSize />
+        <TableHeaders>
+          <TableColumnHeader>
+            <Label>ComputerName</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>EventTime</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>ProviderName</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>EventId</Label>
+            <Alignment>Right</Alignment>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>ErrorType</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Critical</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>DiskNumber</Label>
+            <Alignment>Right</Alignment>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>DeviceName</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>ErrorCode</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>EventCount</Label>
+            <Alignment>Right</Alignment>
+          </TableColumnHeader>
+        </TableHeaders>
+        <TableRowEntries>
+          <TableRowEntry>
+            <TableColumnItems>
+              <TableColumnItem>
+                <PropertyName>ComputerName</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>EventTime</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>ProviderName</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>EventId</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>ErrorType</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>IsCritical</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>DiskNumber</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>DeviceName</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>ErrorCode</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>EventCount</PropertyName>
+              </TableColumnItem>
+            </TableColumnItems>
+          </TableRowEntry>
+        </TableRowEntries>
+      </TableControl>
+    </View>
+    <!-- ============================================================ -->
     <!-- PSWinOps.CrashDump                                           -->
     <!-- Used by: Get-CrashDump                                       -->
     <!-- ============================================================ -->

--- a/PSWinOps.psd1
+++ b/PSWinOps.psd1
@@ -120,6 +120,7 @@
         'Get-DfsReplicationHealth',
         'Get-DhcpServerHealth',
         'Get-DiskCleanupInfo',
+        'Get-DiskErrorEvent',
         'Get-DiskSpace',
         'Get-DnsServerHealth',
         'Get-DriverInventory',
@@ -284,6 +285,7 @@
             ReleaseNotes = '## 0.12.0 - 2026-09-04 UTC
 ### Added
 - Get-ADLockoutSource: Trace the source machine of an AD account lockout via event 4740 on the PDC Emulator
+- Get-DiskErrorEvent: Classify and aggregate Disk, Ntfs, storahci, and storport storage errors from the System log
 - Get-ProcessCrashEvent: Correlate Application Error, Windows Error Reporting, and optional Application Hang events with per-process counts
 
 ## 0.11.0 - 2026-09-04 UTC

--- a/Public/eventlog/Get-DiskErrorEvent.ps1
+++ b/Public/eventlog/Get-DiskErrorEvent.ps1
@@ -1,0 +1,317 @@
+#Requires -Version 5.1
+
+function Get-DiskErrorEvent {
+    <#
+    .SYNOPSIS
+        Report disk, controller, NTFS, and storage errors from the System log
+
+    .DESCRIPTION
+        Queries the Windows System event log for known Disk, Ntfs, storahci, and storport
+        error events over a configurable look-back window. Named EventData fields are
+        parsed from event XML so localized message text does not drive classification.
+
+        Results are classified from centralized provider and event-ID mappings, aggregated
+        by provider, error type, and device, and returned newest first for each machine.
+        Missing event fields remain empty or null, and remote failures do not stop other
+        computers from being processed.
+
+    .PARAMETER ComputerName
+        One or more computer names to target. Defaults to the local computer.
+        Accepts pipeline input by value and by property name.
+
+    .PARAMETER Days
+        Look-back window in days. Valid values are 1 through 3650. Defaults to 7.
+
+    .PARAMETER MaxEvents
+        Maximum number of System log events read per machine. Valid values are 1 through
+        10000. Defaults to 200.
+
+    .PARAMETER DiskNumber
+        Optional disk number filter. Events without a disk number are excluded when this
+        filter is specified.
+
+    .PARAMETER CriticalOnly
+        Return only events classified as critical or likely to indicate hardware failure.
+
+    .PARAMETER Credential
+        Optional PSCredential for authenticating to remote machines. Ignored for local
+        machine queries.
+
+    .EXAMPLE
+        Get-DiskErrorEvent
+
+        Returns recognized disk and storage errors from the local computer over the last
+        seven days.
+
+    .EXAMPLE
+        Get-DiskErrorEvent -ComputerName 'SRV01' -Days 30 -CriticalOnly
+
+        Returns critical storage errors from SRV01 over the last 30 days.
+
+    .EXAMPLE
+        'SRV01', 'SRV02' | Get-DiskErrorEvent -MaxEvents 500 -DiskNumber 0
+
+        Returns disk-zero errors from multiple computers through pipeline input.
+
+    .OUTPUTS
+        PSWinOps.DiskErrorEvent
+        One object per recognized storage event, newest first, with classification and
+        an EventCount aggregated over the selected look-back window.
+
+    .NOTES
+        Author: Franck SALLET
+        Version: 1.0.0
+        Last Modified: 2026-09-04
+        Requires: PowerShell 5.1+ / Windows only
+        Requires: Event Log Readers membership for remote or protected System log access
+        Requires: WinRM enabled on target machines for remote queries
+
+        IsCritical is deterministic: BadBlock, ControllerReset, and FileSystem are critical;
+        IoTimeout is non-critical unless the event is mapped to a provider/ID marked critical;
+        Unknown is non-critical. Localized Message text is never used for classification.
+
+    .LINK
+        https://github.com/k9fr4n/PSWinOps
+
+    .LINK
+        https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.diagnostics/get-winevent
+    #>
+    [CmdletBinding(SupportsShouldProcess = $false, ConfirmImpact = 'None')]
+    [OutputType('PSWinOps.DiskErrorEvent')]
+    param(
+        [Parameter(Mandatory = $false, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [ValidateNotNullOrEmpty()]
+        [Alias('CN', 'Name', 'DNSHostName')]
+        [string[]]$ComputerName = $env:COMPUTERNAME,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateRange(1, 3650)]
+        [int]$Days = 7,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateRange(1, 10000)]
+        [int]$MaxEvents = 200,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateRange(0, 2147483647)]
+        [Nullable[int]]$DiskNumber,
+
+        [Parameter(Mandatory = $false)]
+        [switch]$CriticalOnly,
+
+        [Parameter(Mandatory = $false)]
+        [System.Management.Automation.PSCredential]$Credential
+    )
+
+    begin {
+        Write-Verbose "[$($MyInvocation.MyCommand)] Starting disk error event query"
+
+        $startTime = (Get-Date).AddDays(-$Days)
+        $diskFilter = if ($DiskNumber -ge 0) { $DiskNumber } else { $null }
+
+        $scriptBlock = {
+            param(
+                [datetime]$ScanStartTime,
+                [int]$MaxEvts,
+                [Nullable[int]]$DiskNumberFilter,
+                [bool]$CriticalOnlyFilter
+            )
+
+            $eventDefinitions = @{
+                'disk|7'       = [PSCustomObject]@{ ErrorType = 'BadBlock';        IsCritical = $true  }
+                'disk|51'      = [PSCustomObject]@{ ErrorType = 'IoTimeout';       IsCritical = $false }
+                'disk|154'     = [PSCustomObject]@{ ErrorType = 'IoTimeout';       IsCritical = $true  }
+                'ntfs|55'      = [PSCustomObject]@{ ErrorType = 'FileSystem';      IsCritical = $true  }
+                'storahci|129' = [PSCustomObject]@{ ErrorType = 'ControllerReset'; IsCritical = $true  }
+                'storahci|153' = [PSCustomObject]@{ ErrorType = 'IoTimeout';       IsCritical = $false }
+                'storport|129' = [PSCustomObject]@{ ErrorType = 'ControllerReset'; IsCritical = $true  }
+                'storport|153' = [PSCustomObject]@{ ErrorType = 'IoTimeout';       IsCritical = $false }
+            }
+
+            $filter = @{
+                LogName      = 'System'
+                ProviderName = @('Disk', 'Ntfs', 'storahci', 'storport')
+                Id           = @(7, 51, 55, 129, 153, 154)
+                StartTime    = $ScanStartTime
+            }
+
+            $eventRecords = @()
+            try {
+                $eventRecords = @(Get-WinEvent -FilterHashtable $filter -MaxEvents $MaxEvts -ErrorAction Stop)
+            } catch {
+                if ($_.Exception.Message -notmatch 'No events were found') {
+                    throw
+                }
+            }
+
+            if ($eventRecords.Count -eq 0) {
+                return
+            }
+
+            function Get-EventDataMap {
+                param(
+                    [Parameter(Mandatory = $true)]
+                    [object]$Event
+                )
+
+                $map = @{}
+                try {
+                    $xml = [xml]$Event.ToXml()
+                    foreach ($node in @($xml.SelectNodes("//*[local-name()='Data']"))) {
+                        $name = [string]$node.GetAttribute('Name')
+                        if ([string]::IsNullOrWhiteSpace($name)) {
+                            continue
+                        }
+
+                        $map[$name] = [string]$node.InnerText
+                    }
+                } catch {
+                    Write-Verbose "Could not parse event $($Event.Id) as XML: $_"
+                }
+
+                return $map
+            }
+
+            function Get-EventField {
+                param(
+                    [Parameter(Mandatory = $true)]
+                    [hashtable]$Data,
+                    [Parameter(Mandatory = $true)]
+                    [string[]]$Names
+                )
+
+                foreach ($name in $Names) {
+                    if ($Data.ContainsKey($name) -and -not [string]::IsNullOrWhiteSpace([string]$Data[$name])) {
+                        return [string]$Data[$name]
+                    }
+                }
+
+                return ''
+            }
+
+            function ConvertTo-DiskNumber {
+                param(
+                    [string]$Value
+                )
+
+                if ([string]::IsNullOrWhiteSpace($Value)) {
+                    return $null
+                }
+
+                $match = [regex]::Match($Value, '^\s*(\d+)\s*$')
+                if ($match.Success) {
+                    return [int]$match.Groups[1].Value
+                }
+
+                $match = [regex]::Match($Value, '(?i)harddisk(\d+)')
+                if ($match.Success) {
+                    return [int]$match.Groups[1].Value
+                }
+
+                return $null
+            }
+
+            $rows = [System.Collections.Generic.List[psobject]]::new()
+            foreach ($eventRecord in @($eventRecords | Sort-Object -Property TimeCreated -Descending)) {
+                $providerName = [string]$eventRecord.ProviderName
+                $eventId = [int]$eventRecord.Id
+                $definitionKey = "$($providerName.ToLowerInvariant())|$eventId"
+                if (-not $eventDefinitions.ContainsKey($definitionKey)) {
+                    continue
+                }
+
+                $data = Get-EventDataMap -Event $eventRecord
+                $deviceName = Get-EventField -Data $data -Names @('DeviceName', 'Device')
+                $devicePath = Get-EventField -Data $data -Names @('DevicePath', 'TargetDevice', 'Path')
+                $diskNumberValue = Get-EventField -Data $data -Names @('DiskNumber', 'DeviceNumber', 'TargetDeviceNumber')
+                $diskNumberFromData = ConvertTo-DiskNumber -Value $diskNumberValue
+                if ($null -eq $diskNumberFromData) {
+                    $diskNumberFromData = ConvertTo-DiskNumber -Value $deviceName
+                }
+                if ($null -eq $diskNumberFromData) {
+                    $diskNumberFromData = ConvertTo-DiskNumber -Value $devicePath
+                }
+
+                $definition = $eventDefinitions[$definitionKey]
+                $errorType = $definition.ErrorType
+                $isCritical = [bool]$definition.IsCritical
+                if ($data.Count -eq 0) {
+                    $errorType = 'Unknown'
+                    $isCritical = $false
+                }
+
+                $rows.Add([PSCustomObject]@{
+                    EventTime    = $eventRecord.TimeCreated
+                    ProviderName = $providerName
+                    EventId      = $eventId
+                    ErrorType    = $errorType
+                    IsCritical   = $isCritical
+                    DiskNumber   = $diskNumberFromData
+                    DeviceName   = $deviceName
+                    DevicePath   = $devicePath
+                    ErrorCode    = Get-EventField -Data $data -Names @('ErrorCode', 'Error', 'Status')
+                    RetryCount   = ConvertTo-DiskNumber -Value (Get-EventField -Data $data -Names @('RetryCount', 'Retries'))
+                    Message      = [string]$eventRecord.Message
+                })
+            }
+
+            $eventTally = @{}
+            foreach ($row in $rows) {
+                $diskKey = if ($null -eq $row.DiskNumber) { '' } else { [string]$row.DiskNumber }
+                $key = '{0}|{1}|{2}|{3}|{4}' -f $row.ProviderName.ToLowerInvariant(), $row.ErrorType, $diskKey, $row.DeviceName, $row.DevicePath
+                if ($eventTally.ContainsKey($key)) {
+                    $eventTally[$key]++
+                } else {
+                    $eventTally[$key] = 1
+                }
+            }
+
+            foreach ($row in ($rows | Sort-Object -Property EventTime -Descending)) {
+                if ($null -ne $DiskNumberFilter -and $row.DiskNumber -ne $DiskNumberFilter) {
+                    continue
+                }
+                if ($CriticalOnlyFilter -and -not $row.IsCritical) {
+                    continue
+                }
+
+                $diskKey = if ($null -eq $row.DiskNumber) { '' } else { [string]$row.DiskNumber }
+                $key = '{0}|{1}|{2}|{3}|{4}' -f $row.ProviderName.ToLowerInvariant(), $row.ErrorType, $diskKey, $row.DeviceName, $row.DevicePath
+
+                [PSCustomObject]@{
+                    PSTypeName   = 'PSWinOps.DiskErrorEvent'
+                    ComputerName = $env:COMPUTERNAME
+                    EventTime    = $row.EventTime.ToString('o')
+                    ProviderName = $row.ProviderName
+                    EventId      = $row.EventId
+                    ErrorType    = $row.ErrorType
+                    IsCritical   = $row.IsCritical
+                    DiskNumber   = $row.DiskNumber
+                    DeviceName   = $row.DeviceName
+                    DevicePath   = $row.DevicePath
+                    ErrorCode    = $row.ErrorCode
+                    RetryCount   = $row.RetryCount
+                    EventCount   = $eventTally[$key]
+                    Message      = $row.Message
+                    Timestamp    = Get-Date -Format 'o'
+                }
+            }
+        }
+    }
+
+    process {
+        foreach ($targetComputer in $ComputerName) {
+            try {
+                Write-Verbose "[$($MyInvocation.MyCommand)] Querying disk error events on '$targetComputer'"
+                Invoke-RemoteOrLocal -ComputerName $targetComputer -Credential $Credential `
+                    -ScriptBlock $scriptBlock `
+                    -ArgumentList @($startTime, $MaxEvents, $diskFilter, [bool]$CriticalOnly)
+            } catch {
+                Write-Error "[$($MyInvocation.MyCommand)] Failed on '$targetComputer': $_"
+            }
+        }
+    }
+
+    end {
+        Write-Verbose "[$($MyInvocation.MyCommand)] Completed disk error event query"
+    }
+}

--- a/Tests/Public/eventlog/Get-DiskErrorEvent.Tests.ps1
+++ b/Tests/Public/eventlog/Get-DiskErrorEvent.Tests.ps1
@@ -1,0 +1,233 @@
+#Requires -Version 5.1
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+
+param()
+
+BeforeAll {
+    $script:modulePath = Split-Path -Path (Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent) -Parent
+    Import-Module -Name (Join-Path -Path $script:modulePath -ChildPath 'PSWinOps.psd1') -Force
+
+    function New-MockDiskEvent {
+        param(
+            [Parameter(Mandatory = $true)]
+            [string]$ProviderName,
+            [Parameter(Mandatory = $true)]
+            [int]$EventId,
+            [Parameter(Mandatory = $true)]
+            [datetime]$TimeCreated,
+            [Parameter(Mandatory = $true)]
+            [string]$XmlContent,
+            [string]$Message = 'Simulated storage event'
+        )
+
+        $mockEvent = [PSCustomObject]@{
+            ProviderName = $ProviderName
+            Id           = $EventId
+            TimeCreated  = $TimeCreated
+            Message      = $Message
+        }
+
+        $mockEvent | Add-Member -MemberType ScriptMethod -Name 'ToXml' -Value {
+            return $XmlContent
+        }.GetNewClosure() -Force
+
+        return $mockEvent
+    }
+
+    function New-DiskEventXml {
+        param(
+            [string]$DiskNumber = '0',
+            [string]$DeviceName = '\\Device\\Harddisk0\\DR0',
+            [string]$DevicePath = '\\Device\\0000007a',
+            [string]$ErrorCode = '0xC0000185',
+            [string]$RetryCount = '3'
+        )
+
+        @"
+<Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
+  <EventData>
+    <Data Name="DiskNumber">$DiskNumber</Data>
+    <Data Name="DeviceName">$DeviceName</Data>
+    <Data Name="DevicePath">$DevicePath</Data>
+    <Data Name="ErrorCode">$ErrorCode</Data>
+    <Data Name="RetryCount">$RetryCount</Data>
+  </EventData>
+</Event>
+"@
+    }
+}
+
+Describe -Name 'Get-DiskErrorEvent' -Fixture {
+    Context -Name 'Local parsing, classification, sorting, and aggregation' -Fixture {
+        BeforeAll {
+            $script:badBlockNewest = New-MockDiskEvent -ProviderName 'Disk' -EventId 7 `
+                -TimeCreated (Get-Date '2026-09-04 10:00:00') -XmlContent (New-DiskEventXml)
+            $script:badBlockOlder = New-MockDiskEvent -ProviderName 'Disk' -EventId 7 `
+                -TimeCreated (Get-Date '2026-09-03 10:00:00') -XmlContent (New-DiskEventXml)
+            $script:ioTimeout = New-MockDiskEvent -ProviderName 'Disk' -EventId 51 `
+                -TimeCreated (Get-Date '2026-09-02 10:00:00') -XmlContent (New-DiskEventXml -DiskNumber '1' -DeviceName '\\Device\\Harddisk1\\DR1')
+            $script:controllerReset = New-MockDiskEvent -ProviderName 'storport' -EventId 129 `
+                -TimeCreated (Get-Date '2026-09-01 10:00:00') -XmlContent (New-DiskEventXml -DiskNumber '2' -DeviceName '\\Device\\Harddisk2\\DR2')
+            $script:ignoredProvider = New-MockDiskEvent -ProviderName 'CustomProvider' -EventId 7 `
+                -TimeCreated (Get-Date '2026-09-04 11:00:00') -XmlContent (New-DiskEventXml)
+
+            Mock -CommandName 'Get-WinEvent' -ModuleName 'PSWinOps' -MockWith {
+                @($script:badBlockOlder, $script:ioTimeout, $script:controllerReset, $script:ignoredProvider, $script:badBlockNewest)
+            }
+        }
+
+        It -Name 'Should return recognized events newest first and ignore unrelated provider IDs' -Test {
+            $result = @(Get-DiskErrorEvent)
+            $result.Count | Should -Be 4
+            $result[0].EventId | Should -Be 7
+            $result[0].ProviderName | Should -Be 'Disk'
+            $result[0].PSObject.TypeNames[0] | Should -Be 'PSWinOps.DiskErrorEvent'
+            [string[]]$result.EventTime | Should -Be ([string[]]($result.EventTime | Sort-Object -Descending))
+        }
+
+        It -Name 'Should parse named XML fields and classify events deterministically' -Test {
+            $result = @(Get-DiskErrorEvent)
+            $badBlock = $result | Where-Object { $_.EventId -eq 7 } | Select-Object -First 1
+            $badBlock.ErrorType | Should -Be 'BadBlock'
+            $badBlock.IsCritical | Should -BeTrue
+            $badBlock.DiskNumber | Should -Be 0
+            $badBlock.DeviceName | Should -Be '\\Device\\Harddisk0\\DR0'
+            $badBlock.ErrorCode | Should -Be '0xC0000185'
+            $badBlock.RetryCount | Should -Be 3
+        }
+
+        It -Name 'Should aggregate EventCount by provider, error type, and device' -Test {
+            $result = @(Get-DiskErrorEvent)
+            @($result | Where-Object { $_.EventId -eq 7 } | Select-Object -ExpandProperty EventCount) | Should -Be @(2, 2)
+        }
+    }
+
+    Context -Name 'Filters and incomplete XML' -Fixture {
+        BeforeAll {
+            $script:critical = New-MockDiskEvent -ProviderName 'Ntfs' -EventId 55 `
+                -TimeCreated (Get-Date '2026-09-04 10:00:00') -XmlContent (New-DiskEventXml -DiskNumber '0')
+            $script:warning = New-MockDiskEvent -ProviderName 'storport' -EventId 153 `
+                -TimeCreated (Get-Date '2026-09-04 09:00:00') -XmlContent (New-DiskEventXml -DiskNumber '1')
+            $script:incomplete = New-MockDiskEvent -ProviderName 'Disk' -EventId 154 `
+                -TimeCreated (Get-Date '2026-09-04 08:00:00') `
+                -XmlContent '<Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event"><EventData /></Event>'
+
+            Mock -CommandName 'Get-WinEvent' -ModuleName 'PSWinOps' -MockWith {
+                @($script:critical, $script:warning, $script:incomplete)
+            }
+        }
+
+        It -Name 'Should apply DiskNumber after parsing' -Test {
+            $result = @(Get-DiskErrorEvent -DiskNumber 1)
+            $result.Count | Should -Be 1
+            $result[0].ProviderName | Should -Be 'storport'
+            $result[0].DiskNumber | Should -Be 1
+        }
+
+        It -Name 'Should apply CriticalOnly after classification' -Test {
+            $result = @(Get-DiskErrorEvent -CriticalOnly)
+            $result.Count | Should -Be 1
+            $result[0].ErrorType | Should -Be 'FileSystem'
+            $result[0].IsCritical | Should -BeTrue
+        }
+
+        It -Name 'Should preserve incomplete events as non-critical Unknown rows' -Test {
+            $result = @(Get-DiskErrorEvent)
+            $unknown = $result | Where-Object { $_.EventId -eq 154 }
+            $unknown.ErrorType | Should -Be 'Unknown'
+            $unknown.IsCritical | Should -BeFalse
+            $unknown.DiskNumber | Should -BeNullOrEmpty
+            $unknown.DevicePath | Should -Be ''
+        }
+    }
+
+    Context -Name 'Remote, pipeline, and error isolation' -Fixture {
+        BeforeAll {
+            Mock -CommandName 'Invoke-Command' -ModuleName 'PSWinOps' -MockWith {
+                [PSCustomObject]@{
+                    PSTypeName   = 'PSWinOps.DiskErrorEvent'
+                    ComputerName = 'SRV01'
+                    EventTime    = '2026-09-04T10:00:00.0000000'
+                    ProviderName = 'Disk'
+                    EventId      = 7
+                    ErrorType    = 'BadBlock'
+                    IsCritical   = $true
+                    DiskNumber   = 0
+                    DeviceName   = '\\Device\\Harddisk0\\DR0'
+                    DevicePath   = ''
+                    ErrorCode    = ''
+                    RetryCount   = $null
+                    EventCount   = 1
+                    Message      = 'Simulated disk error'
+                    Timestamp    = '2026-09-04T10:00:00.0000000'
+                }
+            }
+        }
+
+        It -Name 'Should dispatch remote queries and propagate Credential' -Test {
+            $securePassword = ConvertTo-SecureString -String 'P@ssw0rd123!' -AsPlainText -Force
+            $credential = [System.Management.Automation.PSCredential]::new('CONTOSO\svc', $securePassword)
+            $result = @(Get-DiskErrorEvent -ComputerName 'SRV01' -Credential $credential)
+            $result.ComputerName | Should -Be 'SRV01'
+            Should -Invoke -CommandName 'Invoke-Command' -ModuleName 'PSWinOps' -Times 1 -Exactly -ParameterFilter {
+                $Credential -eq $credential
+            }
+        }
+
+        It -Name 'Should continue after a per-machine failure in pipeline input' -Test {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -MockWith {
+                if ($ComputerName -eq 'SRV01') {
+                    throw 'Simulated failure on SRV01'
+                }
+
+                [PSCustomObject]@{
+                    PSTypeName   = 'PSWinOps.DiskErrorEvent'
+                    ComputerName = $ComputerName
+                    EventTime    = '2026-09-04T10:00:00.0000000'
+                    ProviderName = 'Disk'
+                    EventId      = 7
+                    ErrorType    = 'BadBlock'
+                    IsCritical   = $true
+                    DiskNumber   = 0
+                    DeviceName   = ''
+                    DevicePath   = ''
+                    ErrorCode    = ''
+                    RetryCount   = $null
+                    EventCount   = 1
+                    Message      = ''
+                    Timestamp    = '2026-09-04T10:00:00.0000000'
+                }
+            }
+
+            $output = 'SRV01', 'SRV02' | Get-DiskErrorEvent -ErrorAction Continue 2>&1
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -Times 2 -Exactly
+            @($output | Where-Object { $_ -is [System.Management.Automation.ErrorRecord] }).Count | Should -BeGreaterThan 0
+            @($output | Where-Object { $_ -isnot [System.Management.Automation.ErrorRecord] }).Count | Should -Be 1
+            ($output | Where-Object { $_ -isnot [System.Management.Automation.ErrorRecord] }).ComputerName | Should -Be 'SRV02'
+        }
+    }
+
+    Context -Name 'Parameter validation and metadata' -Fixture {
+        It -Name 'Should reject invalid ComputerName, Days, MaxEvents, and DiskNumber' -Test {
+            { Get-DiskErrorEvent -ComputerName '' } | Should -Throw
+            { Get-DiskErrorEvent -ComputerName $null } | Should -Throw
+            { Get-DiskErrorEvent -Days 0 } | Should -Throw
+            { Get-DiskErrorEvent -Days 3651 } | Should -Throw
+            { Get-DiskErrorEvent -MaxEvents 0 } | Should -Throw
+            { Get-DiskErrorEvent -MaxEvents 10001 } | Should -Throw
+            { Get-DiskErrorEvent -DiskNumber -1 } | Should -Throw
+        }
+
+        It -Name 'Should expose pipeline support and aliases on ComputerName' -Test {
+            $command = Get-Command -Name 'Get-DiskErrorEvent'
+            $parameterAttribute = $command.Parameters['ComputerName'].Attributes.Where({
+                $_ -is [System.Management.Automation.ParameterAttribute]
+            })[0]
+            $parameterAttribute.ValueFromPipeline | Should -Be $true
+            $parameterAttribute.ValueFromPipelineByPropertyName | Should -Be $true
+            $command.Parameters['ComputerName'].Aliases | Should -Contain 'CN'
+            $command.Parameters['ComputerName'].Aliases | Should -Contain 'Name'
+            $command.Parameters['ComputerName'].Aliases | Should -Contain 'DNSHostName'
+        }
+    }
+}

--- a/en-US/about_PSWinOps.help.txt
+++ b/en-US/about_PSWinOps.help.txt
@@ -68,13 +68,14 @@ FUNCTION DOMAINS
 
       Get-ExpiringCertificate
 
-  eventlog (5 functions)
+  eventlog (6 functions)
     Functions for correlating Windows System and Security
     event log entries into lockout-source, shutdown/restart,
-    failed-logon, application-crash, and Service Control
-    Manager crash reports.
+    failed-logon, application-crash, storage-error, and
+    Service Control Manager crash reports.
 
       Get-ADLockoutSource
+      Get-DiskErrorEvent
       Get-LogonFailure
       Get-ProcessCrashEvent
       Get-ServiceCrashEvent
@@ -329,7 +330,7 @@ REMOTE EXECUTION PATTERN
     in the pipeline continue to be processed.
 
 PSWINOPS TYPE REGISTRY
-    The following 103 PSTypeName values are defined by the
+    The following 104 PSTypeName values are defined by the
     module. Each corresponds to the output of one or more
     public functions.
 
@@ -370,6 +371,7 @@ PSWINOPS TYPE REGISTRY
       PSWinOps.DhcpServerHealth
       PSWinOps.DiskCleanupInfo
       PSWinOps.DiskCleanupResult
+      PSWinOps.DiskErrorEvent
       PSWinOps.DiskSpace
       PSWinOps.DnsResolution
       PSWinOps.DnsServerHealth


### PR DESCRIPTION
## Summary
Add Get-DiskErrorEvent for deterministic, XML-based classification and aggregation of Disk, Ntfs, storahci, and storport System log errors. Includes remote/pipeline support, critical and disk filters, typed formatting, documentation, and Pester coverage.

## Validation
Linux static checks passed. PowerShell/Pester and PSScriptAnalyzer were not runnable on this Linux/ARM host; Windows CI is required.

Closes #89