### PR TITLE
feat(eventlog): add scheduled task failure reporting (#90)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -327,6 +327,7 @@ its `<View>` in `PSWinOps.Format.ps1xml`. This table is the reference list; keep
 | Get-PageFileConfiguration | PSWinOps.PageFileConfiguration | Table |
 | Get-PendingReboot | PSWinOps.PendingReboot | List |
 | Get-ScheduledTaskDetail | PSWinOps.ScheduledTaskDetail | Table |
+| Get-ScheduledTaskFailure | PSWinOps.ScheduledTaskFailure | Table |
 | Get-StartupProgram | PSWinOps.StartupProgram | Table |
 | Set-PageFile | PSWinOps.PageFileConfiguration | List |
 | Clear-Arp | PSWinOps.ArpEntry | Table |

--- a/PSWinOps.Format.ps1xml
+++ b/PSWinOps.Format.ps1xml
@@ -8080,6 +8080,76 @@
       </TableControl>
     </View>
     <!-- ============================================================ -->
+    <!-- PSWinOps.ScheduledTaskFailure                                -->
+    <!-- Used by: Get-ScheduledTaskFailure                            -->
+    <!-- ============================================================ -->
+    <View>
+      <Name>PSWinOps.ScheduledTaskFailure</Name>
+      <ViewSelectedBy>
+        <TypeName>PSWinOps.ScheduledTaskFailure</TypeName>
+      </ViewSelectedBy>
+      <TableControl>
+        <AutoSize />
+        <TableHeaders>
+          <TableColumnHeader>
+            <Label>ComputerName</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>EventTime</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>FailureReason</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>TaskName</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>TaskPath</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>ActionName</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>ResultCodeHex</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>FailureCount</Label>
+            <Alignment>Right</Alignment>
+          </TableColumnHeader>
+        </TableHeaders>
+        <TableRowEntries>
+          <TableRowEntry>
+            <TableColumnItems>
+              <TableColumnItem>
+                <PropertyName>ComputerName</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>EventTime</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>FailureReason</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>TaskName</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>TaskPath</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>ActionName</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>ResultCodeHex</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>FailureCount</PropertyName>
+              </TableColumnItem>
+            </TableColumnItems>
+          </TableRowEntry>
+        </TableRowEntries>
+      </TableControl>
+    </View>
+    <!-- ============================================================ -->
     <!-- PSWinOps.CrashDump                                           -->
     <!-- Used by: Get-CrashDump                                       -->
     <!-- ============================================================ -->

--- a/PSWinOps.psd1
+++ b/PSWinOps.psd1
@@ -160,6 +160,7 @@
         'Get-RdpSessionLock',
         'Get-RDSHealth',
         'Get-ScheduledTaskDetail',
+        'Get-ScheduledTaskFailure',
         'Get-ServiceAccount',
         'Get-ServiceCrashEvent',
         'Get-ServiceHealth',
@@ -287,6 +288,7 @@
 - Get-ADLockoutSource: Trace the source machine of an AD account lockout via event 4740 on the PDC Emulator
 - Get-DiskErrorEvent: Classify and aggregate Disk, Ntfs, storahci, and storport storage errors from the System log
 - Get-ProcessCrashEvent: Correlate Application Error, Windows Error Reporting, and optional Application Hang events with per-process counts
+- Get-ScheduledTaskFailure: Report Task Scheduler task-start and action failures with XML field extraction and per-task counts
 
 ## 0.11.0 - 2026-09-04 UTC
 ### Added

--- a/Public/eventlog/Get-ScheduledTaskFailure.ps1
+++ b/Public/eventlog/Get-ScheduledTaskFailure.ps1
@@ -1,0 +1,333 @@
+#Requires -Version 5.1
+
+function Get-ScheduledTaskFailure {
+    <#
+    .SYNOPSIS
+        Report failed scheduled-task starts and actions from Task Scheduler
+
+    .DESCRIPTION
+        Queries the Microsoft-Windows-TaskScheduler/Operational event log for task-start
+        and action-failure events over a configurable look-back window. Named EventData
+        fields are parsed from event XML so localized message text does not drive extraction.
+
+        Results retain the task path, action, user, raw and hexadecimal result codes, and
+        the latest known run time. FailureCount is aggregated per task over the full window,
+        results are newest first, and failures on one computer do not stop other targets.
+
+    .PARAMETER ComputerName
+        One or more computer names to target. Defaults to the local computer.
+        Accepts pipeline input by value and by property name.
+
+    .PARAMETER Days
+        Look-back window in days. Valid values are 1 through 3650. Defaults to 7.
+
+    .PARAMETER MaxEvents
+        Maximum number of Task Scheduler events read per machine. Valid values are 1 through
+        10000. Defaults to 200.
+
+    .PARAMETER TaskPath
+        Optional case-insensitive filter on the extracted full task path.
+
+    .PARAMETER TaskName
+        Optional case-insensitive filter on the extracted task name.
+
+    .PARAMETER Credential
+        Optional PSCredential for authenticating to remote machines. Ignored for local
+        machine queries.
+
+    .EXAMPLE
+        Get-ScheduledTaskFailure
+
+        Returns scheduled-task start and action failures from the local computer over the
+        last seven days.
+
+    .EXAMPLE
+        Get-ScheduledTaskFailure -ComputerName 'SRV01' -Days 30 -TaskPath '\Backup\'
+
+        Returns failures for tasks under the Backup path on SRV01 over the last 30 days.
+
+    .EXAMPLE
+        'SRV01', 'SRV02' | Get-ScheduledTaskFailure -MaxEvents 500 -TaskName 'NightlyBackup'
+
+        Returns failures for the named task from multiple computers through pipeline input.
+
+    .OUTPUTS
+        PSWinOps.ScheduledTaskFailure
+        One object per recognized Task Scheduler failure event, newest first, with the
+        number of failures for the task across the selected look-back window.
+
+    .NOTES
+        Author: Franck SALLET
+        Version: 1.0.0
+        Last Modified: 2026-09-04
+        Requires: PowerShell 5.1+ / Windows only
+        Requires: Event Log Readers membership for remote or protected Task Scheduler log access
+        Requires: WinRM enabled on target machines for remote queries
+
+        Event IDs 101 and 103 represent task/action start failures; 202 and 203 represent
+        action completion or launch failures. Classification uses the event ID and named XML
+        fields, never localized message text.
+
+    .LINK
+        https://github.com/k9fr4n/PSWinOps
+
+    .LINK
+        https://learn.microsoft.com/en-us/windows/win32/taskschd/task-scheduler-2-0
+    #>
+    [CmdletBinding(SupportsShouldProcess = $false, ConfirmImpact = 'None')]
+    [OutputType('PSWinOps.ScheduledTaskFailure')]
+    param(
+        [Parameter(Mandatory = $false, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [ValidateNotNullOrEmpty()]
+        [Alias('CN', 'Name', 'DNSHostName')]
+        [string[]]$ComputerName = $env:COMPUTERNAME,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateRange(1, 3650)]
+        [int]$Days = 7,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateRange(1, 10000)]
+        [int]$MaxEvents = 200,
+
+        [Parameter(Mandatory = $false)]
+        [string]$TaskPath = '',
+
+        [Parameter(Mandatory = $false)]
+        [string]$TaskName = '',
+
+        [Parameter(Mandatory = $false)]
+        [System.Management.Automation.PSCredential]$Credential
+    )
+
+    begin {
+        Write-Verbose "[$($MyInvocation.MyCommand)] Starting scheduled task failure query"
+
+        $startTime = (Get-Date).AddDays(-$Days)
+
+        $scriptBlock = {
+            param(
+                [datetime]$ScanStartTime,
+                [int]$MaxEvts,
+                [string]$TaskPathFilter,
+                [string]$TaskNameFilter
+            )
+
+            $failureDefinitions = @{
+                101 = 'TaskStartFailure'
+                103 = 'ActionStartFailure'
+                202 = 'ActionFailure'
+                203 = 'ActionLaunchFailure'
+            }
+
+            $filter = @{
+                LogName   = 'Microsoft-Windows-TaskScheduler/Operational'
+                Id        = @(101, 103, 202, 203)
+                StartTime = $ScanStartTime
+            }
+
+            $eventRecords = @()
+            try {
+                $eventRecords = @(Get-WinEvent -FilterHashtable $filter -MaxEvents $MaxEvts -ErrorAction Stop)
+            } catch {
+                if ($_.Exception.Message -notmatch 'No events were found') {
+                    throw
+                }
+            }
+
+            if ($eventRecords.Count -eq 0) {
+                return
+            }
+
+            function Get-EventDataMap {
+                param(
+                    [Parameter(Mandatory = $true)]
+                    [object]$Event
+                )
+
+                $map = @{}
+                try {
+                    $xml = [xml]$Event.ToXml()
+                    foreach ($node in @($xml.SelectNodes("//*[local-name()='Data']"))) {
+                        $name = [string]$node.GetAttribute('Name')
+                        if ([string]::IsNullOrWhiteSpace($name)) {
+                            continue
+                        }
+
+                        $value = [string]$node.InnerText
+                        if (-not $map.ContainsKey($name) -or [string]::IsNullOrEmpty([string]$map[$name])) {
+                            $map[$name] = $value
+                        }
+                    }
+                } catch {
+                    Write-Verbose "Could not parse Task Scheduler event $($Event.Id) as XML: $_"
+                }
+
+                return $map
+            }
+
+            function Get-EventField {
+                param(
+                    [Parameter(Mandatory = $true)]
+                    [hashtable]$Data,
+                    [Parameter(Mandatory = $true)]
+                    [string[]]$Names
+                )
+
+                foreach ($name in $Names) {
+                    if ($Data.ContainsKey($name) -and -not [string]::IsNullOrWhiteSpace([string]$Data[$name])) {
+                        return [string]$Data[$name]
+                    }
+                }
+
+                return ''
+            }
+
+            function ConvertTo-ResultCodeHex {
+                param(
+                    [Parameter(Mandatory = $false)]
+                    [string]$Value
+                )
+
+                if ([string]::IsNullOrWhiteSpace($Value)) {
+                    return ''
+                }
+
+                $number = [uint32]0
+                if ([uint32]::TryParse($Value.Trim(), [Globalization.NumberStyles]::Integer, [Globalization.CultureInfo]::InvariantCulture, [ref]$number)) {
+                    return ('0x{0:X8}' -f $number)
+                }
+
+                $hexValue = $Value.Trim()
+                if ($hexValue.StartsWith('0x', [System.StringComparison]::OrdinalIgnoreCase)) {
+                    $hexValue = $hexValue.Substring(2)
+                }
+
+                if ([uint32]::TryParse($hexValue, [Globalization.NumberStyles]::AllowHexSpecifier, [Globalization.CultureInfo]::InvariantCulture, [ref]$number)) {
+                    return ('0x{0:X8}' -f $number)
+                }
+
+                return ''
+            }
+
+            function Resolve-TaskIdentity {
+                param(
+                    [Parameter(Mandatory = $true)]
+                    [AllowEmptyString()]
+                    [string]$RawTaskName,
+                    [Parameter(Mandatory = $true)]
+                    [AllowEmptyString()]
+                    [string]$ExplicitTaskPath
+                )
+
+                $taskPathValue = $ExplicitTaskPath
+                $taskNameValue = $RawTaskName
+                if (-not [string]::IsNullOrWhiteSpace($RawTaskName)) {
+                    $separatorIndex = $RawTaskName.LastIndexOf('\')
+                    if ($separatorIndex -ge 0) {
+                        $taskPathValue = $RawTaskName.Substring(0, $separatorIndex + 1)
+                        $taskNameValue = $RawTaskName.Substring($separatorIndex + 1)
+                    }
+                }
+
+                [PSCustomObject]@{
+                    TaskName = $taskNameValue
+                    TaskPath = $taskPathValue
+                }
+            }
+
+            $rows = [System.Collections.Generic.List[psobject]]::new()
+            foreach ($eventRecord in @($eventRecords | Sort-Object -Property TimeCreated -Descending)) {
+                $eventId = [int]$eventRecord.Id
+                if (-not $failureDefinitions.ContainsKey($eventId)) {
+                    continue
+                }
+
+                $data = Get-EventDataMap -Event $eventRecord
+                $rawTaskName = Get-EventField -Data $data -Names @('TaskName', 'Task')
+                $explicitTaskPath = Get-EventField -Data $data -Names @('TaskPath', 'Path')
+                $taskIdentity = Resolve-TaskIdentity -RawTaskName $rawTaskName -ExplicitTaskPath $explicitTaskPath
+                $actionName = Get-EventField -Data $data -Names @('ActionName', 'Action', 'TaskAction', 'Command')
+                $userName = Get-EventField -Data $data -Names @('UserName', 'User', 'UserContext', 'PrincipalName', 'AccountName')
+                $resultCode = Get-EventField -Data $data -Names @('ResultCode', 'ErrorValue', 'ErrorCode', 'HRESULT', 'Status')
+                $lastRunTimeValue = Get-EventField -Data $data -Names @('LastRunTime', 'RunTime', 'StartTime')
+                $lastRunTime = $eventRecord.TimeCreated
+                if (-not [string]::IsNullOrWhiteSpace($lastRunTimeValue)) {
+                    $parsedLastRunTime = [datetime]::MinValue
+                    if ([datetime]::TryParse($lastRunTimeValue, [Globalization.CultureInfo]::InvariantCulture, [Globalization.DateTimeStyles]::AssumeLocal, [ref]$parsedLastRunTime)) {
+                        $lastRunTime = $parsedLastRunTime
+                    }
+                }
+
+                $rows.Add([PSCustomObject]@{
+                    EventTime     = $eventRecord.TimeCreated
+                    EventId       = $eventId
+                    TaskName      = $taskIdentity.TaskName
+                    TaskPath      = $taskIdentity.TaskPath
+                    ActionName    = $actionName
+                    UserName      = $userName
+                    ResultCode    = $resultCode
+                    ResultCodeHex = ConvertTo-ResultCodeHex -Value $resultCode
+                    FailureReason = $failureDefinitions[$eventId]
+                    LastRunTime   = $lastRunTime
+                    Message       = [string]$eventRecord.Message
+                })
+            }
+
+            $failureTally = @{}
+            foreach ($row in $rows) {
+                $taskKey = '{0}|{1}' -f ([string]$row.TaskPath).ToLowerInvariant(), ([string]$row.TaskName).ToLowerInvariant()
+                if ($failureTally.ContainsKey($taskKey)) {
+                    $failureTally[$taskKey]++
+                } else {
+                    $failureTally[$taskKey] = 1
+                }
+            }
+
+            foreach ($row in ($rows | Sort-Object -Property EventTime -Descending)) {
+                if (-not [string]::IsNullOrWhiteSpace($TaskPathFilter) -and $row.TaskPath -ine $TaskPathFilter) {
+                    continue
+                }
+                if (-not [string]::IsNullOrWhiteSpace($TaskNameFilter) -and $row.TaskName -ine $TaskNameFilter) {
+                    continue
+                }
+
+                $taskKey = '{0}|{1}' -f ([string]$row.TaskPath).ToLowerInvariant(), ([string]$row.TaskName).ToLowerInvariant()
+                [PSCustomObject]@{
+                    PSTypeName     = 'PSWinOps.ScheduledTaskFailure'
+                    ComputerName   = $env:COMPUTERNAME
+                    EventTime      = $row.EventTime.ToString('o')
+                    EventId        = $row.EventId
+                    TaskName       = $row.TaskName
+                    TaskPath       = $row.TaskPath
+                    ActionName     = $row.ActionName
+                    UserName       = $row.UserName
+                    ResultCode     = $row.ResultCode
+                    ResultCodeHex  = $row.ResultCodeHex
+                    FailureReason  = $row.FailureReason
+                    LastRunTime    = $row.LastRunTime.ToString('o')
+                    FailureCount   = $failureTally[$taskKey]
+                    Message        = $row.Message
+                    Timestamp      = Get-Date -Format 'o'
+                }
+            }
+        }
+    }
+
+    process {
+        foreach ($targetComputer in $ComputerName) {
+            try {
+                Write-Verbose "[$($MyInvocation.MyCommand)] Querying scheduled task failures on '$targetComputer'"
+                Invoke-RemoteOrLocal -ComputerName $targetComputer -Credential $Credential `
+                    -ScriptBlock $scriptBlock `
+                    -ArgumentList @($startTime, $MaxEvents, $TaskPath, $TaskName)
+            } catch {
+                Write-Error "[$($MyInvocation.MyCommand)] Failed on '$targetComputer': $_"
+            }
+        }
+    }
+
+    end {
+        Write-Verbose "[$($MyInvocation.MyCommand)] Completed scheduled task failure query"
+    }
+}

--- a/Tests/Public/eventlog/Get-ScheduledTaskFailure.Tests.ps1
+++ b/Tests/Public/eventlog/Get-ScheduledTaskFailure.Tests.ps1
@@ -1,0 +1,268 @@
+#Requires -Version 5.1
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+
+param()
+
+BeforeAll {
+    $script:modulePath = Split-Path -Path (Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent) -Parent
+    Import-Module -Name (Join-Path -Path $script:modulePath -ChildPath 'PSWinOps.psd1') -Force
+
+    function New-MockScheduledTaskEvent {
+        param(
+            [Parameter(Mandatory = $true)]
+            [int]$EventId,
+            [Parameter(Mandatory = $true)]
+            [datetime]$TimeCreated,
+            [Parameter(Mandatory = $true)]
+            [string]$XmlContent,
+            [string]$Message = 'Simulated scheduled-task failure'
+        )
+
+        $mockEvent = [PSCustomObject]@{
+            Id          = $EventId
+            TimeCreated = $TimeCreated
+            Message     = $Message
+        }
+
+        $mockEvent | Add-Member -MemberType ScriptMethod -Name 'ToXml' -Value {
+            return $XmlContent
+        }.GetNewClosure() -Force
+
+        return $mockEvent
+    }
+
+    function New-TaskStartFailureXml {
+        param(
+            [string]$TaskName = '\Backup\NightlyBackup',
+            [string]$UserName = 'CONTOSO\svc-backup',
+            [string]$ErrorValue = '2147942402'
+        )
+
+        @"
+<Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
+  <EventData>
+    <Data Name="TaskName">$TaskName</Data>
+    <Data Name="UserName">$UserName</Data>
+    <Data Name="ErrorValue">$ErrorValue</Data>
+  </EventData>
+</Event>
+"@
+    }
+
+    function New-ActionFailureXml {
+        param(
+            [string]$TaskName = '\Backup\NightlyBackup',
+            [string]$ActionName = 'C:\Scripts\backup.ps1',
+            [string]$ResultCode = '0x80070005'
+        )
+
+        @"
+<Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
+  <EventData>
+    <Data Name="TaskName">$TaskName</Data>
+    <Data Name="ActionName">$ActionName</Data>
+    <Data Name="ResultCode">$ResultCode</Data>
+  </EventData>
+</Event>
+"@
+    }
+}
+
+Describe -Name 'Get-ScheduledTaskFailure' -Fixture {
+    Context -Name 'Local parsing, classification, sorting, and aggregation' -Fixture {
+        BeforeAll {
+            $script:taskStartFailure = New-MockScheduledTaskEvent -EventId 101 `
+                -TimeCreated (Get-Date '2026-09-04 10:00:00') `
+                -XmlContent (New-TaskStartFailureXml)
+            $script:actionFailure = New-MockScheduledTaskEvent -EventId 202 `
+                -TimeCreated (Get-Date '2026-09-03 10:00:00') `
+                -XmlContent (New-ActionFailureXml)
+            $script:otherTaskFailure = New-MockScheduledTaskEvent -EventId 203 `
+                -TimeCreated (Get-Date '2026-09-02 10:00:00') `
+                -XmlContent (New-ActionFailureXml -TaskName '\Maintenance\Cleanup' -ActionName 'clean.cmd')
+
+            Mock -CommandName 'Get-WinEvent' -ModuleName 'PSWinOps' -MockWith {
+                @($script:otherTaskFailure, $script:actionFailure, $script:taskStartFailure)
+            }
+        }
+
+        It -Name 'Should return recognized failures newest first and type the output' -Test {
+            $result = @(Get-ScheduledTaskFailure)
+            $result.Count | Should -Be 3
+            $result[0].EventId | Should -Be 101
+            $result[0].PSObject.TypeNames[0] | Should -Be 'PSWinOps.ScheduledTaskFailure'
+            [string[]]$result.EventTime | Should -Be ([string[]]($result.EventTime | Sort-Object -Descending))
+        }
+
+        It -Name 'Should parse task identity, action, user, failure reason, and result codes from XML' -Test {
+            $result = @(Get-ScheduledTaskFailure)
+            $start = $result | Where-Object EventId -eq 101
+            $action = $result | Where-Object EventId -eq 202
+
+            $start.TaskPath | Should -Be '\Backup\'
+            $start.TaskName | Should -Be 'NightlyBackup'
+            $start.UserName | Should -Be 'CONTOSO\svc-backup'
+            $start.FailureReason | Should -Be 'TaskStartFailure'
+            $start.ResultCode | Should -Be '2147942402'
+            $start.ResultCodeHex | Should -Be '0x80070002'
+            $action.ActionName | Should -Be 'C:\Scripts\backup.ps1'
+            $action.FailureReason | Should -Be 'ActionFailure'
+            $action.ResultCodeHex | Should -Be '0x80070005'
+        }
+
+        It -Name 'Should aggregate FailureCount per task before applying filters' -Test {
+            $script:secondFailure = New-MockScheduledTaskEvent -EventId 103 `
+                -TimeCreated (Get-Date '2026-09-01 10:00:00') `
+                -XmlContent (New-TaskStartFailureXml -ErrorValue '2147942402')
+            Mock -CommandName 'Get-WinEvent' -ModuleName 'PSWinOps' -MockWith {
+                @($script:taskStartFailure, $script:actionFailure, $script:secondFailure)
+            }
+
+            $result = @(Get-ScheduledTaskFailure -TaskName 'NIGHTLYBACKUP')
+            $result.Count | Should -Be 3
+            $result | ForEach-Object { $_.FailureCount | Should -Be 3 }
+        }
+
+        It -Name 'Should apply TaskPath after XML extraction' -Test {
+            $result = @(Get-ScheduledTaskFailure -TaskPath '\Maintenance\')
+            $result.Count | Should -Be 1
+            $result[0].TaskName | Should -Be 'Cleanup'
+        }
+    }
+
+    Context -Name 'Incomplete events and empty result' -Fixture {
+        It -Name 'Should preserve an incomplete event with empty extracted fields' -Test {
+            $incomplete = New-MockScheduledTaskEvent -EventId 103 `
+                -TimeCreated (Get-Date '2026-09-04 07:00:00') `
+                -XmlContent '<Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event"><EventData /></Event>'
+            Mock -CommandName 'Get-WinEvent' -ModuleName 'PSWinOps' -MockWith { $incomplete }
+
+            $result = @(Get-ScheduledTaskFailure)
+            $result.Count | Should -Be 1
+            $result.TaskName | Should -Be ''
+            $result.TaskPath | Should -Be ''
+            $result.FailureCount | Should -Be 1
+            $result.LastRunTime | Should -Not -BeNullOrEmpty
+        }
+
+        It -Name 'Should emit nothing when no events are found' -Test {
+            Mock -CommandName 'Get-WinEvent' -ModuleName 'PSWinOps' -MockWith { $null }
+            $result = @(Get-ScheduledTaskFailure -ErrorAction Stop)
+            $result.Count | Should -Be 0
+        }
+    }
+
+    Context -Name 'Explicit remote machine' -Fixture {
+        BeforeAll {
+            Mock -CommandName 'Invoke-Command' -ModuleName 'PSWinOps' -MockWith {
+                [PSCustomObject]@{
+                    PSTypeName     = 'PSWinOps.ScheduledTaskFailure'
+                    ComputerName   = 'SRV01'
+                    EventTime      = '2026-09-04T10:00:00.0000000'
+                    EventId        = 101
+                    TaskName       = 'NightlyBackup'
+                    TaskPath       = '\Backup\'
+                    ActionName     = ''
+                    UserName       = 'CONTOSO\svc-backup'
+                    ResultCode     = '2147942402'
+                    ResultCodeHex  = '0x80070002'
+                    FailureReason  = 'TaskStartFailure'
+                    LastRunTime    = '2026-09-04T10:00:00.0000000'
+                    FailureCount   = 1
+                    Message        = 'Simulated failure'
+                    Timestamp      = '2026-09-04T10:00:00.0000000'
+                }
+            }
+        }
+
+        It -Name 'Should dispatch remote queries' -Test {
+            $result = @(Get-ScheduledTaskFailure -ComputerName 'SRV01')
+            $result.ComputerName | Should -Be 'SRV01'
+            Should -Invoke -CommandName 'Invoke-Command' -ModuleName 'PSWinOps' -Times 1 -Exactly
+        }
+
+        It -Name 'Should propagate Credential to Invoke-Command' -Test {
+            $securePassword = ConvertTo-SecureString -String 'P@ssw0rd123!' -AsPlainText -Force
+            $credential = [System.Management.Automation.PSCredential]::new('CONTOSO\svc', $securePassword)
+            Get-ScheduledTaskFailure -ComputerName 'SRV01' -Credential $credential
+            Should -Invoke -CommandName 'Invoke-Command' -ModuleName 'PSWinOps' -Times 1 -Exactly -ParameterFilter {
+                $Credential -eq $credential
+            }
+        }
+    }
+
+    Context -Name 'Pipeline and per-machine failure isolation' -Fixture {
+        BeforeAll {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -MockWith {
+                if ($ComputerName -eq 'SRV01') {
+                    throw 'Simulated WinRM failure on SRV01'
+                }
+
+                [PSCustomObject]@{
+                    PSTypeName     = 'PSWinOps.ScheduledTaskFailure'
+                    ComputerName   = $ComputerName
+                    EventTime      = '2026-09-04T10:00:00.0000000'
+                    EventId        = 203
+                    TaskName       = 'Cleanup'
+                    TaskPath       = '\Maintenance\'
+                    ActionName     = 'clean.cmd'
+                    UserName       = ''
+                    ResultCode     = ''
+                    ResultCodeHex  = ''
+                    FailureReason  = 'ActionLaunchFailure'
+                    LastRunTime    = '2026-09-04T10:00:00.0000000'
+                    FailureCount   = 1
+                    Message        = ''
+                    Timestamp      = '2026-09-04T10:00:00.0000000'
+                }
+            }
+        }
+
+        It -Name 'Should continue after a per-machine failure in pipeline input' -Test {
+            $output = 'SRV01', 'SRV02' | Get-ScheduledTaskFailure -ErrorAction Continue 2>&1
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -Times 2 -Exactly
+            @($output | Where-Object { $_ -is [System.Management.Automation.ErrorRecord] }).Count | Should -BeGreaterThan 0
+            @($output | Where-Object { $_ -isnot [System.Management.Automation.ErrorRecord] }).Count | Should -Be 1
+            ($output | Where-Object { $_ -isnot [System.Management.Automation.ErrorRecord] }).ComputerName | Should -Be 'SRV02'
+        }
+    }
+
+    Context -Name 'Parameter validation and metadata' -Fixture {
+        It -Name 'Should reject invalid ComputerName, Days, and MaxEvents' -Test {
+            { Get-ScheduledTaskFailure -ComputerName '' } | Should -Throw
+            { Get-ScheduledTaskFailure -ComputerName $null } | Should -Throw
+            { Get-ScheduledTaskFailure -Days 0 } | Should -Throw
+            { Get-ScheduledTaskFailure -Days 3651 } | Should -Throw
+            { Get-ScheduledTaskFailure -MaxEvents 0 } | Should -Throw
+            { Get-ScheduledTaskFailure -MaxEvents 10001 } | Should -Throw
+        }
+
+        It -Name 'Should expose pipeline support and aliases on ComputerName' -Test {
+            $command = Get-Command -Name 'Get-ScheduledTaskFailure'
+            $parameterAttribute = $command.Parameters['ComputerName'].Attributes.Where({
+                $_ -is [System.Management.Automation.ParameterAttribute]
+            })[0]
+            $parameterAttribute.ValueFromPipeline | Should -Be $true
+            $parameterAttribute.ValueFromPipelineByPropertyName | Should -Be $true
+            $command.Parameters['ComputerName'].Aliases | Should -Contain 'CN'
+            $command.Parameters['ComputerName'].Aliases | Should -Contain 'Name'
+            $command.Parameters['ComputerName'].Aliases | Should -Contain 'DNSHostName'
+        }
+
+        It -Name 'Should expose the required output properties' -Test {
+            $script:event = New-MockScheduledTaskEvent -EventId 101 `
+                -TimeCreated (Get-Date '2026-09-04 10:00:00') `
+                -XmlContent (New-TaskStartFailureXml)
+            Mock -CommandName 'Get-WinEvent' -ModuleName 'PSWinOps' -MockWith { $script:event }
+
+            $result = @(Get-ScheduledTaskFailure)
+            foreach ($property in @(
+                'ComputerName', 'EventTime', 'EventId', 'TaskName', 'TaskPath', 'ActionName',
+                'UserName', 'ResultCode', 'ResultCodeHex', 'FailureReason', 'LastRunTime',
+                'FailureCount', 'Message', 'Timestamp'
+            )) {
+                $result[0].PSObject.Properties.Name | Should -Contain $property
+            }
+        }
+    }
+}

--- a/en-US/about_PSWinOps.help.txt
+++ b/en-US/about_PSWinOps.help.txt
@@ -68,16 +68,17 @@ FUNCTION DOMAINS
 
       Get-ExpiringCertificate
 
-  eventlog (6 functions)
+  eventlog (7 functions)
     Functions for correlating Windows System and Security
     event log entries into lockout-source, shutdown/restart,
-    failed-logon, application-crash, storage-error, and
-    Service Control Manager crash reports.
+    failed-logon, application-crash, storage-error,
+    scheduled-task, and Service Control Manager crash reports.
 
       Get-ADLockoutSource
       Get-DiskErrorEvent
       Get-LogonFailure
       Get-ProcessCrashEvent
+      Get-ScheduledTaskFailure
       Get-ServiceCrashEvent
       Get-UnexpectedShutdown
 
@@ -330,7 +331,7 @@ REMOTE EXECUTION PATTERN
     in the pipeline continue to be processed.
 
 PSWINOPS TYPE REGISTRY
-    The following 104 PSTypeName values are defined by the
+    The following 105 PSTypeName values are defined by the
     module. Each corresponds to the output of one or more
     public functions.
 
@@ -422,6 +423,7 @@ PSWINOPS TYPE REGISTRY
       PSWinOps.RDSHealth
       PSWinOps.RebootHistory
       PSWinOps.ScheduledTaskDetail
+      PSWinOps.ScheduledTaskFailure
       PSWinOps.ServiceAccount
       PSWinOps.ServiceCrashEvent
       PSWinOps.ServiceHealth


### PR DESCRIPTION
## Summary

Add Get-ScheduledTaskFailure for XML-based Task Scheduler failure reporting across local and remote computers.

- Parses Task Scheduler Operational events 101, 103, 202, and 203
- Aggregates per-task failure counts and preserves raw/hex result codes
- Adds format view, manifest export, help documentation, and Pester coverage

Closes #90