### PR TITLE
feat(eventlog): add Windows Update failure reporting (#91)

### DIFF
--- a/PSWinOps.Format.ps1xml
+++ b/PSWinOps.Format.ps1xml
@@ -6492,6 +6492,69 @@
       </TableControl>
     </View>
     <!-- ============================================================ -->
+    <!-- PSWinOps.WindowsUpdateFailure                                -->
+    <!-- Used by: Get-WindowsUpdateFailure                            -->
+    <!-- ============================================================ -->
+    <View>
+      <Name>PSWinOps.WindowsUpdateFailure</Name>
+      <ViewSelectedBy>
+        <TypeName>PSWinOps.WindowsUpdateFailure</TypeName>
+      </ViewSelectedBy>
+      <TableControl>
+        <AutoSize />
+        <TableHeaders>
+          <TableColumnHeader>
+            <Label>ComputerName</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>EventTime</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Status</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>KBArticle</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>UpdateTitle</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>ErrorCodeHex</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>RebootRequired</Label>
+          </TableColumnHeader>
+        </TableHeaders>
+        <TableRowEntries>
+          <TableRowEntry>
+            <TableColumnItems>
+              <TableColumnItem>
+                <PropertyName>ComputerName</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>EventTime</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>Status</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>KBArticle</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>UpdateTitle</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>ErrorCodeHex</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>RebootRequired</PropertyName>
+              </TableColumnItem>
+            </TableColumnItems>
+          </TableRowEntry>
+        </TableRowEntries>
+      </TableControl>
+    </View>
+    <!-- ============================================================ -->
     <!-- PSWinOps.DiskCleanupInfo                                     -->
     <!-- Used by: Get-DiskCleanupInfo                                 -->
     <!-- ============================================================ -->

--- a/PSWinOps.psd1
+++ b/PSWinOps.psd1
@@ -173,6 +173,7 @@
         'Get-UnexpectedShutdown',
         'Get-WindowsUpdate',
         'Get-WindowsUpdateConfiguration',
+        'Get-WindowsUpdateFailure',
         'Get-WindowsUpdateHistory',
         'Get-WSUSHealth',
         'Hide-WindowsUpdate',

--- a/Public/eventlog/Get-WindowsUpdateFailure.ps1
+++ b/Public/eventlog/Get-WindowsUpdateFailure.ps1
@@ -208,7 +208,11 @@ function Get-WindowsUpdateFailure {
                         [Globalization.NumberStyles]::Integer,
                         [Globalization.CultureInfo]::InvariantCulture,
                         [ref]$signedNumber)) {
-                    return ('0x{0:X8}' -f ([uint32]$signedNumber))
+                    $unsignedValue = $signedNumber
+                    if ($signedNumber -lt 0) {
+                        $unsignedValue += 4294967296
+                    }
+                    return ('0x{0:X8}' -f $unsignedValue)
                 }
 
                 $hexValue = $rawValue -replace '^0x', ''

--- a/Public/eventlog/Get-WindowsUpdateFailure.ps1
+++ b/Public/eventlog/Get-WindowsUpdateFailure.ps1
@@ -1,0 +1,323 @@
+#Requires -Version 5.1
+
+function Get-WindowsUpdateFailure {
+    <#
+    .SYNOPSIS
+        Report Windows Update failures and restart requirements from the System log
+
+    .DESCRIPTION
+        Queries the Microsoft-Windows-WindowsUpdateClient provider in the System event log
+        for failed installations, required restarts, and optionally successful installations.
+        Named XML EventData fields are parsed so localized event message text does not drive
+        classification or extraction.
+
+        Results include the update identity, KB article, raw and hexadecimal error codes,
+        restart status, and event message. Results are newest first, and an error on one
+        computer does not stop the remaining computers from being processed.
+
+    .PARAMETER ComputerName
+        One or more computer names to target. Defaults to the local computer.
+        Accepts pipeline input by value and by property name.
+
+    .PARAMETER Days
+        Look-back window in days. Valid values are 1 through 3650. Defaults to 30.
+
+    .PARAMETER MaxEvents
+        Maximum number of Windows Update events read per machine. Valid values are 1 through
+        10000. Defaults to 200. The most recent events are prioritized when the log is larger.
+
+    .PARAMETER KBArticle
+        Optional case-insensitive filter for the extracted KB article, such as KB5030211.
+
+    .PARAMETER UpdateTitle
+        Optional case-insensitive substring filter for the update title.
+
+    .PARAMETER IncludeSuccess
+        Includes event ID 19 successful installations in addition to failures and required
+        restart events.
+
+    .PARAMETER Credential
+        Optional PSCredential for authenticating to remote machines. Ignored for local
+        machine queries.
+
+    .EXAMPLE
+        Get-WindowsUpdateFailure
+
+        Returns failed Windows Update installations and required restarts from the local
+        computer over the last 30 days.
+
+    .EXAMPLE
+        Get-WindowsUpdateFailure -ComputerName 'SRV01' -Days 90 -KBArticle 'KB5030211'
+
+        Returns matching Windows Update events from SRV01 over the last 90 days.
+
+    .EXAMPLE
+        'SRV01', 'SRV02' | Get-WindowsUpdateFailure -MaxEvents 500 -IncludeSuccess
+
+        Returns failures, required restarts, and successful installations from multiple
+        computers through pipeline input.
+
+    .OUTPUTS
+        PSWinOps.WindowsUpdateFailure
+        One object per recognized Windows Update event, newest first, with status, update
+        identity, error information, restart state, and the raw event message.
+
+    .NOTES
+        Author: Franck SALLET
+        Version: 1.0.0
+        Last Modified: 2026-09-04
+        Requires: PowerShell 5.1+ / Windows only
+        Requires: Event Log Readers membership for remote or protected System log access
+        Requires: WinRM enabled on target machines for remote queries
+
+        Event IDs 20, 21, and 19 represent installation failure, restart required, and
+        installation success respectively. EventData XML is used for extraction; localized
+        Message text is retained for context only and is never used for classification.
+
+    .LINK
+        https://github.com/k9fr4n/PSWinOps
+
+    .LINK
+        https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.diagnostics/get-winevent
+    #>
+    [CmdletBinding(SupportsShouldProcess = $false, ConfirmImpact = 'None')]
+    [OutputType('PSWinOps.WindowsUpdateFailure')]
+    param(
+        [Parameter(Mandatory = $false, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [ValidateNotNullOrEmpty()]
+        [Alias('CN', 'Name', 'DNSHostName')]
+        [string[]]$ComputerName = $env:COMPUTERNAME,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateRange(1, 3650)]
+        [int]$Days = 30,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateRange(1, 10000)]
+        [int]$MaxEvents = 200,
+
+        [Parameter(Mandatory = $false)]
+        [AllowEmptyString()]
+        [string]$KBArticle = '',
+
+        [Parameter(Mandatory = $false)]
+        [AllowEmptyString()]
+        [string]$UpdateTitle = '',
+
+        [Parameter(Mandatory = $false)]
+        [switch]$IncludeSuccess,
+
+        [Parameter(Mandatory = $false)]
+        [System.Management.Automation.PSCredential]$Credential
+    )
+
+    begin {
+        Write-Verbose "[$($MyInvocation.MyCommand)] Starting Windows Update failure query"
+
+        $startTime = (Get-Date).AddDays(-$Days)
+
+        $scriptBlock = {
+            param(
+                [datetime]$ScanStartTime,
+                [int]$MaxEvts,
+                [bool]$IncludeSuccessFilter,
+                [string]$KBArticleFilter,
+                [string]$UpdateTitleFilter
+            )
+
+            $eventIds = @(20, 21)
+            if ($IncludeSuccessFilter) {
+                $eventIds += 19
+            }
+
+            $filter = @{
+                LogName      = 'System'
+                ProviderName = 'Microsoft-Windows-WindowsUpdateClient'
+                Id           = $eventIds
+                StartTime    = $ScanStartTime
+            }
+
+            $eventRecords = @()
+            try {
+                $eventRecords = @(Get-WinEvent -FilterHashtable $filter -MaxEvents $MaxEvts -ErrorAction Stop)
+            } catch {
+                if ($_.Exception.Message -notmatch 'No events were found') {
+                    throw
+                }
+            }
+
+            if ($eventRecords.Count -eq 0) {
+                return
+            }
+
+            function Get-EventDataMap {
+                param(
+                    [Parameter(Mandatory = $true)]
+                    [object]$Event
+                )
+
+                $map = @{}
+                try {
+                    $xml = [xml]$Event.ToXml()
+                    foreach ($node in @($xml.SelectNodes("//*[local-name()='Data']"))) {
+                        $name = [string]$node.GetAttribute('Name')
+                        if ([string]::IsNullOrWhiteSpace($name)) {
+                            continue
+                        }
+
+                        $map[$name] = [string]$node.InnerText
+                    }
+                } catch {
+                    Write-Verbose "Could not parse Windows Update event $($Event.Id) as XML: $_"
+                }
+
+                return $map
+            }
+
+            function Get-EventField {
+                param(
+                    [Parameter(Mandatory = $true)]
+                    [hashtable]$Data,
+                    [Parameter(Mandatory = $true)]
+                    [string[]]$Names
+                )
+
+                foreach ($name in $Names) {
+                    if ($Data.ContainsKey($name) -and -not [string]::IsNullOrWhiteSpace([string]$Data[$name])) {
+                        return [string]$Data[$name]
+                    }
+                }
+
+                return ''
+            }
+
+            function ConvertTo-ErrorCodeHex {
+                param(
+                    [Parameter(Mandatory = $false)]
+                    [string]$Value
+                )
+
+                if ([string]::IsNullOrWhiteSpace($Value)) {
+                    return ''
+                }
+
+                $rawValue = $Value.Trim()
+                $signedNumber = [int64]0
+                if ([int64]::TryParse(
+                        $rawValue,
+                        [Globalization.NumberStyles]::Integer,
+                        [Globalization.CultureInfo]::InvariantCulture,
+                        [ref]$signedNumber)) {
+                    return ('0x{0:X8}' -f ([uint32]$signedNumber))
+                }
+
+                $hexValue = $rawValue -replace '^0x', ''
+                $unsignedNumber = [uint32]0
+                if ([uint32]::TryParse(
+                        $hexValue,
+                        [Globalization.NumberStyles]::AllowHexSpecifier,
+                        [Globalization.CultureInfo]::InvariantCulture,
+                        [ref]$unsignedNumber)) {
+                    return ('0x{0:X8}' -f $unsignedNumber)
+                }
+
+                return ''
+            }
+
+            $rows = [System.Collections.Generic.List[psobject]]::new()
+            foreach ($eventRecord in @($eventRecords | Sort-Object -Property TimeCreated -Descending)) {
+                $eventId = [int]$eventRecord.Id
+                if ($eventId -eq 19 -and -not $IncludeSuccessFilter) {
+                    continue
+                }
+
+                $status = switch ($eventId) {
+                    19 { 'Succeeded' }
+                    20 { 'Failed' }
+                    21 { 'RebootRequired' }
+                    default { continue }
+                }
+
+                $data = Get-EventDataMap -Event $eventRecord
+                $updateTitleValue = Get-EventField -Data $data -Names @('UpdateTitle', 'Title', 'UpdateName')
+                $updateIdValue = Get-EventField -Data $data -Names @('UpdateId', 'UpdateGUID', 'UpdateGuid', 'UpdateIdentity')
+                $kbArticleValue = Get-EventField -Data $data -Names @('KBArticle', 'KBNumber', 'KB')
+                if ([string]::IsNullOrWhiteSpace($kbArticleValue) -and -not [string]::IsNullOrWhiteSpace($updateTitleValue)) {
+                    $kbMatch = [regex]::Match($updateTitleValue, '(?i)\bKB\d+\b')
+                    if ($kbMatch.Success) {
+                        $kbArticleValue = $kbMatch.Value
+                    }
+                }
+
+                $errorCodeValue = Get-EventField -Data $data -Names @('ErrorCode', 'HResult', 'HRESULT', 'ResultCode', 'Error')
+                $failureReasonValue = Get-EventField -Data $data -Names @('FailureReason', 'ErrorDescription', 'Reason')
+                if ([string]::IsNullOrWhiteSpace($failureReasonValue)) {
+                    $failureReasonValue = switch ($eventId) {
+                        20 { 'InstallationFailure' }
+                        21 { 'RestartRequired' }
+                        default { '' }
+                    }
+                }
+
+                $rows.Add([PSCustomObject]@{
+                    EventTime       = $eventRecord.TimeCreated
+                    EventId         = $eventId
+                    Status          = $status
+                    KBArticle       = $kbArticleValue
+                    UpdateTitle     = $updateTitleValue
+                    UpdateId        = $updateIdValue
+                    ErrorCode       = $errorCodeValue
+                    ErrorCodeHex    = ConvertTo-ErrorCodeHex -Value $errorCodeValue
+                    RebootRequired  = ($eventId -eq 21)
+                    FailureReason   = $failureReasonValue
+                    Message         = [string]$eventRecord.Message
+                })
+            }
+
+            foreach ($row in ($rows | Sort-Object -Property EventTime -Descending)) {
+                if (-not [string]::IsNullOrWhiteSpace($KBArticleFilter) -and
+                    ([string]$row.KBArticle).IndexOf($KBArticleFilter, [System.StringComparison]::OrdinalIgnoreCase) -lt 0) {
+                    continue
+                }
+                if (-not [string]::IsNullOrWhiteSpace($UpdateTitleFilter) -and
+                    ([string]$row.UpdateTitle).IndexOf($UpdateTitleFilter, [System.StringComparison]::OrdinalIgnoreCase) -lt 0) {
+                    continue
+                }
+
+                [PSCustomObject]@{
+                    PSTypeName      = 'PSWinOps.WindowsUpdateFailure'
+                    ComputerName    = $env:COMPUTERNAME
+                    EventTime       = $row.EventTime.ToString('o')
+                    EventId         = $row.EventId
+                    Status          = $row.Status
+                    KBArticle       = $row.KBArticle
+                    UpdateTitle     = $row.UpdateTitle
+                    UpdateId        = $row.UpdateId
+                    ErrorCode       = $row.ErrorCode
+                    ErrorCodeHex    = $row.ErrorCodeHex
+                    RebootRequired  = $row.RebootRequired
+                    FailureReason   = $row.FailureReason
+                    Message         = $row.Message
+                    Timestamp       = Get-Date -Format 'o'
+                }
+            }
+        }
+    }
+
+    process {
+        foreach ($targetComputer in $ComputerName) {
+            try {
+                Write-Verbose "[$($MyInvocation.MyCommand)] Querying Windows Update failures on '$targetComputer'"
+                Invoke-RemoteOrLocal -ComputerName $targetComputer -Credential $Credential `
+                    -ScriptBlock $scriptBlock `
+                    -ArgumentList @($startTime, $MaxEvents, $IncludeSuccess.IsPresent, $KBArticle, $UpdateTitle)
+            } catch {
+                Write-Error "[$($MyInvocation.MyCommand)] Failed on '$targetComputer': $_"
+            }
+        }
+    }
+
+    end {
+        Write-Verbose "[$($MyInvocation.MyCommand)] Completed Windows Update failure query"
+    }
+}

--- a/Tests/Public/eventlog/Get-WindowsUpdateFailure.Tests.ps1
+++ b/Tests/Public/eventlog/Get-WindowsUpdateFailure.Tests.ps1
@@ -1,0 +1,245 @@
+#Requires -Version 5.1
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+
+param()
+
+BeforeAll {
+    $script:modulePath = Split-Path -Path (Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent) -Parent
+    Import-Module -Name (Join-Path -Path $script:modulePath -ChildPath 'PSWinOps.psd1') -Force
+
+    function New-MockWindowsUpdateEvent {
+        param(
+            [Parameter(Mandatory = $true)]
+            [int]$EventId,
+            [Parameter(Mandatory = $true)]
+            [datetime]$TimeCreated,
+            [Parameter(Mandatory = $true)]
+            [string]$XmlContent,
+            [string]$Message = 'Localized Windows Update event message'
+        )
+
+        $mockEvent = [PSCustomObject]@{
+            Id           = $EventId
+            TimeCreated  = $TimeCreated
+            Message      = $Message
+        }
+
+        $mockEvent | Add-Member -MemberType ScriptMethod -Name 'ToXml' -Value {
+            return $XmlContent
+        }.GetNewClosure() -Force
+
+        return $mockEvent
+    }
+
+    function New-WindowsUpdateXml {
+        param(
+            [string]$UpdateTitle = '2026-09 Cumulative Update (KB5030211)',
+            [string]$UpdateId = '11111111-2222-3333-4444-555555555555',
+            [string]$ErrorCode = '',
+            [string]$FailureReason = ''
+        )
+
+        @"
+<Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
+  <EventData>
+    <Data Name="updateTitle">$UpdateTitle</Data>
+    <Data Name="updateGuid">$UpdateId</Data>
+    <Data Name="errorCode">$ErrorCode</Data>
+    <Data Name="failureReason">$FailureReason</Data>
+  </EventData>
+</Event>
+"@
+    }
+}
+
+Describe -Name 'Get-WindowsUpdateFailure' -Fixture {
+    Context -Name 'Local parsing and classification' -Fixture {
+        BeforeAll {
+            $script:failedEvent = New-MockWindowsUpdateEvent -EventId 20 `
+                -TimeCreated (Get-Date '2026-09-04 10:00:00') `
+                -XmlContent (New-WindowsUpdateXml -ErrorCode '-2147024891')
+            $script:rebootEvent = New-MockWindowsUpdateEvent -EventId 21 `
+                -TimeCreated (Get-Date '2026-09-04 09:00:00') `
+                -XmlContent (New-WindowsUpdateXml -UpdateTitle 'Servicing Stack Update')
+            $script:successEvent = New-MockWindowsUpdateEvent -EventId 19 `
+                -TimeCreated (Get-Date '2026-09-04 08:00:00') `
+                -XmlContent (New-WindowsUpdateXml -UpdateTitle 'Definition Update (KB2267602)')
+
+            Mock -CommandName 'Get-WinEvent' -ModuleName 'PSWinOps' -MockWith {
+                @($script:successEvent, $script:rebootEvent, $script:failedEvent)
+            }
+        }
+
+        It -Name 'Should return failures and restart-required events by default, newest first' -Test {
+            $result = @(Get-WindowsUpdateFailure)
+
+            $result.Count | Should -Be 2
+            $result[0].EventId | Should -Be 20
+            $result[0].Status | Should -Be 'Failed'
+            $result[1].Status | Should -Be 'RebootRequired'
+            $result[0].PSObject.TypeNames | Should -Contain 'PSWinOps.WindowsUpdateFailure'
+            [string[]]$result.EventTime | Should -Be ([string[]]($result.EventTime | Sort-Object -Descending))
+        }
+
+        It -Name 'Should parse named XML fields and preserve raw and hexadecimal error codes' -Test {
+            $result = @(Get-WindowsUpdateFailure)
+            $failed = $result | Where-Object EventId -eq 20
+
+            $failed.KBArticle | Should -Be 'KB5030211'
+            $failed.UpdateTitle | Should -Be '2026-09 Cumulative Update (KB5030211)'
+            $failed.UpdateId | Should -Be '11111111-2222-3333-4444-555555555555'
+            $failed.ErrorCode | Should -Be '-2147024891'
+            $failed.ErrorCodeHex | Should -Be '0x80070005'
+            $failed.FailureReason | Should -Be 'InstallationFailure'
+        }
+
+        It -Name 'Should classify reboot-required events separately from failures' -Test {
+            $reboot = (Get-WindowsUpdateFailure) | Where-Object EventId -eq 21
+
+            $reboot.Status | Should -Be 'RebootRequired'
+            $reboot.RebootRequired | Should -BeTrue
+            $reboot.FailureReason | Should -Be 'RestartRequired'
+        }
+
+        It -Name 'Should include successful installations only when requested' -Test {
+            $result = @(Get-WindowsUpdateFailure -IncludeSuccess)
+
+            $result.Count | Should -Be 3
+            ($result | Where-Object EventId -eq 19).Status | Should -Be 'Succeeded'
+            ($result | Where-Object EventId -eq 19).RebootRequired | Should -BeFalse
+        }
+    }
+
+    Context -Name 'Filters and incomplete events' -Fixture {
+        BeforeAll {
+            $script:filteredEvent = New-MockWindowsUpdateEvent -EventId 20 `
+                -TimeCreated (Get-Date '2026-09-04 10:00:00') `
+                -XmlContent (New-WindowsUpdateXml -UpdateTitle 'Security Update (KB5012345)' -ErrorCode '0x800F081F')
+            $script:untitledEvent = New-MockWindowsUpdateEvent -EventId 21 `
+                -TimeCreated (Get-Date '2026-09-04 09:00:00') `
+                -XmlContent '<Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event"><EventData /></Event>'
+
+            Mock -CommandName 'Get-WinEvent' -ModuleName 'PSWinOps' -MockWith {
+                @($script:filteredEvent, $script:untitledEvent)
+            }
+        }
+
+        It -Name 'Should filter by KB article after XML extraction' -Test {
+            $result = @(Get-WindowsUpdateFailure -KBArticle 'kb5012345')
+
+            $result.Count | Should -Be 1
+            $result[0].KBArticle | Should -Be 'KB5012345'
+        }
+
+        It -Name 'Should filter by update title case-insensitively' -Test {
+            $result = @(Get-WindowsUpdateFailure -UpdateTitle 'SECURITY UPDATE')
+
+            $result.Count | Should -Be 1
+            $result[0].UpdateTitle | Should -Be 'Security Update (KB5012345)'
+        }
+
+        It -Name 'Should preserve missing optional XML fields as empty values' -Test {
+            $result = @(Get-WindowsUpdateFailure)
+            $incomplete = $result | Where-Object EventId -eq 21
+
+            $incomplete.KBArticle | Should -Be ''
+            $incomplete.UpdateTitle | Should -Be ''
+            $incomplete.UpdateId | Should -Be ''
+            $incomplete.ErrorCode | Should -Be ''
+            $incomplete.ErrorCodeHex | Should -Be ''
+        }
+
+        It -Name 'Should return no objects when no events are found' -Test {
+            Mock -CommandName 'Get-WinEvent' -ModuleName 'PSWinOps' -MockWith { $null }
+
+            @(Get-WindowsUpdateFailure) | Should -BeNullOrEmpty
+        }
+    }
+
+    Context -Name 'Remote, credentials, pipeline, and error isolation' -Fixture {
+        BeforeEach {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -MockWith {
+                if ($ComputerName -eq 'SRV01') {
+                    throw 'Simulated WinRM failure on SRV01'
+                }
+
+                [PSCustomObject]@{
+                    PSTypeName      = 'PSWinOps.WindowsUpdateFailure'
+                    ComputerName    = $ComputerName
+                    EventTime       = '2026-09-04T10:00:00.0000000'
+                    EventId         = 20
+                    Status          = 'Failed'
+                    KBArticle       = 'KB5030211'
+                    UpdateTitle     = 'Security Update'
+                    UpdateId        = ''
+                    ErrorCode       = '0x80070005'
+                    ErrorCodeHex    = '0x80070005'
+                    RebootRequired  = $false
+                    FailureReason   = 'InstallationFailure'
+                    Message         = ''
+                    Timestamp       = '2026-09-04T10:00:00.0000000'
+                }
+            }
+        }
+
+        It -Name 'Should query a remote machine and propagate credentials' -Test {
+            $securePassword = ConvertTo-SecureString -String 'P@ssw0rd123!' -AsPlainText -Force
+            $credential = [System.Management.Automation.PSCredential]::new('CONTOSO\svc', $securePassword)
+            $result = @(Get-WindowsUpdateFailure -ComputerName 'SRV02' -Credential $credential)
+
+            $result.ComputerName | Should -Be 'SRV02'
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -Times 1 -Exactly -ParameterFilter {
+                $ComputerName -eq 'SRV02' -and $Credential -eq $credential
+            }
+        }
+
+        It -Name 'Should continue after a per-machine failure in pipeline input' -Test {
+            $output = 'SRV01', 'SRV02' | Get-WindowsUpdateFailure -ErrorAction Continue 2>&1
+
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -Times 2 -Exactly
+            @($output | Where-Object { $_ -is [System.Management.Automation.ErrorRecord] }).Count | Should -BeGreaterThan 0
+            @($output | Where-Object { $_ -isnot [System.Management.Automation.ErrorRecord] }).Count | Should -Be 1
+            ($output | Where-Object { $_ -isnot [System.Management.Automation.ErrorRecord] }).ComputerName | Should -Be 'SRV02'
+        }
+    }
+
+    Context -Name 'Parameter validation and metadata' -Fixture {
+        It -Name 'Should reject invalid ComputerName, Days, and MaxEvents' -Test {
+            { Get-WindowsUpdateFailure -ComputerName '' } | Should -Throw
+            { Get-WindowsUpdateFailure -ComputerName $null } | Should -Throw
+            { Get-WindowsUpdateFailure -Days 0 } | Should -Throw
+            { Get-WindowsUpdateFailure -Days 3651 } | Should -Throw
+            { Get-WindowsUpdateFailure -MaxEvents 0 } | Should -Throw
+            { Get-WindowsUpdateFailure -MaxEvents 10001 } | Should -Throw
+        }
+
+        It -Name 'Should expose pipeline support and aliases on ComputerName' -Test {
+            $command = Get-Command -Name 'Get-WindowsUpdateFailure'
+            $parameterAttribute = $command.Parameters['ComputerName'].Attributes.Where({
+                $_ -is [System.Management.Automation.ParameterAttribute]
+            })[0]
+
+            $parameterAttribute.ValueFromPipeline | Should -Be $true
+            $parameterAttribute.ValueFromPipelineByPropertyName | Should -Be $true
+            $command.Parameters['ComputerName'].Aliases | Should -Contain 'CN'
+            $command.Parameters['ComputerName'].Aliases | Should -Contain 'Name'
+            $command.Parameters['ComputerName'].Aliases | Should -Contain 'DNSHostName'
+        }
+
+        It -Name 'Should expose the required output properties' -Test {
+            $event = New-MockWindowsUpdateEvent -EventId 20 `
+                -TimeCreated (Get-Date '2026-09-04 10:00:00') `
+                -XmlContent (New-WindowsUpdateXml -ErrorCode '5')
+            Mock -CommandName 'Get-WinEvent' -ModuleName 'PSWinOps' -MockWith { $event }
+
+            $result = @(Get-WindowsUpdateFailure)
+            foreach ($property in @(
+                'ComputerName', 'EventTime', 'EventId', 'Status', 'KBArticle', 'UpdateTitle',
+                'UpdateId', 'ErrorCode', 'ErrorCodeHex', 'RebootRequired', 'FailureReason',
+                'Message', 'Timestamp'
+            )) {
+                $result[0].PSObject.Properties.Name | Should -Contain $property
+            }
+        }
+    }
+}

--- a/en-US/about_PSWinOps.help.txt
+++ b/en-US/about_PSWinOps.help.txt
@@ -68,11 +68,12 @@ FUNCTION DOMAINS
 
       Get-ExpiringCertificate
 
-  eventlog (7 functions)
+  eventlog (8 functions)
     Functions for correlating Windows System and Security
     event log entries into lockout-source, shutdown/restart,
     failed-logon, application-crash, storage-error,
-    scheduled-task, and Service Control Manager crash reports.
+    scheduled-task, Service Control Manager crash, and
+    Windows Update failure reports.
 
       Get-ADLockoutSource
       Get-DiskErrorEvent
@@ -81,6 +82,7 @@ FUNCTION DOMAINS
       Get-ScheduledTaskFailure
       Get-ServiceCrashEvent
       Get-UnexpectedShutdown
+      Get-WindowsUpdateFailure
 
   healthcheck (16 functions)
     Functions that evaluate the health of Windows roles and
@@ -331,7 +333,7 @@ REMOTE EXECUTION PATTERN
     in the pipeline continue to be processed.
 
 PSWINOPS TYPE REGISTRY
-    The following 105 PSTypeName values are defined by the
+    The following 106 PSTypeName values are defined by the
     module. Each corresponds to the output of one or more
     public functions.
 
@@ -442,6 +444,7 @@ PSWINOPS TYPE REGISTRY
       PSWinOps.UserProfileRemoval
       PSWinOps.WindowsUpdate
       PSWinOps.WindowsUpdateConfiguration
+      PSWinOps.WindowsUpdateFailure
       PSWinOps.WindowsUpdateHistory
       PSWinOps.WindowsUpdateResetResult
       PSWinOps.WinRMTestResult


### PR DESCRIPTION
## Summary
Add Get-WindowsUpdateFailure for Windows Update event-log failures, required restarts, and optional successful installations.

- Parses named Windows event XML fields without relying on localized messages
- Supports remote and pipeline collection, KB/title filters, HRESULT normalization, and typed output
- Adds Pester coverage, format view, manifest export, and conceptual help updates

## Validation
- Linux-safe conformance, XML, and whitespace checks passed
- PowerShell/Pester skipped locally: Windows-only module and no ARM64 PowerShell runtime available

Closes #91