### PR TITLE
feat(eventlog): add Schannel TLS failure reporting (#92)

### DIFF
--- a/PSWinOps.Format.ps1xml
+++ b/PSWinOps.Format.ps1xml
@@ -8143,6 +8143,89 @@
       </TableControl>
     </View>
     <!-- ============================================================ -->
+    <!-- PSWinOps.SchannelError                                        -->
+    <!-- Used by: Get-SchannelError                                    -->
+    <!-- ============================================================ -->
+    <View>
+      <Name>PSWinOps.SchannelError</Name>
+      <ViewSelectedBy>
+        <TypeName>PSWinOps.SchannelError</TypeName>
+      </ViewSelectedBy>
+      <TableControl>
+        <AutoSize />
+        <TableHeaders>
+          <TableColumnHeader>
+            <Label>ComputerName</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>EventTime</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>EventId</Label>
+            <Alignment>Right</Alignment>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>ErrorType</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Severity</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Role</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Protocol</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>AlertDescription</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>RemoteHost</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>FailureCount</Label>
+            <Alignment>Right</Alignment>
+          </TableColumnHeader>
+        </TableHeaders>
+        <TableRowEntries>
+          <TableRowEntry>
+            <TableColumnItems>
+              <TableColumnItem>
+                <PropertyName>ComputerName</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>EventTime</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>EventId</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>ErrorType</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>Severity</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>Role</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>Protocol</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>AlertDescription</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>RemoteHost</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>FailureCount</PropertyName>
+              </TableColumnItem>
+            </TableColumnItems>
+          </TableRowEntry>
+        </TableRowEntries>
+      </TableControl>
+    </View>
+    <!-- ============================================================ -->
     <!-- PSWinOps.ScheduledTaskFailure                                -->
     <!-- Used by: Get-ScheduledTaskFailure                            -->
     <!-- ============================================================ -->

--- a/PSWinOps.psd1
+++ b/PSWinOps.psd1
@@ -159,6 +159,7 @@
         'Get-RdpSessionHistory',
         'Get-RdpSessionLock',
         'Get-RDSHealth',
+        'Get-SchannelError',
         'Get-ScheduledTaskDetail',
         'Get-ScheduledTaskFailure',
         'Get-ServiceAccount',
@@ -289,6 +290,7 @@
 - Get-ADLockoutSource: Trace the source machine of an AD account lockout via event 4740 on the PDC Emulator
 - Get-DiskErrorEvent: Classify and aggregate Disk, Ntfs, storahci, and storport storage errors from the System log
 - Get-ProcessCrashEvent: Correlate Application Error, Windows Error Reporting, and optional Application Hang events with per-process counts
+- Get-SchannelError: Normalize Schannel TLS, certificate, and negotiation failures from the System log
 - Get-ScheduledTaskFailure: Report Task Scheduler task-start and action failures with XML field extraction and per-task counts
 
 ## 0.11.0 - 2026-09-04 UTC

--- a/Public/eventlog/Get-SchannelError.ps1
+++ b/Public/eventlog/Get-SchannelError.ps1
@@ -1,0 +1,383 @@
+#Requires -Version 5.1
+
+function Get-SchannelError {
+    <#
+    .SYNOPSIS
+        Report Schannel TLS, certificate, and negotiation failures from the System log
+
+    .DESCRIPTION
+        Queries the Schannel provider in the Windows System event log for common TLS and
+        certificate failures. Event XML is parsed for stable diagnostic fields so localized
+        message text does not drive classification or extraction.
+
+        Results classify each failure as Certificate, Protocol, Cipher, Alert, or Unknown,
+        aggregate equivalent occurrences, and return newest events first. Missing XML fields
+        remain empty, sensitive key and secret fields are never extracted, and a failure on one
+        computer does not stop the remaining computers from being processed.
+
+    .PARAMETER ComputerName
+        One or more computer names to target. Defaults to the local computer.
+        Accepts pipeline input by value and by property name.
+
+    .PARAMETER Days
+        Look-back window in days. Valid values are 1 through 3650. Defaults to 7.
+
+    .PARAMETER MaxEvents
+        Maximum number of Schannel events read per machine. Valid values are 1 through
+        10000. Defaults to 200.
+
+    .PARAMETER EventId
+        Optional Schannel event IDs to query. Defaults to 36870, 36871, 36874, and 36888.
+
+    .PARAMETER RemoteHost
+        Optional case-insensitive filter applied after XML parsing to the extracted peer name.
+
+    .PARAMETER Credential
+        Optional PSCredential for authenticating to remote machines. Ignored for local
+        machine queries.
+
+    .EXAMPLE
+        Get-SchannelError
+
+        Returns Schannel errors from the local computer over the last seven days.
+
+    .EXAMPLE
+        Get-SchannelError -ComputerName 'SRV01' -Days 30 -RemoteHost 'api.example.com'
+
+        Returns matching Schannel failures from SRV01 involving the specified peer.
+
+    .EXAMPLE
+        'SRV01', 'SRV02' | Get-SchannelError -MaxEvents 500 -EventId 36888
+
+        Returns generated fatal TLS alerts from multiple computers through pipeline input.
+
+    .OUTPUTS
+        PSWinOps.SchannelError
+        One object per parsed Schannel event, newest first, with normalized classification,
+        extracted XML fields, a FailureCount for equivalent events, and a safe message.
+
+    .NOTES
+        Author: Franck SALLET
+        Version: 1.0.0
+        Last Modified: 2026-09-04
+        Requires: PowerShell 5.1+ / Windows only
+        Requires: Event Log Readers membership for remote or protected System log access
+        Requires: WinRM enabled on target machines for remote queries
+
+        Event IDs 36870, 36871, 36874, and 36888 are queried by default. Private keys,
+        passwords, tokens, and secret fields are deliberately excluded from the output.
+
+    .LINK
+        https://github.com/k9fr4n/PSWinOps
+
+    .LINK
+        https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.diagnostics/get-winevent
+    #>
+    [CmdletBinding(SupportsShouldProcess = $false, ConfirmImpact = 'None')]
+    [OutputType('PSWinOps.SchannelError')]
+    param(
+        [Parameter(Mandatory = $false, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [ValidateNotNullOrEmpty()]
+        [Alias('CN', 'Name', 'DNSHostName')]
+        [string[]]$ComputerName = $env:COMPUTERNAME,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateRange(1, 3650)]
+        [int]$Days = 7,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateRange(1, 10000)]
+        [int]$MaxEvents = 200,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateNotNullOrEmpty()]
+        [int[]]$EventId = @(36870, 36871, 36874, 36888),
+
+        [Parameter(Mandatory = $false)]
+        [AllowEmptyString()]
+        [string]$RemoteHost = '',
+
+        [Parameter(Mandatory = $false)]
+        [System.Management.Automation.PSCredential]$Credential
+    )
+
+    begin {
+        Write-Verbose "[$($MyInvocation.MyCommand)] Starting Schannel error query"
+
+        $startTime = (Get-Date).AddDays(-$Days)
+
+        $scriptBlock = {
+            param(
+                [datetime]$ScanStartTime,
+                [int]$MaxEvts,
+                [int[]]$EventIdFilter,
+                [string]$RemoteHostFilter
+            )
+
+            $filter = @{
+                LogName      = 'System'
+                ProviderName = 'Schannel'
+                Id           = $EventIdFilter
+                StartTime    = $ScanStartTime
+            }
+
+            $eventRecords = @()
+            try {
+                $eventRecords = @(Get-WinEvent -FilterHashtable $filter -MaxEvents $MaxEvts -ErrorAction Stop)
+            } catch {
+                if ($_.Exception.Message -notmatch 'No events were found') {
+                    throw
+                }
+            }
+
+            if ($eventRecords.Count -eq 0) {
+                return
+            }
+
+            function Get-EventDataMap {
+                param(
+                    [Parameter(Mandatory = $true)]
+                    [object]$Event
+                )
+
+                $map = @{}
+                try {
+                    $xml = [xml]$Event.ToXml()
+                    foreach ($node in @($xml.SelectNodes("//*[local-name()='Data']"))) {
+                        $name = [string]$node.GetAttribute('Name')
+                        if ([string]::IsNullOrWhiteSpace($name)) {
+                            continue
+                        }
+
+                        $map[$name] = [string]$node.InnerText
+                    }
+
+                    return [PSCustomObject]@{
+                        Parsed = $true
+                        Data   = $map
+                    }
+                } catch {
+                    Write-Verbose "Could not parse Schannel event $($Event.Id) as XML: $_"
+                    return [PSCustomObject]@{
+                        Parsed = $false
+                        Data   = $map
+                    }
+                }
+            }
+
+            function Get-EventField {
+                param(
+                    [Parameter(Mandatory = $true)]
+                    [hashtable]$Data,
+                    [Parameter(Mandatory = $true)]
+                    [string[]]$Names
+                )
+
+                foreach ($name in $Names) {
+                    if ($Data.ContainsKey($name) -and -not [string]::IsNullOrWhiteSpace([string]$Data[$name])) {
+                        return [string]$Data[$name]
+                    }
+                }
+
+                return ''
+            }
+
+            function ConvertTo-SafeMessage {
+                param(
+                    [AllowEmptyString()]
+                    [string]$Message
+                )
+
+                if ([string]::IsNullOrWhiteSpace($Message)) {
+                    return ''
+                }
+
+                $safeMessage = [regex]::Replace(
+                    $Message,
+                    '(?is)-----BEGIN [^-]+-----.*?-----END [^-]+-----',
+                    '[REDACTED-KEY]'
+                )
+                $safeMessage = [regex]::Replace(
+                    $safeMessage,
+                    '(?im)\b(password|passwd|secret|token|private\s*key)\s*[:=]\s*[^;\r\n]+',
+                    '$1=[REDACTED]'
+                )
+
+                return $safeMessage
+            }
+
+            function Get-NormalizedRole {
+                param(
+                    [AllowEmptyString()]
+                    [string]$Value
+                )
+
+                if ([string]::IsNullOrWhiteSpace($Value)) {
+                    return ''
+                }
+                if ($Value -match '(?i)client') {
+                    return 'Client'
+                }
+                if ($Value -match '(?i)server') {
+                    return 'Server'
+                }
+
+                return $Value
+            }
+
+            function Get-Severity {
+                param(
+                    [Parameter(Mandatory = $true)]
+                    [object]$Event
+                )
+
+                if (-not [string]::IsNullOrWhiteSpace([string]$Event.LevelDisplayName)) {
+                    return [string]$Event.LevelDisplayName
+                }
+
+                switch ([int]$Event.Level) {
+                    1 { return 'Critical' }
+                    2 { return 'Error' }
+                    3 { return 'Warning' }
+                    4 { return 'Information' }
+                    5 { return 'Verbose' }
+                    default { return 'Error' }
+                }
+            }
+
+            $rows = [System.Collections.Generic.List[psobject]]::new()
+            foreach ($eventRecord in @($eventRecords | Sort-Object -Property TimeCreated -Descending)) {
+                $parsedEvent = Get-EventDataMap -Event $eventRecord
+                $data = $parsedEvent.Data
+                $eventId = [int]$eventRecord.Id
+
+                $protocol = Get-EventField -Data $data -Names @(
+                    'Protocol', 'ProtocolVersion', 'TlsVersion', 'TLSVersion', 'SslVersion'
+                )
+                $alertDescription = Get-EventField -Data $data -Names @(
+                    'AlertDescription', 'AlertDescriptionCode', 'Alert', 'AlertType'
+                )
+                $errorState = Get-EventField -Data $data -Names @(
+                    'ErrorState', 'InternalErrorState', 'State', 'ErrorCode', 'Error'
+                )
+                $role = Get-NormalizedRole -Value (Get-EventField -Data $data -Names @(
+                    'Role', 'ConnectionRole', 'EndpointRole', 'ClientServer', 'Direction'
+                ))
+                $remoteHostValue = Get-EventField -Data $data -Names @(
+                    'RemoteHost', 'PeerName', 'PeerHost', 'TargetName', 'ServerName', 'ClientName'
+                )
+                $certificateSubject = Get-EventField -Data $data -Names @(
+                    'CertificateSubject', 'SubjectName', 'CertificateName', 'Subject'
+                )
+                $cipherSuite = Get-EventField -Data $data -Names @(
+                    'CipherSuite', 'Cipher', 'CipherAlgorithm', 'HashAlgorithm', 'ExchangeAlgorithm'
+                )
+
+                $errorType = 'Unknown'
+                if ($parsedEvent.Parsed) {
+                    if (-not [string]::IsNullOrWhiteSpace($cipherSuite)) {
+                        $errorType = 'Cipher'
+                    } elseif (-not [string]::IsNullOrWhiteSpace($alertDescription)) {
+                        $errorType = 'Alert'
+                    } elseif ($eventId -in @(36870, 36871)) {
+                        $errorType = 'Certificate'
+                    } elseif (-not [string]::IsNullOrWhiteSpace($protocol)) {
+                        $errorType = 'Protocol'
+                    } elseif ($eventId -in @(36874, 36888)) {
+                        $errorType = 'Alert'
+                    }
+                }
+
+                $eventTime = $eventRecord.TimeCreated
+                $eventTimeValue = if ($null -eq $eventTime) { '' } else { $eventTime.ToString('o') }
+                $rows.Add([PSCustomObject]@{
+                    EventTime          = $eventTime
+                    EventTimeValue     = $eventTimeValue
+                    EventId            = $eventId
+                    ErrorType          = $errorType
+                    Severity           = Get-Severity -Event $eventRecord
+                    Role               = $role
+                    Protocol           = $protocol
+                    AlertDescription   = $alertDescription
+                    ErrorState         = $errorState
+                    RemoteHost         = $remoteHostValue
+                    CertificateSubject = $certificateSubject
+                    CipherSuite        = $cipherSuite
+                    Message            = ConvertTo-SafeMessage -Message ([string]$eventRecord.Message)
+                })
+            }
+
+            $eventTally = @{}
+            foreach ($row in $rows) {
+                $key = '{0}|{1}|{2}|{3}|{4}|{5}|{6}|{7}|{8}' -f `
+                    $row.EventId,
+                    $row.ErrorType,
+                    $row.Role,
+                    $row.Protocol,
+                    $row.AlertDescription,
+                    $row.ErrorState,
+                    $row.RemoteHost,
+                    $row.CertificateSubject,
+                    $row.CipherSuite
+                if ($eventTally.ContainsKey($key)) {
+                    $eventTally[$key]++
+                } else {
+                    $eventTally[$key] = 1
+                }
+            }
+
+            foreach ($row in ($rows | Sort-Object -Property EventTime -Descending)) {
+                if (-not [string]::IsNullOrWhiteSpace($RemoteHostFilter) -and
+                    ([string]$row.RemoteHost).IndexOf($RemoteHostFilter, [System.StringComparison]::OrdinalIgnoreCase) -lt 0) {
+                    continue
+                }
+
+                $key = '{0}|{1}|{2}|{3}|{4}|{5}|{6}|{7}|{8}' -f `
+                    $row.EventId,
+                    $row.ErrorType,
+                    $row.Role,
+                    $row.Protocol,
+                    $row.AlertDescription,
+                    $row.ErrorState,
+                    $row.RemoteHost,
+                    $row.CertificateSubject,
+                    $row.CipherSuite
+
+                [PSCustomObject]@{
+                    PSTypeName          = 'PSWinOps.SchannelError'
+                    ComputerName        = $env:COMPUTERNAME
+                    EventTime           = $row.EventTimeValue
+                    EventId             = $row.EventId
+                    ErrorType           = $row.ErrorType
+                    Severity            = $row.Severity
+                    Role                = $row.Role
+                    Protocol            = $row.Protocol
+                    AlertDescription    = $row.AlertDescription
+                    ErrorState          = $row.ErrorState
+                    RemoteHost          = $row.RemoteHost
+                    CertificateSubject  = $row.CertificateSubject
+                    FailureCount        = $eventTally[$key]
+                    Message             = $row.Message
+                    Timestamp           = Get-Date -Format 'o'
+                }
+            }
+        }
+    }
+
+    process {
+        foreach ($targetComputer in $ComputerName) {
+            try {
+                Write-Verbose "[$($MyInvocation.MyCommand)] Querying Schannel errors on '$targetComputer'"
+                Invoke-RemoteOrLocal -ComputerName $targetComputer -Credential $Credential `
+                    -ScriptBlock $scriptBlock `
+                    -ArgumentList @($startTime, $MaxEvents, $EventId, $RemoteHost)
+            } catch {
+                Write-Error "[$($MyInvocation.MyCommand)] Failed on '$targetComputer': $_"
+            }
+        }
+    }
+
+    end {
+        Write-Verbose "[$($MyInvocation.MyCommand)] Completed Schannel error query"
+    }
+}

--- a/Tests/Public/eventlog/Get-SchannelError.Tests.ps1
+++ b/Tests/Public/eventlog/Get-SchannelError.Tests.ps1
@@ -1,0 +1,245 @@
+#Requires -Version 5.1
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+
+param()
+
+BeforeAll {
+    $script:modulePath = Split-Path -Path (Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent) -Parent
+    Import-Module -Name (Join-Path -Path $script:modulePath -ChildPath 'PSWinOps.psd1') -Force
+
+    function New-MockSchannelEvent {
+        param(
+            [Parameter(Mandatory = $true)]
+            [int]$EventId,
+            [Parameter(Mandatory = $true)]
+            [datetime]$TimeCreated,
+            [Parameter(Mandatory = $true)]
+            [string]$XmlContent,
+            [string]$Message = 'Localized Schannel event message',
+            [string]$LevelDisplayName = 'Error',
+            [int]$Level = 2
+        )
+
+        $mockEvent = [PSCustomObject]@{
+            Id                = $EventId
+            TimeCreated       = $TimeCreated
+            Message           = $Message
+            LevelDisplayName  = $LevelDisplayName
+            Level             = $Level
+        }
+
+        $mockEvent | Add-Member -MemberType ScriptMethod -Name 'ToXml' -Value {
+            return $XmlContent
+        }.GetNewClosure() -Force
+
+        return $mockEvent
+    }
+
+    function New-SchannelXml {
+        param(
+            [string]$Protocol = '',
+            [string]$AlertDescription = '',
+            [string]$ErrorState = '',
+            [string]$Role = '',
+            [string]$RemoteHost = '',
+            [string]$CertificateSubject = '',
+            [string]$CipherSuite = '',
+            [switch]$IncludeSecretField
+        )
+
+        $data = @(
+            if ($Protocol) { "    <Data Name=`"Protocol`">$Protocol</Data>" }
+            if ($AlertDescription) { "    <Data Name=`"AlertDescription`">$AlertDescription</Data>" }
+            if ($ErrorState) { "    <Data Name=`"ErrorState`">$ErrorState</Data>" }
+            if ($Role) { "    <Data Name=`"Role`">$Role</Data>" }
+            if ($RemoteHost) { "    <Data Name=`"RemoteHost`">$RemoteHost</Data>" }
+            if ($CertificateSubject) { "    <Data Name=`"CertificateSubject`">$CertificateSubject</Data>" }
+            if ($CipherSuite) { "    <Data Name=`"CipherSuite`">$CipherSuite</Data>" }
+            if ($IncludeSecretField) { '    <Data Name="PrivateKey">PRIVATE-KEY-MUST-NOT-APPEAR</Data>' }
+        ) -join "`n"
+
+        @"
+<Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
+  <EventData>
+$data
+  </EventData>
+</Event>
+"@
+    }
+}
+
+Describe -Name 'Get-SchannelError' -Fixture {
+    Context -Name 'Local XML parsing and classification' -Fixture {
+        BeforeAll {
+            $script:alertXml = New-SchannelXml -Protocol 'TLS 1.2' -AlertDescription '40' `
+                -ErrorState '1203' -Role 'Client' -RemoteHost 'api.example.com'
+            $script:alertEvent = New-MockSchannelEvent -EventId 36874 `
+                -TimeCreated (Get-Date '2026-09-04 10:00:00') -XmlContent $script:alertXml `
+                -Message 'TLS alert from api.example.com'
+            $script:alertEvent2 = New-MockSchannelEvent -EventId 36874 `
+                -TimeCreated (Get-Date '2026-09-04 09:00:00') -XmlContent $script:alertXml
+            $script:certificateEvent = New-MockSchannelEvent -EventId 36870 `
+                -TimeCreated (Get-Date '2026-09-04 08:00:00') `
+                -XmlContent (New-SchannelXml -ErrorState '10013' -CertificateSubject 'CN=server.example.com' -IncludeSecretField)
+            $script:cipherEvent = New-MockSchannelEvent -EventId 36888 `
+                -TimeCreated (Get-Date '2026-09-04 07:00:00') `
+                -XmlContent (New-SchannelXml -CipherSuite 'TLS_AES_256_GCM_SHA384')
+            $script:unknownEvent = New-MockSchannelEvent -EventId 36888 `
+                -TimeCreated (Get-Date '2026-09-04 06:00:00') `
+                -XmlContent '<Event><EventData>' `
+                -Message 'private key=TOPSECRET token=TOKENVALUE'
+
+            Mock -CommandName 'Get-WinEvent' -ModuleName 'PSWinOps' -MockWith {
+                @($script:unknownEvent, $script:cipherEvent, $script:certificateEvent, $script:alertEvent2, $script:alertEvent)
+            }
+        }
+
+        It -Name 'Should parse fields, classify events, aggregate equivalents, and sort newest first' -Test {
+            $result = @(Get-SchannelError)
+
+            $result.Count | Should -Be 5
+            $result[0].EventId | Should -Be 36874
+            $result[0].ErrorType | Should -Be 'Alert'
+            $result[0].Protocol | Should -Be 'TLS 1.2'
+            $result[0].AlertDescription | Should -Be '40'
+            $result[0].Role | Should -Be 'Client'
+            $result[0].RemoteHost | Should -Be 'api.example.com'
+            $result[0].FailureCount | Should -Be 2
+            ($result | Where-Object ErrorType -eq 'Certificate').Count | Should -Be 1
+            ($result | Where-Object ErrorType -eq 'Cipher').Count | Should -Be 1
+            ($result | Where-Object ErrorType -eq 'Unknown').Count | Should -Be 1
+            $result[0].PSObject.TypeNames | Should -Contain 'PSWinOps.SchannelError'
+        }
+
+        It -Name 'Should preserve missing optional fields and redact sensitive message content' -Test {
+            $result = @(Get-SchannelError)
+            $certificate = $result | Where-Object EventId -eq 36870
+            $unknown = $result | Where-Object ErrorType -eq 'Unknown'
+
+            $certificate.Protocol | Should -Be ''
+            $certificate.AlertDescription | Should -Be ''
+            $certificate.RemoteHost | Should -Be ''
+            $certificate.CertificateSubject | Should -Be 'CN=server.example.com'
+            $unknown.Message | Should -Not -Match 'TOPSECRET|TOKENVALUE'
+            $result | ConvertTo-Json -Depth 5 | Should -Not -Match 'PRIVATE-KEY-MUST-NOT-APPEAR|TOPSECRET|TOKENVALUE'
+        }
+
+        It -Name 'Should classify protocol-only XML as Protocol' -Test {
+            $protocolEvent = New-MockSchannelEvent -EventId 9999 `
+                -TimeCreated (Get-Date '2026-09-04 11:00:00') `
+                -XmlContent (New-SchannelXml -Protocol 'TLS 1.3')
+            Mock -CommandName 'Get-WinEvent' -ModuleName 'PSWinOps' -MockWith { $protocolEvent }
+
+            $result = @(Get-SchannelError -EventId 9999)
+
+            $result.ErrorType | Should -Be 'Protocol'
+            $result.Protocol | Should -Be 'TLS 1.3'
+            Should -Invoke -CommandName 'Get-WinEvent' -ModuleName 'PSWinOps' -Times 1 -Exactly -ParameterFilter {
+                $FilterHashtable.Id -contains 9999
+            }
+        }
+
+        It -Name 'Should filter by remote host after XML extraction' -Test {
+            $otherEvent = New-MockSchannelEvent -EventId 36874 `
+                -TimeCreated (Get-Date '2026-09-04 10:30:00') `
+                -XmlContent (New-SchannelXml -RemoteHost 'other.example.com')
+            Mock -CommandName 'Get-WinEvent' -ModuleName 'PSWinOps' -MockWith {
+                @($script:alertEvent, $otherEvent)
+            }
+
+            $result = @(Get-SchannelError -RemoteHost 'API.EXAMPLE.COM')
+
+            $result.Count | Should -Be 1
+            $result.RemoteHost | Should -Be 'api.example.com'
+        }
+    }
+
+    Context -Name 'Remote, credentials, pipeline, and error isolation' -Fixture {
+        BeforeEach {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -MockWith {
+                if ($ComputerName -eq 'SRV01') {
+                    throw 'Simulated WinRM failure on SRV01'
+                }
+
+                [PSCustomObject]@{
+                    PSTypeName         = 'PSWinOps.SchannelError'
+                    ComputerName       = $ComputerName
+                    EventTime          = '2026-09-04T10:00:00.0000000'
+                    EventId            = 36888
+                    ErrorType          = 'Alert'
+                    Severity           = 'Error'
+                    Role               = 'Server'
+                    Protocol           = 'TLS 1.2'
+                    AlertDescription   = '40'
+                    ErrorState         = '1203'
+                    RemoteHost         = 'api.example.com'
+                    CertificateSubject = ''
+                    FailureCount       = 1
+                    Message            = ''
+                    Timestamp          = '2026-09-04T10:00:00.0000000'
+                }
+            }
+        }
+
+        It -Name 'Should query a remote machine and propagate credentials' -Test {
+            $securePassword = ConvertTo-SecureString -String 'P@ssw0rd123!' -AsPlainText -Force
+            $credential = [System.Management.Automation.PSCredential]::new('CONTOSO\svc', $securePassword)
+            $result = @(Get-SchannelError -ComputerName 'SRV02' -Credential $credential)
+
+            $result.ComputerName | Should -Be 'SRV02'
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -Times 1 -Exactly -ParameterFilter {
+                $ComputerName -eq 'SRV02' -and $Credential -eq $credential
+            }
+        }
+
+        It -Name 'Should continue after a per-machine failure in pipeline input' -Test {
+            $output = 'SRV01', 'SRV02' | Get-SchannelError -ErrorAction Continue 2>&1
+
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -Times 2 -Exactly
+            @($output | Where-Object { $_ -is [System.Management.Automation.ErrorRecord] }).Count | Should -BeGreaterThan 0
+            @($output | Where-Object { $_ -isnot [System.Management.Automation.ErrorRecord] }).Count | Should -Be 1
+            ($output | Where-Object { $_ -isnot [System.Management.Automation.ErrorRecord] }).ComputerName | Should -Be 'SRV02'
+        }
+    }
+
+    Context -Name 'Parameter validation and metadata' -Fixture {
+        It -Name 'Should reject invalid ComputerName, Days, MaxEvents, and EventId' -Test {
+            { Get-SchannelError -ComputerName '' } | Should -Throw
+            { Get-SchannelError -ComputerName $null } | Should -Throw
+            { Get-SchannelError -Days 0 } | Should -Throw
+            { Get-SchannelError -Days 3651 } | Should -Throw
+            { Get-SchannelError -MaxEvents 0 } | Should -Throw
+            { Get-SchannelError -MaxEvents 10001 } | Should -Throw
+            { Get-SchannelError -EventId @() } | Should -Throw
+        }
+
+        It -Name 'Should expose pipeline support and aliases on ComputerName' -Test {
+            $command = Get-Command -Name 'Get-SchannelError'
+            $parameterAttribute = $command.Parameters['ComputerName'].Attributes.Where({
+                $_ -is [System.Management.Automation.ParameterAttribute]
+            })[0]
+
+            $parameterAttribute.ValueFromPipeline | Should -Be $true
+            $parameterAttribute.ValueFromPipelineByPropertyName | Should -Be $true
+            $command.Parameters['ComputerName'].Aliases | Should -Contain 'CN'
+            $command.Parameters['ComputerName'].Aliases | Should -Contain 'Name'
+            $command.Parameters['ComputerName'].Aliases | Should -Contain 'DNSHostName'
+        }
+
+        It -Name 'Should expose the required output properties' -Test {
+            $event = New-MockSchannelEvent -EventId 36874 `
+                -TimeCreated (Get-Date '2026-09-04 10:00:00') `
+                -XmlContent (New-SchannelXml -AlertDescription '40')
+            Mock -CommandName 'Get-WinEvent' -ModuleName 'PSWinOps' -MockWith { $event }
+
+            $result = @(Get-SchannelError)
+            foreach ($property in @(
+                'ComputerName', 'EventTime', 'EventId', 'ErrorType', 'Severity', 'Role',
+                'Protocol', 'AlertDescription', 'ErrorState', 'RemoteHost',
+                'CertificateSubject', 'FailureCount', 'Message', 'Timestamp'
+            )) {
+                $result[0].PSObject.Properties.Name | Should -Contain $property
+            }
+        }
+    }
+}

--- a/en-US/about_PSWinOps.help.txt
+++ b/en-US/about_PSWinOps.help.txt
@@ -68,17 +68,18 @@ FUNCTION DOMAINS
 
       Get-ExpiringCertificate
 
-  eventlog (8 functions)
+  eventlog (9 functions)
     Functions for correlating Windows System and Security
     event log entries into lockout-source, shutdown/restart,
     failed-logon, application-crash, storage-error,
-    scheduled-task, Service Control Manager crash, and
-    Windows Update failure reports.
+    Schannel TLS, scheduled-task, Service Control Manager
+    crash, and Windows Update failure reports.
 
       Get-ADLockoutSource
       Get-DiskErrorEvent
       Get-LogonFailure
       Get-ProcessCrashEvent
+      Get-SchannelError
       Get-ScheduledTaskFailure
       Get-ServiceCrashEvent
       Get-UnexpectedShutdown
@@ -333,7 +334,7 @@ REMOTE EXECUTION PATTERN
     in the pipeline continue to be processed.
 
 PSWINOPS TYPE REGISTRY
-    The following 106 PSTypeName values are defined by the
+    The following 107 PSTypeName values are defined by the
     module. Each corresponds to the output of one or more
     public functions.
 
@@ -424,6 +425,7 @@ PSWINOPS TYPE REGISTRY
       PSWinOps.RdpSessionLock
       PSWinOps.RDSHealth
       PSWinOps.RebootHistory
+      PSWinOps.SchannelError
       PSWinOps.ScheduledTaskDetail
       PSWinOps.ScheduledTaskFailure
       PSWinOps.ServiceAccount


### PR DESCRIPTION
## Summary
- Add Get-SchannelError with XML-based Schannel parsing and normalized TLS failure classification
- Add peer filtering, equivalent failure counts, remote/pipeline support, and secret-safe output
- Add format metadata, module exports, documentation, and Pester coverage

## Validation
- PowerShell parser: passed
- PSScriptAnalyzer on changed source: passed
- Functional parser harness: passed
- Full Pester suite: deferred to Windows CI because this module is Windows-only

Closes #92