### PR TITLE
fix(format): add Windows Update result views (#101)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,7 @@
 ### Added
 
 - `ConvertTo-Markdown`: Convert PowerShell objects into deterministic GitHub-Flavored Markdown tables with stable column and row ordering.
+
+### Fixed
+
+- Added default format views for Windows Update result objects.

--- a/PSWinOps.Format.ps1xml
+++ b/PSWinOps.Format.ps1xml
@@ -7785,6 +7785,365 @@
       </ListControl>
     </View>
     <!-- ============================================================ -->
+    <!-- PSWinOps.WindowsUpdateCacheResult                            -->
+    <!-- Used by: Clear-WindowsUpdateCache                            -->
+    <!-- ============================================================ -->
+    <View>
+      <Name>PSWinOps.WindowsUpdateCacheResult</Name>
+      <ViewSelectedBy>
+        <TypeName>PSWinOps.WindowsUpdateCacheResult</TypeName>
+      </ViewSelectedBy>
+      <TableControl>
+        <AutoSize />
+        <TableHeaders>
+          <TableColumnHeader>
+            <Label>ComputerName</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>CachePath</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>FileCount</Label>
+            <Alignment>Right</Alignment>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>SizeFreedMB</Label>
+            <Alignment>Right</Alignment>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>DataStoreCleared</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Result</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Timestamp</Label>
+          </TableColumnHeader>
+        </TableHeaders>
+        <TableRowEntries>
+          <TableRowEntry>
+            <TableColumnItems>
+              <TableColumnItem>
+                <PropertyName>ComputerName</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>CachePath</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>FileCount</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>SizeFreedMB</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>DataStoreCleared</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>Result</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>Timestamp</PropertyName>
+              </TableColumnItem>
+            </TableColumnItems>
+          </TableRowEntry>
+        </TableRowEntries>
+      </TableControl>
+    </View>
+    <!-- ============================================================ -->
+    <!-- PSWinOps.WindowsUpdateDownloadResult                         -->
+    <!-- Used by: Save-WindowsUpdate                                  -->
+    <!-- ============================================================ -->
+    <View>
+      <Name>PSWinOps.WindowsUpdateDownloadResult</Name>
+      <ViewSelectedBy>
+        <TypeName>PSWinOps.WindowsUpdateDownloadResult</TypeName>
+      </ViewSelectedBy>
+      <TableControl>
+        <AutoSize />
+        <TableHeaders>
+          <TableColumnHeader>
+            <Label>ComputerName</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Title</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>KBArticle</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>SizeMB</Label>
+            <Alignment>Right</Alignment>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Result</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>HResult</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Timestamp</Label>
+          </TableColumnHeader>
+        </TableHeaders>
+        <TableRowEntries>
+          <TableRowEntry>
+            <TableColumnItems>
+              <TableColumnItem>
+                <PropertyName>ComputerName</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>Title</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>KBArticle</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>SizeMB</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>Result</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>HResult</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>Timestamp</PropertyName>
+              </TableColumnItem>
+            </TableColumnItems>
+          </TableRowEntry>
+        </TableRowEntries>
+      </TableControl>
+    </View>
+    <!-- ============================================================ -->
+    <!-- PSWinOps.WindowsUpdateHideResult                              -->
+    <!-- Used by: Hide-WindowsUpdate                                   -->
+    <!-- ============================================================ -->
+    <View>
+      <Name>PSWinOps.WindowsUpdateHideResult</Name>
+      <ViewSelectedBy>
+        <TypeName>PSWinOps.WindowsUpdateHideResult</TypeName>
+      </ViewSelectedBy>
+      <TableControl>
+        <AutoSize />
+        <TableHeaders>
+          <TableColumnHeader>
+            <Label>ComputerName</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Title</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>KBArticle</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Result</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Timestamp</Label>
+          </TableColumnHeader>
+        </TableHeaders>
+        <TableRowEntries>
+          <TableRowEntry>
+            <TableColumnItems>
+              <TableColumnItem>
+                <PropertyName>ComputerName</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>Title</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>KBArticle</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>Result</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>Timestamp</PropertyName>
+              </TableColumnItem>
+            </TableColumnItems>
+          </TableRowEntry>
+        </TableRowEntries>
+      </TableControl>
+    </View>
+    <!-- ============================================================ -->
+    <!-- PSWinOps.WindowsUpdateInstallResult                           -->
+    <!-- Used by: Install-WindowsUpdate                                -->
+    <!-- ============================================================ -->
+    <View>
+      <Name>PSWinOps.WindowsUpdateInstallResult</Name>
+      <ViewSelectedBy>
+        <TypeName>PSWinOps.WindowsUpdateInstallResult</TypeName>
+      </ViewSelectedBy>
+      <TableControl>
+        <AutoSize />
+        <TableHeaders>
+          <TableColumnHeader>
+            <Label>ComputerName</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Title</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>KBArticle</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>SizeMB</Label>
+            <Alignment>Right</Alignment>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Result</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>HResult</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>RebootRequired</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Timestamp</Label>
+          </TableColumnHeader>
+        </TableHeaders>
+        <TableRowEntries>
+          <TableRowEntry>
+            <TableColumnItems>
+              <TableColumnItem>
+                <PropertyName>ComputerName</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>Title</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>KBArticle</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>SizeMB</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>Result</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>HResult</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>RebootRequired</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>Timestamp</PropertyName>
+              </TableColumnItem>
+            </TableColumnItems>
+          </TableRowEntry>
+        </TableRowEntries>
+      </TableControl>
+    </View>
+    <!-- ============================================================ -->
+    <!-- PSWinOps.WindowsUpdateShowResult                              -->
+    <!-- Used by: Show-WindowsUpdate                                   -->
+    <!-- ============================================================ -->
+    <View>
+      <Name>PSWinOps.WindowsUpdateShowResult</Name>
+      <ViewSelectedBy>
+        <TypeName>PSWinOps.WindowsUpdateShowResult</TypeName>
+      </ViewSelectedBy>
+      <TableControl>
+        <AutoSize />
+        <TableHeaders>
+          <TableColumnHeader>
+            <Label>ComputerName</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Title</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>KBArticle</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Result</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Timestamp</Label>
+          </TableColumnHeader>
+        </TableHeaders>
+        <TableRowEntries>
+          <TableRowEntry>
+            <TableColumnItems>
+              <TableColumnItem>
+                <PropertyName>ComputerName</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>Title</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>KBArticle</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>Result</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>Timestamp</PropertyName>
+              </TableColumnItem>
+            </TableColumnItems>
+          </TableRowEntry>
+        </TableRowEntries>
+      </TableControl>
+    </View>
+    <!-- ============================================================ -->
+    <!-- PSWinOps.WindowsUpdateUninstallResult                         -->
+    <!-- Used by: Uninstall-WindowsUpdate                              -->
+    <!-- ============================================================ -->
+    <View>
+      <Name>PSWinOps.WindowsUpdateUninstallResult</Name>
+      <ViewSelectedBy>
+        <TypeName>PSWinOps.WindowsUpdateUninstallResult</TypeName>
+      </ViewSelectedBy>
+      <TableControl>
+        <AutoSize />
+        <TableHeaders>
+          <TableColumnHeader>
+            <Label>ComputerName</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>KBArticle</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Result</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>ExitCode</Label>
+            <Alignment>Right</Alignment>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>RebootRequired</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Timestamp</Label>
+          </TableColumnHeader>
+        </TableHeaders>
+        <TableRowEntries>
+          <TableRowEntry>
+            <TableColumnItems>
+              <TableColumnItem>
+                <PropertyName>ComputerName</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>KBArticle</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>Result</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>ExitCode</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>RebootRequired</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>Timestamp</PropertyName>
+              </TableColumnItem>
+            </TableColumnItems>
+          </TableRowEntry>
+        </TableRowEntries>
+      </TableControl>
+    </View>
+    <!-- ============================================================ -->
     <!-- PSWinOps.UnexpectedShutdown                                  -->
     <!-- Used by: Get-UnexpectedShutdown                              -->
     <!-- ============================================================ -->

--- a/Tests/PSWinOps.Format.Tests.ps1
+++ b/Tests/PSWinOps.Format.Tests.ps1
@@ -1,0 +1,40 @@
+#Requires -Version 5.1
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+BeforeAll {
+    $script:formatPath = Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -ChildPath 'PSWinOps.Format.ps1xml'
+    [xml]$script:formatXml = Get-Content -Path $script:formatPath -Raw
+
+    $script:windowsUpdateResultTypes = @(
+        'PSWinOps.PendingReboot'
+        'PSWinOps.WindowsUpdateResetResult'
+        'PSWinOps.WindowsUpdateCacheResult'
+        'PSWinOps.WindowsUpdateDownloadResult'
+        'PSWinOps.WindowsUpdateHideResult'
+        'PSWinOps.WindowsUpdateInstallResult'
+        'PSWinOps.WindowsUpdateShowResult'
+        'PSWinOps.WindowsUpdateUninstallResult'
+    )
+}
+
+Describe -Name 'PSWinOps format definitions' -Fixture {
+    It -Name 'should have a valid XML format definition' -Test {
+        $script:formatXml.Configuration.ViewDefinitions | Should -Not -BeNullOrEmpty
+    }
+
+    It -Name 'should define a functional view for each Windows Update result type' -Test {
+        foreach ($typeName in $script:windowsUpdateResultTypes) {
+            $views = @(
+                $script:formatXml.Configuration.ViewDefinitions.View |
+                    Where-Object { @($_.ViewSelectedBy.TypeName) -contains $typeName }
+            )
+
+            $views.Count | Should -BeGreaterThan 0 -Because "$typeName must have a format view"
+
+            foreach ($view in $views) {
+                $view.Name | Should -Not -BeNullOrEmpty
+                ([bool]$view.TableControl -or [bool]$view.ListControl) | Should -BeTrue -Because "$typeName must use TableControl or ListControl"
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds default format views for the six Windows Update result PSTypeNames that were missing from PSWinOps.Format.ps1xml, and adds a static regression test covering all eight issue types.

## Validation

- XML parsed successfully in an isolated Python 3.12 container
- All newly added view property mappings validated against the expected output properties
- Pester/PowerShell execution unavailable on this Linux ARM host; Windows CI remains authoritative

Closes #101