### PR TITLE
docs(help): sync domain inventories (#102)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,4 +8,5 @@
 
 ### Fixed
 
+- Synchronized the documented public-function inventories and counts in `about_PSWinOps.help.txt`.
 - Added default format views for Windows Update result objects.

--- a/Tests/PSWinOps.psm1.Tests.ps1
+++ b/Tests/PSWinOps.psm1.Tests.ps1
@@ -281,5 +281,47 @@ Describe -Name 'PSWinOps Module Loader' -Fixture {
             $aboutFile = Get-ChildItem -Path $helpPath -Filter 'about_PSWinOps*' -ErrorAction SilentlyContinue
             $aboutFile | Should -Not -BeNullOrEmpty
         }
+
+        It -Name 'Should list every public function exactly once in its documented domain' -Test {
+            $aboutPath = Join-Path -Path $script:modulePath -ChildPath 'en-US/about_PSWinOps.help.txt'
+            $content = Get-Content -Path $aboutPath -Raw
+            $domainSection = [regex]::Match(
+                $content,
+                '(?ms)^FUNCTION DOMAINS\r?\n(?<section>.*?)^OUTPUT CONVENTIONS'
+            ).Groups['section'].Value
+            $documentedDomains = @{}
+            $currentDomain = $null
+
+            foreach ($line in ($domainSection -split '\r?\n')) {
+                if ($line -match '^\s{2}(\S+) \((\d+) function(s)?\)$') {
+                    $currentDomain = $Matches[1]
+                    $documentedDomains[$currentDomain] = @{
+                        Count     = [int]$Matches[2]
+                        Functions = @()
+                    }
+                }
+                elseif ($currentDomain -and $line -match '^\s{6}([A-Za-z][\w-]+)$') {
+                    $documentedDomains[$currentDomain].Functions += $Matches[1]
+                }
+            }
+
+            $publicRoot = Join-Path -Path $script:modulePath -ChildPath 'Public'
+            $actualDomains = @(Get-ChildItem -Path $publicRoot -Directory | Select-Object -ExpandProperty Name)
+
+            (@($documentedDomains.Keys | Sort-Object) -join "`n") |
+                Should -Be ((@($actualDomains | Sort-Object)) -join "`n")
+
+            foreach ($domain in $actualDomains) {
+                $actualFunctions = @(
+                    Get-ChildItem -Path (Join-Path -Path $publicRoot -ChildPath $domain) -Filter '*.ps1' -File |
+                        Select-Object -ExpandProperty BaseName |
+                        Sort-Object
+                )
+                $documentedFunctions = @($documentedDomains[$domain].Functions | Sort-Object)
+
+                $documentedDomains[$domain].Count | Should -Be $actualFunctions.Count
+                ($documentedFunctions -join "`n") | Should -Be ($actualFunctions -join "`n")
+            }
+        }
     }
 }

--- a/en-US/about_PSWinOps.help.txt
+++ b/en-US/about_PSWinOps.help.txt
@@ -33,7 +33,7 @@ LONG DESCRIPTION
 FUNCTION DOMAINS
     PSWinOps organizes its functions into fourteen domains.
 
-  activedirectory (21 functions)
+  activedirectory (22 functions)
     Functions for Active Directory inventory, user and
     computer management, group membership analysis,
     replication monitoring, and security auditing.
@@ -218,15 +218,21 @@ FUNCTION DOMAINS
       Show-SystemMonitor
       Stop-ProcessTree
 
-  windowsupdate (4 functions)
+  windowsupdate (10 functions)
     Functions for querying and managing Windows Update
     on local or remote machines via the COM API and
     registry.
 
+      Clear-WindowsUpdateCache
       Get-WindowsUpdate
       Get-WindowsUpdateConfiguration
       Get-WindowsUpdateHistory
+      Hide-WindowsUpdate
+      Install-WindowsUpdate
       Reset-WindowsUpdateComponent
+      Save-WindowsUpdate
+      Show-WindowsUpdate
+      Uninstall-WindowsUpdate
 
   utils (4 functions)
     Pure utility functions that do not follow the standard


### PR DESCRIPTION
## Summary

- Synchronize all 14 documented domains with the 139 tracked public functions.
- Correct the Active Directory and Windows Update counts and add the six missing Windows Update entries.
- Add a Pester regression test for domain/function inventory drift.

Closes #102