### PR TITLE
docs(help): complete PSTypeName registry (#103)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,4 +9,5 @@
 ### Fixed
 
 - Synchronized the documented public-function inventories and counts in `about_PSWinOps.help.txt`.
+- Completed the `PSTypeName` registry in `about_PSWinOps.help.txt` and corrected its count to 119.
 - Added default format views for Windows Update result objects.

--- a/Tests/PSWinOps.psm1.Tests.ps1
+++ b/Tests/PSWinOps.psm1.Tests.ps1
@@ -323,5 +323,45 @@ Describe -Name 'PSWinOps Module Loader' -Fixture {
                 ($documentedFunctions -join "`n") | Should -Be ($actualFunctions -join "`n")
             }
         }
+
+        It -Name 'Should keep PSTypeName registry synchronized with sources and format views' -Test {
+            $sourceTypes = @(
+                Get-ChildItem -Path (Join-Path -Path $script:modulePath -ChildPath 'Public') -Filter '*.ps1' -Recurse -File |
+                    ForEach-Object {
+                        $source = Get-Content -Path $_.FullName -Raw
+                        [regex]::Matches(
+                            $source,
+                            'PSTypeName\s*=\s*[''"](?<Type>PSWinOps\.[A-Za-z0-9]+)'
+                        ) | ForEach-Object { $_.Groups['Type'].Value }
+                    } |
+                    Sort-Object -Unique
+            )
+            $aboutPath = Join-Path -Path $script:modulePath -ChildPath 'en-US/about_PSWinOps.help.txt'
+            $aboutContent = Get-Content -Path $aboutPath -Raw
+            $registrySection = [regex]::Match(
+                $aboutContent,
+                '(?ms)^PSWINOPS TYPE REGISTRY\r?\n(?<section>.*?)^SEE ALSO'
+            ).Groups['section'].Value
+            $documentedTypes = @(
+                [regex]::Matches(
+                    $registrySection,
+                    '(?m)^\s{6}(?<Type>PSWinOps\.[A-Za-z0-9]+)\s*$'
+                ) | ForEach-Object { $_.Groups['Type'].Value } |
+                    Sort-Object -Unique
+            )
+            $formatPath = Join-Path -Path $script:modulePath -ChildPath 'PSWinOps.Format.ps1xml'
+            $formatContent = Get-Content -Path $formatPath -Raw
+            $formatTypes = @(
+                [regex]::Matches(
+                    $formatContent,
+                    '(?<Type>PSWinOps\.[A-Za-z0-9]+)'
+                ) | ForEach-Object { $_.Groups['Type'].Value } |
+                    Sort-Object -Unique
+            )
+
+            $sourceTypes.Count | Should -Be 119
+            ($documentedTypes -join "`n") | Should -Be ($sourceTypes -join "`n")
+            ($formatTypes -join "`n") | Should -Be ($sourceTypes -join "`n")
+        }
     }
 }

--- a/en-US/about_PSWinOps.help.txt
+++ b/en-US/about_PSWinOps.help.txt
@@ -341,7 +341,7 @@ REMOTE EXECUTION PATTERN
     in the pipeline continue to be processed.
 
 PSWINOPS TYPE REGISTRY
-    The following 107 PSTypeName values are defined by the
+    The following 119 PSTypeName values are defined by the
     module. Each corresponds to the output of one or more
     public functions.
 
@@ -452,10 +452,16 @@ PSWINOPS TYPE REGISTRY
       PSWinOps.UnexpectedShutdown
       PSWinOps.UserProfileRemoval
       PSWinOps.WindowsUpdate
+      PSWinOps.WindowsUpdateCacheResult
       PSWinOps.WindowsUpdateConfiguration
+      PSWinOps.WindowsUpdateDownloadResult
       PSWinOps.WindowsUpdateFailure
+      PSWinOps.WindowsUpdateHideResult
       PSWinOps.WindowsUpdateHistory
+      PSWinOps.WindowsUpdateInstallResult
       PSWinOps.WindowsUpdateResetResult
+      PSWinOps.WindowsUpdateShowResult
+      PSWinOps.WindowsUpdateUninstallResult
       PSWinOps.WinRMTestResult
       PSWinOps.WSUSHealth
 


### PR DESCRIPTION
## Summary
- document all 119 structured PSTypeName values in the conceptual help registry
- add a regression test comparing source, help, and format inventories
- record the documentation correction in the changelog

## Validation
- Linux registry consistency check passed
- Pester not run: PowerShell is not installed and the module is Windows-only

Closes #103