### PR TITLE
fix(ci): exclude integration tests from publish workflow (#106)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -80,6 +80,7 @@ jobs:
           $config.TestResult.Enabled      = $true
           $config.TestResult.OutputPath   = 'TestResults.xml'
           $config.TestResult.OutputFormat = 'NUnitXml'
+          $config.Filter.ExcludeTag       = @('Integration')
 
           $result = Invoke-Pester -Configuration $config
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Synchronized the documented public-function inventories and counts in `about_PSWinOps.help.txt`.
 - Completed the `PSTypeName` registry in `about_PSWinOps.help.txt` and corrected its count to 119.
 - Added default format views for Windows Update result objects.
+- Excluded `Integration`-tagged tests from the release publication workflow.
 
 ## 0.12.0 - 2026-09-04 UTC
 ### Added


### PR DESCRIPTION
## Summary
- Exclude Pester tests tagged `Integration` from the release publication workflow.
- Keep the release validation behavior aligned with the main CI workflow.
- Document the fix in the unreleased changelog.

## Validation
- YAML syntax validation passed.
- git diff --check passed.
- Windows PowerShell/Pester tests not run locally because this repository is Windows-only.

Closes #106