### PR TITLE
refactor(contract): standardize action results (#108)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Completed the `PSTypeName` registry in `about_PSWinOps.help.txt` and corrected its count to 119.
 - Added default format views for Windows Update result objects.
 - Excluded `Integration`-tagged tests from the release publication workflow.
+- Standardized action-function output with typed `PSWinOps.ActionResult` objects for status, target, errors, and timestamps.
 
 ## 0.12.0 - 2026-09-04 UTC
 ### Added

--- a/PSWinOps.Format.ps1xml
+++ b/PSWinOps.Format.ps1xml
@@ -8955,5 +8955,64 @@
         </TableRowEntries>
       </TableControl>
     </View>
+    <!-- ============================================================ -->
+    <!-- PSWinOps.ActionResult                                         -->
+    <!-- Used by: Clear-Arp, Edit-HostsFile, Remove-NetworkRoute,     -->
+    <!--          Set-NTPClient, Set-ProxyConfiguration,               -->
+    <!--          Remove-ProxyConfiguration                             -->
+    <!-- ============================================================ -->
+    <View>
+      <Name>PSWinOps.ActionResult</Name>
+      <ViewSelectedBy>
+        <TypeName>PSWinOps.ActionResult</TypeName>
+      </ViewSelectedBy>
+      <TableControl>
+        <AutoSize />
+        <TableHeaders>
+          <TableColumnHeader>
+            <Label>ComputerName</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Action</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Target</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Status</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Error</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Timestamp</Label>
+          </TableColumnHeader>
+        </TableHeaders>
+        <TableRowEntries>
+          <TableRowEntry>
+            <TableColumnItems>
+              <TableColumnItem>
+                <PropertyName>ComputerName</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>Action</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>Target</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>Status</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>Error</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>Timestamp</PropertyName>
+              </TableColumnItem>
+            </TableColumnItems>
+          </TableRowEntry>
+        </TableRowEntries>
+      </TableControl>
+    </View>
   </ViewDefinitions>
 </Configuration>

--- a/Private/ConvertTo-ActionResult.ps1
+++ b/Private/ConvertTo-ActionResult.ps1
@@ -1,0 +1,36 @@
+#Requires -Version 5.1
+
+function ConvertTo-ActionResult {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Action,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Target,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('Succeeded', 'Failed', 'WhatIf')]
+        [string]$Status,
+
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        [string]$ErrorMessage,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateNotNullOrEmpty()]
+        [string]$ComputerName = $env:COMPUTERNAME
+    )
+
+    [PSCustomObject]@{
+        PSTypeName   = 'PSWinOps.ActionResult'
+        ComputerName = $ComputerName
+        Action       = $Action
+        Target       = $Target
+        Status       = $Status
+        Error        = $ErrorMessage
+        Timestamp    = Get-Date -Format 'o'
+    }
+}

--- a/Public/network/Clear-Arp.ps1
+++ b/Public/network/Clear-Arp.ps1
@@ -27,8 +27,8 @@ function Clear-Arp {
             Clears the ARP cache with verbose output showing execution details.
 
         .OUTPUTS
-            None
-            This function does not produce pipeline output.
+            PSWinOps.ActionResult
+            Returns the action status, target, error details, and timestamp.
 
         .NOTES
             Author: Franck SALLET
@@ -44,7 +44,7 @@ function Clear-Arp {
             https://learn.microsoft.com/en-us/windows-server/networking/technologies/netsh/netsh-interface-ip
     #>
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Medium')]
-    [OutputType([void])]
+    [OutputType('PSWinOps.ActionResult')]
     param()
 
     begin {
@@ -75,20 +75,30 @@ function Clear-Arp {
     }
 
     process {
-        if ($PSCmdlet.ShouldProcess('Local ARP cache', 'Delete all entries')) {
-            try {
-                Write-Verbose "[$($MyInvocation.MyCommand)] Running: netsh interface ip delete arpcache"
-                $result = Invoke-NativeCommand -FilePath $netshPath -ArgumentList @('interface', 'ip', 'delete', 'arpcache')
+        $target = 'Local ARP cache'
 
-                if ($result.ExitCode -ne 0) {
-                    Write-Error "[$($MyInvocation.MyCommand)] netsh interface ip delete arpcache failed (exit code $($result.ExitCode)): $($result.Output)"
-                } else {
-                    Write-Verbose "[$($MyInvocation.MyCommand)] ARP cache cleared successfully"
-                    Write-Information -MessageData '[OK] ARP cache cleared successfully'
-                }
-            } catch {
-                Write-Error "[$($MyInvocation.MyCommand)] Failed to clear ARP cache: $_"
+        if (-not $PSCmdlet.ShouldProcess($target, 'Delete all entries')) {
+            ConvertTo-ActionResult -Action $MyInvocation.MyCommand -Target $target -Status 'WhatIf'
+            return
+        }
+
+        try {
+            Write-Verbose "[$($MyInvocation.MyCommand)] Running: netsh interface ip delete arpcache"
+            $result = Invoke-NativeCommand -FilePath $netshPath -ArgumentList @('interface', 'ip', 'delete', 'arpcache')
+
+            if ($result.ExitCode -ne 0) {
+                $errorMessage = "[$($MyInvocation.MyCommand)] netsh interface ip delete arpcache failed (exit code $($result.ExitCode)): $($result.Output)"
+                Write-Error $errorMessage
+                ConvertTo-ActionResult -Action $MyInvocation.MyCommand -Target $target -Status 'Failed' -ErrorMessage $errorMessage
+            } else {
+                Write-Verbose "[$($MyInvocation.MyCommand)] ARP cache cleared successfully"
+                Write-Information -MessageData '[OK] ARP cache cleared successfully'
+                ConvertTo-ActionResult -Action $MyInvocation.MyCommand -Target $target -Status 'Succeeded'
             }
+        } catch {
+            $errorMessage = "[$($MyInvocation.MyCommand)] Failed to clear ARP cache: $_"
+            Write-Error $errorMessage
+            ConvertTo-ActionResult -Action $MyInvocation.MyCommand -Target $target -Status 'Failed' -ErrorMessage $errorMessage
         }
     }
 

--- a/Public/network/Edit-HostsFile.ps1
+++ b/Public/network/Edit-HostsFile.ps1
@@ -32,8 +32,8 @@ function Edit-HostsFile {
             Opens the hosts file in VS Code as Administrator.
 
         .OUTPUTS
-            None
-            This function does not produce pipeline output.
+            PSWinOps.ActionResult
+            Returns the action status, target, error details, and timestamp.
 
         .NOTES
             Author:        Franck SALLET
@@ -46,7 +46,7 @@ function Edit-HostsFile {
             https://github.com/k9fr4n/PSWinOps
     #>
     [CmdletBinding(SupportsShouldProcess)]
-    [OutputType([void])]
+    [OutputType('PSWinOps.ActionResult')]
     param(
         [Parameter(Mandatory = $false)]
         [ValidateNotNullOrEmpty()]
@@ -69,15 +69,20 @@ function Edit-HostsFile {
             )
         }
 
-        if (-not $PSCmdlet.ShouldProcess($hostsPath, "Open with '$Editor' as Administrator")) {
+        $target = $hostsPath
+        if (-not $PSCmdlet.ShouldProcess($target, "Open with '$Editor' as Administrator")) {
+            ConvertTo-ActionResult -Action $MyInvocation.MyCommand -Target $target -Status 'WhatIf'
             return
         }
 
         try {
             Write-Verbose "[$($MyInvocation.MyCommand)] Opening '$hostsPath' with '$Editor' as Administrator"
             Start-Process -FilePath $Editor -ArgumentList $hostsPath -Verb RunAs -ErrorAction Stop
+            ConvertTo-ActionResult -Action $MyInvocation.MyCommand -Target $target -Status 'Succeeded'
         } catch {
-            Write-Error "[$($MyInvocation.MyCommand)] Failed to open hosts file: $_"
+            $errorMessage = "[$($MyInvocation.MyCommand)] Failed to open hosts file: $_"
+            Write-Error $errorMessage
+            ConvertTo-ActionResult -Action $MyInvocation.MyCommand -Target $target -Status 'Failed' -ErrorMessage $errorMessage
         }
     }
 }

--- a/Public/network/Remove-NetworkRoute.ps1
+++ b/Public/network/Remove-NetworkRoute.ps1
@@ -52,8 +52,8 @@ function Remove-NetworkRoute {
             Removes the route on two remote servers via pipeline.
 
         .OUTPUTS
-            None
-            This function does not produce pipeline output.
+            PSWinOps.ActionResult
+            Returns one action result per target computer.
 
         .NOTES
             Author:        Franck SALLET
@@ -70,7 +70,7 @@ function Remove-NetworkRoute {
             https://learn.microsoft.com/en-us/powershell/module/nettcpip/remove-netroute
     #>
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
-    [OutputType([void])]
+    [OutputType('PSWinOps.ActionResult')]
     param(
         [Parameter(Mandatory = $false,
             ValueFromPipeline = $true,
@@ -132,12 +132,13 @@ function Remove-NetworkRoute {
 
     process {
         foreach ($targetComputer in $ComputerName) {
-            try {
-                $shouldProcessTarget = "Route $DestinationPrefix on '$targetComputer'"
+            $shouldProcessTarget = "Route $DestinationPrefix on '$targetComputer'"
 
+            try {
                 Write-Verbose "[$($MyInvocation.MyCommand)] Removing route on '$targetComputer'"
 
                 if (-not $PSCmdlet.ShouldProcess($shouldProcessTarget, 'Remove network route')) {
+                    ConvertTo-ActionResult -ComputerName $targetComputer -Action $MyInvocation.MyCommand -Target $shouldProcessTarget -Status 'WhatIf'
                     continue
                 }
 
@@ -163,8 +164,11 @@ function Remove-NetworkRoute {
                 $null = Invoke-RemoteOrLocal -ComputerName $targetComputer -ScriptBlock $queryScriptBlock -ArgumentList $queryArgs -Credential $Credential
 
                 Write-Verbose "[$($MyInvocation.MyCommand)] Route '$DestinationPrefix' removed successfully on '$targetComputer'"
+                ConvertTo-ActionResult -ComputerName $targetComputer -Action $MyInvocation.MyCommand -Target $shouldProcessTarget -Status 'Succeeded'
             } catch {
-                Write-Error "[$($MyInvocation.MyCommand)] Failed on '$targetComputer': $_"
+                $errorMessage = "[$($MyInvocation.MyCommand)] Failed on '$targetComputer': $_"
+                Write-Error $errorMessage
+                ConvertTo-ActionResult -ComputerName $targetComputer -Action $MyInvocation.MyCommand -Target $shouldProcessTarget -Status 'Failed' -ErrorMessage $errorMessage
             }
         }
     }

--- a/Public/ntp/Set-NTPClient.ps1
+++ b/Public/ntp/Set-NTPClient.ps1
@@ -48,8 +48,8 @@ function Set-NTPClient {
             Shows what would happen if the configuration were applied with custom poll intervals.
 
         .OUTPUTS
-            None
-            This function does not produce pipeline output.
+            PSWinOps.ActionResult
+            Returns the NTP configuration action status and any error details.
 
         .NOTES
             Author: Franck SALLET
@@ -65,7 +65,7 @@ function Set-NTPClient {
             https://learn.microsoft.com/en-us/windows-server/networking/windows-time-service/windows-time-service-tools-and-settings
     #>
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
-    [OutputType([void])]
+    [OutputType('PSWinOps.ActionResult')]
     param (
         [Parameter(Mandatory = $true, Position = 0)]
         [ValidateNotNullOrEmpty()]
@@ -128,7 +128,10 @@ function Set-NTPClient {
     }
 
     process {
-        if (-not $PSCmdlet.ShouldProcess('Windows Time Service (W32Time)', 'Configure NTP synchronization')) {
+        $target = 'Windows Time Service (W32Time)'
+
+        if (-not $PSCmdlet.ShouldProcess($target, 'Configure NTP synchronization')) {
+            ConvertTo-ActionResult -Action $MyInvocation.MyCommand -Target $target -Status 'WhatIf'
             return
         }
 
@@ -253,14 +256,27 @@ function Set-NTPClient {
             }
 
             Write-Information -MessageData '[OK] Windows Time Service configuration completed successfully'
+            $actionStatus = if ($isSyncSuccessful) { 'Succeeded' } else { 'Failed' }
+            $actionError = if ($isSyncSuccessful) {
+                $null
+            } else {
+                "Time synchronization failed (exit code $syncExitCode): $($syncResult.Output)"
+            }
+            ConvertTo-ActionResult -Action $MyInvocation.MyCommand -Target $target -Status $actionStatus -ErrorMessage $actionError
         } catch [System.UnauthorizedAccessException] {
-            Write-Error "[$($MyInvocation.MyCommand)] Access denied - Administrator privileges required: $_"
+            $errorMessage = "[$($MyInvocation.MyCommand)] Access denied - Administrator privileges required: $_"
+            Write-Error $errorMessage
+            ConvertTo-ActionResult -Action $MyInvocation.MyCommand -Target $target -Status 'Failed' -ErrorMessage $errorMessage
             throw
         } catch [System.InvalidOperationException] {
-            Write-Error "[$($MyInvocation.MyCommand)] Service operation failed: $_"
+            $errorMessage = "[$($MyInvocation.MyCommand)] Service operation failed: $_"
+            Write-Error $errorMessage
+            ConvertTo-ActionResult -Action $MyInvocation.MyCommand -Target $target -Status 'Failed' -ErrorMessage $errorMessage
             throw
         } catch {
-            Write-Error "[$($MyInvocation.MyCommand)] Unexpected error during NTP configuration: $_"
+            $errorMessage = "[$($MyInvocation.MyCommand)] Unexpected error during NTP configuration: $_"
+            Write-Error $errorMessage
+            ConvertTo-ActionResult -Action $MyInvocation.MyCommand -Target $target -Status 'Failed' -ErrorMessage $errorMessage
             throw
         }
     }

--- a/Public/proxy/Remove-ProxyConfiguration.ps1
+++ b/Public/proxy/Remove-ProxyConfiguration.ps1
@@ -41,8 +41,8 @@ function Remove-ProxyConfiguration {
             Clears proxy environment variables without confirmation prompt.
 
         .OUTPUTS
-            None
-            This function does not produce pipeline output.
+            PSWinOps.ActionResult
+            Returns one action result per targeted proxy scope.
 
         .NOTES
             Author: Franck SALLET
@@ -61,7 +61,7 @@ function Remove-ProxyConfiguration {
             https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/netsh-winhttp
     #>
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Medium')]
-    [OutputType([void])]
+    [OutputType('PSWinOps.ActionResult')]
     param (
         [Parameter(Mandatory = $false)]
         [ValidateSet('WinINET', 'WinHTTP', 'Environment', 'All')]
@@ -85,6 +85,7 @@ function Remove-ProxyConfiguration {
         # -- WinINET (HKCU Internet Settings) --
         if ($resolvedScopes -contains 'WinINET') {
             $winInetPath = 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Internet Settings'
+            $target = 'WinINET'
 
             if ($PSCmdlet.ShouldProcess('WinINET (Internet Settings registry)', 'Remove proxy configuration')) {
                 try {
@@ -98,14 +99,20 @@ function Remove-ProxyConfiguration {
                     }
 
                     Write-Information -MessageData '[OK] WinINET proxy configuration removed'
+                    ConvertTo-ActionResult -Action $MyInvocation.MyCommand -Target $target -Status 'Succeeded'
                 } catch {
-                    Write-Error "[$($MyInvocation.MyCommand)] Failed to remove WinINET proxy configuration: $_"
+                    $errorMessage = "[$($MyInvocation.MyCommand)] Failed to remove WinINET proxy configuration: $_"
+                    Write-Error $errorMessage
+                    ConvertTo-ActionResult -Action $MyInvocation.MyCommand -Target $target -Status 'Failed' -ErrorMessage $errorMessage
                 }
+            } else {
+                ConvertTo-ActionResult -Action $MyInvocation.MyCommand -Target $target -Status 'WhatIf'
             }
         }
 
         # -- WinHTTP (netsh winhttp) --
         if ($resolvedScopes -contains 'WinHTTP') {
+            $target = 'WinHTTP'
             if ($PSCmdlet.ShouldProcess('WinHTTP (netsh winhttp)', 'Reset proxy to direct access')) {
                 try {
                     if (-not (Test-IsAdministrator)) {
@@ -125,18 +132,26 @@ function Remove-ProxyConfiguration {
 
                     if ($netshExitCode -ne 0) {
                         $outputText = $netshResult.Output
-                        Write-Error "[$($MyInvocation.MyCommand)] netsh winhttp reset proxy failed (exit code $netshExitCode): $outputText"
+                        $errorMessage = "[$($MyInvocation.MyCommand)] netsh winhttp reset proxy failed (exit code $netshExitCode): $outputText"
+                        Write-Error $errorMessage
+                        ConvertTo-ActionResult -Action $MyInvocation.MyCommand -Target $target -Status 'Failed' -ErrorMessage $errorMessage
                     } else {
                         Write-Information -MessageData '[OK] WinHTTP proxy configuration reset to direct access'
+                        ConvertTo-ActionResult -Action $MyInvocation.MyCommand -Target $target -Status 'Succeeded'
                     }
                 } catch {
-                    Write-Error "[$($MyInvocation.MyCommand)] Failed to reset WinHTTP proxy: $_"
+                    $errorMessage = "[$($MyInvocation.MyCommand)] Failed to reset WinHTTP proxy: $_"
+                    Write-Error $errorMessage
+                    ConvertTo-ActionResult -Action $MyInvocation.MyCommand -Target $target -Status 'Failed' -ErrorMessage $errorMessage
                 }
+            } else {
+                ConvertTo-ActionResult -Action $MyInvocation.MyCommand -Target $target -Status 'WhatIf'
             }
         }
 
         # -- Environment variables --
         if ($resolvedScopes -contains 'Environment') {
+            $target = 'Environment'
             if ($PSCmdlet.ShouldProcess('Environment variables (HTTP_PROXY, HTTPS_PROXY, NO_PROXY)', 'Remove proxy configuration')) {
                 try {
                     Write-Verbose "[$($MyInvocation.MyCommand)] Clearing proxy environment variables"
@@ -157,9 +172,14 @@ function Remove-ProxyConfiguration {
                     }
 
                     Write-Information -MessageData '[OK] Proxy environment variables cleared'
+                    ConvertTo-ActionResult -Action $MyInvocation.MyCommand -Target $target -Status 'Succeeded'
                 } catch {
-                    Write-Error "[$($MyInvocation.MyCommand)] Failed to clear proxy environment variables: $_"
+                    $errorMessage = "[$($MyInvocation.MyCommand)] Failed to clear proxy environment variables: $_"
+                    Write-Error $errorMessage
+                    ConvertTo-ActionResult -Action $MyInvocation.MyCommand -Target $target -Status 'Failed' -ErrorMessage $errorMessage
                 }
+            } else {
+                ConvertTo-ActionResult -Action $MyInvocation.MyCommand -Target $target -Status 'WhatIf'
             }
         }
     }

--- a/Public/proxy/Set-ProxyConfiguration.ps1
+++ b/Public/proxy/Set-ProxyConfiguration.ps1
@@ -55,8 +55,8 @@ function Set-ProxyConfiguration {
             Configures WinINET to use a PAC auto-configuration URL (no static proxy).
 
         .OUTPUTS
-            None
-            This function does not produce pipeline output.
+            PSWinOps.ActionResult
+            Returns one action result per targeted proxy scope.
 
         .NOTES
             Author: Franck SALLET
@@ -81,7 +81,7 @@ function Set-ProxyConfiguration {
             https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/netsh-winhttp
     #>
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Medium')]
-    [OutputType([void])]
+    [OutputType('PSWinOps.ActionResult')]
     param (
         [Parameter(Mandatory = $false)]
         [ValidateNotNullOrEmpty()]
@@ -130,6 +130,7 @@ function Set-ProxyConfiguration {
         # -- WinINET (HKCU Internet Settings) --
         if ($resolvedScopes -contains 'WinINET') {
             $winInetPath = 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Internet Settings'
+            $target = 'WinINET'
 
             if ($PSCmdlet.ShouldProcess('WinINET (Internet Settings registry)', 'Set proxy configuration')) {
                 try {
@@ -152,93 +153,112 @@ function Set-ProxyConfiguration {
                     }
 
                     Write-Information -MessageData '[OK] WinINET proxy configured successfully'
+                    ConvertTo-ActionResult -Action $MyInvocation.MyCommand -Target $target -Status 'Succeeded'
                 } catch {
-                    Write-Error "[$($MyInvocation.MyCommand)] Failed to configure WinINET proxy: $_"
+                    $errorMessage = "[$($MyInvocation.MyCommand)] Failed to configure WinINET proxy: $_"
+                    Write-Error $errorMessage
+                    ConvertTo-ActionResult -Action $MyInvocation.MyCommand -Target $target -Status 'Failed' -ErrorMessage $errorMessage
                 }
+            } else {
+                ConvertTo-ActionResult -Action $MyInvocation.MyCommand -Target $target -Status 'WhatIf'
             }
         }
 
         # -- WinHTTP (netsh winhttp) --
         if ($resolvedScopes -contains 'WinHTTP') {
+            $target = 'WinHTTP'
             if (-not $ProxyServer) {
-                Write-Warning "[$($MyInvocation.MyCommand)] WinHTTP scope requires -ProxyServer. Skipping WinHTTP configuration."
-            } else {
-                if ($PSCmdlet.ShouldProcess('WinHTTP (netsh winhttp)', 'Set proxy configuration')) {
-                    try {
-                        if (-not (Test-IsAdministrator)) {
-                            throw [System.UnauthorizedAccessException]::new('WinHTTP scope requires Administrator privileges.')
-                        }
-
-                        Write-Verbose "[$($MyInvocation.MyCommand)] Configuring WinHTTP proxy settings"
-
-                        $netshPath = Join-Path -Path $env:SystemRoot -ChildPath 'System32\netsh.exe'
-                        if (-not (Test-Path -Path $netshPath -PathType Leaf)) {
-                            throw "netsh.exe not found at '$netshPath'"
-                        }
-
-                        $netshArgs = @('winhttp', 'set', 'proxy', "proxy-server=$ProxyServer")
-                        if ($BypassList) {
-                            $netshArgs += "bypass-list=$BypassList"
-                        }
-
-                        Write-Verbose "[$($MyInvocation.MyCommand)] Running: netsh $($netshArgs -join ' ')"
-                        $netshResult = Invoke-NativeCommand -FilePath $netshPath -ArgumentList $netshArgs
-                        $netshExitCode = $netshResult.ExitCode
-
-                        if ($netshExitCode -ne 0) {
-                            $outputText = $netshResult.Output
-                            Write-Error "[$($MyInvocation.MyCommand)] netsh winhttp set proxy failed (exit code $netshExitCode): $outputText"
-                        } else {
-                            Write-Information -MessageData '[OK] WinHTTP proxy configured successfully'
-                        }
-                    } catch {
-                        Write-Error "[$($MyInvocation.MyCommand)] Failed to configure WinHTTP proxy: $_"
+                $errorMessage = "[$($MyInvocation.MyCommand)] WinHTTP scope requires -ProxyServer. Skipping WinHTTP configuration."
+                Write-Warning $errorMessage
+                ConvertTo-ActionResult -Action $MyInvocation.MyCommand -Target $target -Status 'Failed' -ErrorMessage $errorMessage
+            } elseif ($PSCmdlet.ShouldProcess('WinHTTP (netsh winhttp)', 'Set proxy configuration')) {
+                try {
+                    if (-not (Test-IsAdministrator)) {
+                        throw [System.UnauthorizedAccessException]::new('WinHTTP scope requires Administrator privileges.')
                     }
+
+                    Write-Verbose "[$($MyInvocation.MyCommand)] Configuring WinHTTP proxy settings"
+
+                    $netshPath = Join-Path -Path $env:SystemRoot -ChildPath 'System32\netsh.exe'
+                    if (-not (Test-Path -Path $netshPath -PathType Leaf)) {
+                        throw "netsh.exe not found at '$netshPath'"
+                    }
+
+                    $netshArgs = @('winhttp', 'set', 'proxy', "proxy-server=$ProxyServer")
+                    if ($BypassList) {
+                        $netshArgs += "bypass-list=$BypassList"
+                    }
+
+                    Write-Verbose "[$($MyInvocation.MyCommand)] Running: netsh $($netshArgs -join ' ')"
+                    $netshResult = Invoke-NativeCommand -FilePath $netshPath -ArgumentList $netshArgs
+                    $netshExitCode = $netshResult.ExitCode
+
+                    if ($netshExitCode -ne 0) {
+                        $outputText = $netshResult.Output
+                        $errorMessage = "[$($MyInvocation.MyCommand)] netsh winhttp set proxy failed (exit code $netshExitCode): $outputText"
+                        Write-Error $errorMessage
+                        ConvertTo-ActionResult -Action $MyInvocation.MyCommand -Target $target -Status 'Failed' -ErrorMessage $errorMessage
+                    } else {
+                        Write-Information -MessageData '[OK] WinHTTP proxy configured successfully'
+                        ConvertTo-ActionResult -Action $MyInvocation.MyCommand -Target $target -Status 'Succeeded'
+                    }
+                } catch {
+                    $errorMessage = "[$($MyInvocation.MyCommand)] Failed to configure WinHTTP proxy: $_"
+                    Write-Error $errorMessage
+                    ConvertTo-ActionResult -Action $MyInvocation.MyCommand -Target $target -Status 'Failed' -ErrorMessage $errorMessage
                 }
+            } else {
+                ConvertTo-ActionResult -Action $MyInvocation.MyCommand -Target $target -Status 'WhatIf'
             }
         }
 
         # -- Environment variables --
         if ($resolvedScopes -contains 'Environment') {
+            $target = 'Environment'
             if (-not $ProxyServer) {
-                Write-Warning "[$($MyInvocation.MyCommand)] Environment scope requires -ProxyServer. Skipping environment configuration."
-            } else {
-                if ($PSCmdlet.ShouldProcess('Environment variables (HTTP_PROXY, HTTPS_PROXY, NO_PROXY)', 'Set proxy configuration')) {
-                    try {
-                        Write-Verbose "[$($MyInvocation.MyCommand)] Configuring proxy environment variables"
+                $errorMessage = "[$($MyInvocation.MyCommand)] Environment scope requires -ProxyServer. Skipping environment configuration."
+                Write-Warning $errorMessage
+                ConvertTo-ActionResult -Action $MyInvocation.MyCommand -Target $target -Status 'Failed' -ErrorMessage $errorMessage
+            } elseif ($PSCmdlet.ShouldProcess('Environment variables (HTTP_PROXY, HTTPS_PROXY, NO_PROXY)', 'Set proxy configuration')) {
+                try {
+                    Write-Verbose "[$($MyInvocation.MyCommand)] Configuring proxy environment variables"
 
-                        # Build proxy URL (add http:// scheme if not present)
-                        $proxyUrl = if ($ProxyServer -match '^https?://') { $ProxyServer } else { "http://$ProxyServer" }
+                    # Build proxy URL (add http:// scheme if not present)
+                    $proxyUrl = if ($ProxyServer -match '^https?://') { $ProxyServer } else { "http://$ProxyServer" }
 
-                        # Set Process-level (immediate effect)
-                        $env:HTTP_PROXY  = $proxyUrl
-                        $env:HTTPS_PROXY = $proxyUrl
-                        Write-Verbose "[$($MyInvocation.MyCommand)] HTTP_PROXY and HTTPS_PROXY set to: $proxyUrl"
+                    # Set Process-level (immediate effect)
+                    $env:HTTP_PROXY  = $proxyUrl
+                    $env:HTTPS_PROXY = $proxyUrl
+                    Write-Verbose "[$($MyInvocation.MyCommand)] HTTP_PROXY and HTTPS_PROXY set to: $proxyUrl"
 
-                        if ($BypassList) {
-                            # Convert semicolon-separated WinINET format to comma-separated NO_PROXY format
-                            $noProxy = ($BypassList -replace '<local>', 'localhost' -replace ';', ',').Trim()
-                            $env:NO_PROXY = $noProxy
-                            Write-Verbose "[$($MyInvocation.MyCommand)] NO_PROXY set to: $noProxy"
-                        }
-
-                        # Set User-level (persistent across sessions)
-                        try {
-                            [System.Environment]::SetEnvironmentVariable('HTTP_PROXY', $proxyUrl, [System.EnvironmentVariableTarget]::User)
-                            [System.Environment]::SetEnvironmentVariable('HTTPS_PROXY', $proxyUrl, [System.EnvironmentVariableTarget]::User)
-                            if ($BypassList) {
-                                [System.Environment]::SetEnvironmentVariable('NO_PROXY', $noProxy, [System.EnvironmentVariableTarget]::User)
-                            }
-                            Write-Verbose "[$($MyInvocation.MyCommand)] User-level environment variables persisted"
-                        } catch {
-                            Write-Warning "[$($MyInvocation.MyCommand)] Failed to persist User-level environment variables: $_. Process-level variables were set successfully."
-                        }
-
-                        Write-Information -MessageData '[OK] Proxy environment variables configured successfully'
-                    } catch {
-                        Write-Error "[$($MyInvocation.MyCommand)] Failed to configure proxy environment variables: $_"
+                    if ($BypassList) {
+                        # Convert semicolon-separated WinINET format to comma-separated NO_PROXY format
+                        $noProxy = ($BypassList -replace '<local>', 'localhost' -replace ';', ',').Trim()
+                        $env:NO_PROXY = $noProxy
+                        Write-Verbose "[$($MyInvocation.MyCommand)] NO_PROXY set to: $noProxy"
                     }
+
+                    # Set User-level (persistent across sessions)
+                    try {
+                        [System.Environment]::SetEnvironmentVariable('HTTP_PROXY', $proxyUrl, [System.EnvironmentVariableTarget]::User)
+                        [System.Environment]::SetEnvironmentVariable('HTTPS_PROXY', $proxyUrl, [System.EnvironmentVariableTarget]::User)
+                        if ($BypassList) {
+                            [System.Environment]::SetEnvironmentVariable('NO_PROXY', $noProxy, [System.EnvironmentVariableTarget]::User)
+                        }
+                        Write-Verbose "[$($MyInvocation.MyCommand)] User-level environment variables persisted"
+                    } catch {
+                        Write-Warning "[$($MyInvocation.MyCommand)] Failed to persist User-level environment variables: $_. Process-level variables were set successfully."
+                    }
+
+                    Write-Information -MessageData '[OK] Proxy environment variables configured successfully'
+                    ConvertTo-ActionResult -Action $MyInvocation.MyCommand -Target $target -Status 'Succeeded'
+                } catch {
+                    $errorMessage = "[$($MyInvocation.MyCommand)] Failed to configure proxy environment variables: $_"
+                    Write-Error $errorMessage
+                    ConvertTo-ActionResult -Action $MyInvocation.MyCommand -Target $target -Status 'Failed' -ErrorMessage $errorMessage
                 }
+            } else {
+                ConvertTo-ActionResult -Action $MyInvocation.MyCommand -Target $target -Status 'WhatIf'
             }
         }
     }

--- a/Tests/Public/network/Clear-Arp.Tests.ps1
+++ b/Tests/Public/network/Clear-Arp.Tests.ps1
@@ -33,9 +33,9 @@ Describe 'Clear-Arp' {
             $mandatoryParams | Should -BeNullOrEmpty
         }
 
-        It 'Should have OutputType of void' {
+        It 'Should have OutputType of ActionResult' {
             $cmd = Get-Command -Name 'Clear-Arp'
-            $cmd.OutputType.Type | Should -Contain ([void])
+            $cmd.OutputType.Name | Should -Contain 'PSWinOps.ActionResult'
         }
     }
 
@@ -105,9 +105,11 @@ Describe 'Clear-Arp' {
             { Clear-Arp -Confirm:$false -ErrorAction SilentlyContinue } | Should -Not -Throw
         }
 
-        It 'Should return void (no output object)' {
+        It 'Should return a successful ActionResult' {
             $result = Clear-Arp -Confirm:$false 6>&1 | Where-Object { $_ -isnot [System.Management.Automation.InformationRecord] }
-            $result | Should -BeNullOrEmpty
+            $result.PSTypeNames | Should -Contain 'PSWinOps.ActionResult'
+            $result.Status | Should -Be 'Succeeded'
+            $result.Error | Should -BeNullOrEmpty
         }
 
         It 'Should call Invoke-NativeCommand with netsh arguments' {

--- a/Tests/Public/network/Edit-HostsFile.Tests.ps1
+++ b/Tests/Public/network/Edit-HostsFile.Tests.ps1
@@ -17,9 +17,9 @@ Describe 'Edit-HostsFile' {
             $meta.SupportsShouldProcess | Should -BeTrue
         }
 
-        It 'Should have OutputType void' {
+        It 'Should have OutputType ActionResult' {
             $cmd = Get-Command -Name 'Edit-HostsFile'
-            $cmd.OutputType.Type | Should -Contain ([void])
+            $cmd.OutputType.Name | Should -Contain 'PSWinOps.ActionResult'
         }
 
         It 'Should have Editor parameter with default notepad.exe' {
@@ -59,6 +59,13 @@ Describe 'Edit-HostsFile' {
             Should -Invoke -CommandName 'Start-Process' -ModuleName $script:ModuleName -Times 1 -Exactly -ParameterFilter {
                 $ArgumentList -like '*drivers*etc*hosts'
             }
+        }
+
+        It 'Should return a successful ActionResult' {
+            $result = Edit-HostsFile -Confirm:$false
+            $result.PSTypeNames | Should -Contain 'PSWinOps.ActionResult'
+            $result.Status | Should -Be 'Succeeded'
+            $result.Target | Should -Match 'drivers.*etc.*hosts'
         }
     }
 

--- a/Tests/Public/network/Remove-NetworkRoute.Tests.ps1
+++ b/Tests/Public/network/Remove-NetworkRoute.Tests.ps1
@@ -22,9 +22,9 @@ Describe 'Remove-NetworkRoute' {
             $meta.ConfirmImpact | Should -Be 'High'
         }
 
-        It 'Should have OutputType void' {
+        It 'Should have OutputType ActionResult' {
             $cmd = Get-Command -Name 'Remove-NetworkRoute'
-            $cmd.OutputType.Type | Should -Contain ([void])
+            $cmd.OutputType.Name | Should -Contain 'PSWinOps.ActionResult'
         }
 
         It 'Should require DestinationPrefix parameter' {
@@ -53,9 +53,11 @@ Describe 'Remove-NetworkRoute' {
             Should -Invoke -CommandName 'Remove-NetRoute' -ModuleName $script:ModuleName -Times 1 -Exactly
         }
 
-        It 'Should not produce pipeline output' {
+        It 'Should produce a successful ActionResult' {
             $result = Remove-NetworkRoute -DestinationPrefix '10.10.0.0/16' -InterfaceAlias 'Ethernet' -Confirm:$false
-            $result | Should -BeNullOrEmpty
+            $result.PSTypeNames | Should -Contain 'PSWinOps.ActionResult'
+            $result.Status | Should -Be 'Succeeded'
+            $result.ComputerName | Should -Be $env:COMPUTERNAME
         }
 
         It 'Should respect -WhatIf and not call Remove-NetRoute' {

--- a/Tests/Public/ntp/Set-NTPClient.Tests.ps1
+++ b/Tests/Public/ntp/Set-NTPClient.Tests.ps1
@@ -52,8 +52,11 @@ Describe -Name 'Set-NTPClient' -Fixture {
             Mock -CommandName 'Invoke-NativeCommand' -ModuleName 'PSWinOps' -MockWith { [PSCustomObject]@{ Output = ($script:mockSyncOutputEN -join "`r`n"); ExitCode = 0 } } -ParameterFilter { ($ArgumentList -join ' ') -match '/resync' }
         }
 
-        It -Name 'Should complete without throwing' -Test {
-            { Set-NTPClient -NtpServers 'ntp1.example.com', 'ntp2.example.com' -Confirm:$false } | Should -Not -Throw
+        It -Name 'Should return a successful ActionResult' -Test {
+            $result = Set-NTPClient -NtpServers 'ntp1.example.com', 'ntp2.example.com' -Confirm:$false
+            $result.PSTypeNames | Should -Contain 'PSWinOps.ActionResult'
+            $result.Status | Should -Be 'Succeeded'
+            $result.Target | Should -Be 'Windows Time Service (W32Time)'
         }
         It -Name 'Should call Set-ItemProperty for NtpServer registry key' -Test {
             Set-NTPClient -NtpServers 'ntp1.example.com' -Confirm:$false
@@ -279,8 +282,11 @@ Describe -Name 'Set-NTPClient' -Fixture {
             Mock -CommandName 'Invoke-NativeCommand' -ModuleName 'PSWinOps' -MockWith { [PSCustomObject]@{ Output = 'ntp1.example.com'; ExitCode = 0 } } -ParameterFilter { ($ArgumentList -join ' ') -match '/query.*source' }
         }
 
-        It -Name 'Should not throw when sync fails but should emit warnings' -Test {
-            { Set-NTPClient -NtpServers 'ntp1.example.com' -Confirm:$false } | Should -Not -Throw
+        It -Name 'Should return a failed ActionResult when sync fails' -Test {
+            $result = Set-NTPClient -NtpServers 'ntp1.example.com' -Confirm:$false
+            $result.PSTypeNames | Should -Contain 'PSWinOps.ActionResult'
+            $result.Status | Should -Be 'Failed'
+            $result.Error | Should -Match 'Time synchronization failed'
         }
     }
 

--- a/Tests/Public/proxy/Remove-ProxyConfiguration.Tests.ps1
+++ b/Tests/Public/proxy/Remove-ProxyConfiguration.Tests.ps1
@@ -308,9 +308,11 @@ Describe 'Remove-ProxyConfiguration' {
             Mock -ModuleName $script:ModuleName -CommandName 'Remove-ItemProperty' -MockWith {}
         }
 
-        It 'Should return void (no output object)' {
+        It 'Should return a successful ActionResult' {
             $result = Remove-ProxyConfiguration -Scope WinINET -Confirm:$false 6>&1 | Where-Object { $_ -isnot [System.Management.Automation.InformationRecord] }
-            $result | Should -BeNullOrEmpty
+            $result.PSTypeNames | Should -Contain 'PSWinOps.ActionResult'
+            $result.Status | Should -Be 'Succeeded'
+            $result.Target | Should -Be 'WinINET'
         }
     }
 

--- a/Tests/Public/proxy/Set-ProxyConfiguration.Tests.ps1
+++ b/Tests/Public/proxy/Set-ProxyConfiguration.Tests.ps1
@@ -257,9 +257,11 @@ Describe 'Set-ProxyConfiguration' {
             } -MockWith { 'C:\Windows\System32\netsh.exe' }
         }
 
-        It 'Should return void (no output object)' {
+        It 'Should return a successful ActionResult' {
             $result = Set-ProxyConfiguration -ProxyServer 'proxy.example.com:8080' -Scope WinINET -Confirm:$false 6>&1 | Where-Object { $_ -isnot [System.Management.Automation.InformationRecord] }
-            $result | Should -BeNullOrEmpty
+            $result.PSTypeNames | Should -Contain 'PSWinOps.ActionResult'
+            $result.Status | Should -Be 'Succeeded'
+            $result.Target | Should -Be 'WinINET'
         }
     }
 

--- a/en-US/about_PSWinOps.help.txt
+++ b/en-US/about_PSWinOps.help.txt
@@ -341,10 +341,11 @@ REMOTE EXECUTION PATTERN
     in the pipeline continue to be processed.
 
 PSWINOPS TYPE REGISTRY
-    The following 119 PSTypeName values are defined by the
+    The following 120 PSTypeName values are defined by the
     module. Each corresponds to the output of one or more
     public functions.
 
+      PSWinOps.ActionResult
       PSWinOps.ActiveRdpSession
       PSWinOps.ADAccountDisableResult
       PSWinOps.ADAccountEnableResult


### PR DESCRIPTION
## Summary
Standardize the six action functions on typed `PSWinOps.ActionResult` objects with status, target, timestamp, and error details.

The change also updates the format view, Pester coverage, help registry, and changelog.

Closes #108