### PR TITLE
feat(system): add Set-DisplayLanguage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -422,6 +422,7 @@ its `<View>` in `PSWinOps.Format.ps1xml`. This table is the reference list; keep
 | Get-StartupProgram | PSWinOps.StartupProgram | Table |
 | Get-SystemSummary | PSWinOps.SystemSummary | List |
 | Remove-UserProfile | PSWinOps.UserProfileRemoval | Table |
+| Set-DisplayLanguage | PSWinOps.DisplayLanguageResult | Table |
 | Set-EnvironmentVariable | PSWinOps.EnvironmentVariable | Table |
 | Set-PageFile | PSWinOps.PageFileConfiguration | List |
 | Stop-ProcessTree | PSWinOps.ProcessKillResult | Table |

--- a/PSWinOps.Format.ps1xml
+++ b/PSWinOps.Format.ps1xml
@@ -2617,6 +2617,64 @@
       </TableControl>
     </View>
     <!-- ============================================================ -->
+    <!-- PSWinOps.DisplayLanguageResult                               -->
+    <!-- Used by: Set-DisplayLanguage                                 -->
+    <!-- ============================================================ -->
+    <View>
+      <Name>PSWinOps.DisplayLanguageResult</Name>
+      <ViewSelectedBy>
+        <TypeName>PSWinOps.DisplayLanguageResult</TypeName>
+      </ViewSelectedBy>
+      <TableControl>
+        <AutoSize />
+        <TableHeaders>
+          <TableColumnHeader>
+            <Label>ComputerName</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Language</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>PackAction</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>AppliedToSystem</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>AppliedToNewUsers</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Status</Label>
+          </TableColumnHeader>
+        </TableHeaders>
+        <TableRowEntries>
+          <TableRowEntry>
+            <TableColumnItems>
+              <TableColumnItem>
+                <PropertyName>ComputerName</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>Language</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>PackAction</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>AppliedToSystem</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>AppliedToNewUsers</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>Status</PropertyName>
+              </TableColumnItem>
+            </TableColumnItems>
+          </TableRowEntry>
+        </TableRowEntries>
+      </TableControl>
+    </View>
+
+    <!-- ============================================================ -->
     <!-- PSWinOps.EnvironmentVariable                                 -->
     <!-- Used by: Get-EnvironmentVariable, Set-EnvironmentVariable    -->
     <!-- ============================================================ -->

--- a/PSWinOps.psd1
+++ b/PSWinOps.psd1
@@ -12,7 +12,7 @@
     RootModule           = 'PSWinOps.psm1'
 
     # Version number of this module.
-    ModuleVersion        = '1.2.0'
+    ModuleVersion        = '1.2.1'
 
     # Supported PSEditions
     # Core is supported on Windows only; the module-level guard in PSWinOps.psm1 blocks
@@ -198,6 +198,7 @@
         'Restore-ShadowCopyFile',
         'Save-WindowsUpdate',
         'Search-ADObject',
+        'Set-DisplayLanguage',
         'Set-EnvironmentVariable',
         'Set-IISCertificateBinding',
         'Set-NetworkRoute',
@@ -426,7 +427,12 @@
             # IconUri = ''
 
             # ReleaseNotes of this module
-            ReleaseNotes = '## 1.2.0 - 2026-09-09 UTC
+            ReleaseNotes = '## 1.2.1 - 2026-09-10 UTC
+
+### Added
+- New system domain function: Set-DisplayLanguage, changes the Windows UI display language for the current user (and optionally the system account / new user profiles) via Set-WinUILanguageOverride, installing the language pack automatically through LanguagePackManagement when missing.
+
+## 1.2.0 - 2026-09-09 UTC
 
 ### Changed
 - Breaking: renamed Set-IISBindingCertificate to Set-IISCertificateBinding and Test-IISBindingCertificate to Test-IISCertificateBinding for consistency with Get-IISCertificateBinding (#125). The PSWinOps.IISBindingCertificateResult PSTypeName is renamed to PSWinOps.IISCertificateBindingResult. Aliases sibc/tibc are renamed to sicb/ticb. No compatibility aliases are provided for the old function names.

--- a/Public/system/Set-DisplayLanguage.ps1
+++ b/Public/system/Set-DisplayLanguage.ps1
@@ -1,0 +1,235 @@
+#Requires -Version 5.1
+function Set-DisplayLanguage {
+    <#
+        .SYNOPSIS
+            Sets the Windows UI display language on local or remote computers
+
+        .DESCRIPTION
+            Changes the Windows UI display language for the current user via
+            Set-WinUILanguageOverride, installing the language pack automatically
+            through the LanguagePackManagement module when it is not already present.
+            Optionally propagates the settings to the system account (Welcome Screen)
+            and/or new user profiles via Copy-UserInternationalSettingsToSystem.
+            The LanguagePackManagement module ships built-in on Windows 11 22H2+ and
+            Windows Server 2022+; on earlier OS versions (e.g. Windows Server 2019) the
+            module is not available and the function fails with clear guidance instead
+            of the underlying "Get-InstalledLanguage is not recognized" error. A session
+            restart is required for changes to take effect.
+
+        .PARAMETER Language
+            The BCP-47 language tag to apply (e.g. 'en-US', 'fr-FR').
+            Must follow the format: two lowercase letters, a hyphen, two uppercase letters.
+
+        .PARAMETER NoInstall
+            Disables automatic installation of the language pack if it is not already
+            present. By default, the function installs the pack automatically when missing.
+
+        .PARAMETER ApplyToSystem
+            Copies the language settings to the system account (Welcome Screen / login
+            screen). Requires elevated privileges.
+
+        .PARAMETER ApplyToNewUsers
+            Copies the language settings to all new user profiles created after this
+            change. Requires elevated privileges.
+
+        .PARAMETER ComputerName
+            One or more computer names to target. Defaults to the local computer.
+            Accepts pipeline input by value and by property name. On a remote computer,
+            the user-scoped override applies to the executing account's profile (the
+            WinRM logon identity), not the interactive console user.
+
+        .PARAMETER Credential
+            Optional PSCredential for authenticating to remote computers.
+            Not used for local operations.
+
+        .EXAMPLE
+            Set-DisplayLanguage -Language en-US
+
+            Changes the display language to English (United States) for the current
+            user on the local computer, installing the language pack automatically.
+
+        .EXAMPLE
+            Set-DisplayLanguage -Language fr-FR -ComputerName 'SRV01' -ApplyToSystem -ApplyToNewUsers
+
+            Changes the display language to French on SRV01 for the current user, the
+            system account, and all future new user profiles. Requires an elevated session.
+
+        .EXAMPLE
+            'SRV01', 'SRV02' | Set-DisplayLanguage -Language en-US -NoInstall
+
+            Changes the display language on both servers via pipeline, without
+            installing the language pack if it is missing.
+
+        .OUTPUTS
+            PSWinOps.DisplayLanguageResult
+            Returns one object per computer describing the pack action taken and
+            whether the user/system/new-user settings were applied.
+
+        .NOTES
+            Author: Franck SALLET
+            Version: 1.0.0
+            Last Modified: 2026-09-10
+            Requires: PowerShell 5.1+ / Windows only
+            Requires: LanguagePackManagement module (built-in on Windows 11 22H2+ / Windows Server 2022+)
+            Requires: Administrator privileges for -ApplyToSystem / -ApplyToNewUsers
+
+        .LINK
+            https://github.com/k9fr4n/PSWinOps
+
+        .LINK
+            https://learn.microsoft.com/en-us/powershell/module/languagepackmanagement/
+    #>
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Medium')]
+    [OutputType('PSWinOps.DisplayLanguageResult')]
+    param(
+        [Parameter(Mandatory = $true, HelpMessage = 'BCP-47 language tag to apply, e.g. en-US or fr-FR')]
+        [ValidatePattern('^[a-z]{2}-[A-Z]{2}$')]
+        [string]$Language,
+
+        [Parameter(Mandatory = $false, HelpMessage = 'Skip automatic installation of a missing language pack')]
+        [switch]$NoInstall,
+
+        [Parameter(Mandatory = $false, HelpMessage = 'Copy settings to the system account (Welcome Screen)')]
+        [switch]$ApplyToSystem,
+
+        [Parameter(Mandatory = $false, HelpMessage = 'Copy settings to new user profiles')]
+        [switch]$ApplyToNewUsers,
+
+        [Parameter(Mandatory = $false, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [ValidateNotNullOrEmpty()]
+        [Alias('CN', 'Name', 'DNSHostName')]
+        [string[]]$ComputerName = @($env:COMPUTERNAME),
+
+        [Parameter(Mandatory = $false)]
+        [ValidateNotNull()]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential
+    )
+
+    begin {
+        Write-Verbose -Message "[$($MyInvocation.MyCommand)] Starting with Language='$Language', NoInstall=$($NoInstall.IsPresent), ApplyToSystem=$($ApplyToSystem.IsPresent), ApplyToNewUsers=$($ApplyToNewUsers.IsPresent)"
+
+        if ($ApplyToSystem -or $ApplyToNewUsers) {
+            if (-not (Test-IsAdministrator)) {
+                $adminException = [System.Security.SecurityException]::new(
+                    'Applying settings to the system account or new user profiles requires administrator privileges.'
+                )
+                $adminRecord = [System.Management.Automation.ErrorRecord]::new(
+                    $adminException,
+                    'InsufficientPrivilege',
+                    [System.Management.Automation.ErrorCategory]::PermissionDenied,
+                    $null
+                )
+                $PSCmdlet.ThrowTerminatingError($adminRecord)
+            }
+        }
+
+        $scriptBlock = {
+            param(
+                [string]$TargetLanguage,
+                [bool]$SkipInstall,
+                [bool]$ToSystem,
+                [bool]$ToNewUsers
+            )
+
+            $languagePackModule = Get-Module -ListAvailable -Name 'LanguagePackManagement'
+            if (-not $languagePackModule) {
+                throw "The 'LanguagePackManagement' module is not available on this computer. It ships built-in on Windows 11 22H2+ and Windows Server 2022+; on earlier OS versions (e.g. Windows Server 2019) install the language pack via 'lpksetup.exe' or Server Manager and use 'Set-WinUILanguageOverride' instead."
+            }
+
+            $installed = Get-InstalledLanguage -ErrorAction Stop | Where-Object -FilterScript { $_.LanguageId -eq $TargetLanguage }
+
+            if (-not $installed) {
+                if ($SkipInstall) {
+                    return [PSCustomObject]@{
+                        PackAction        = 'Skipped'
+                        UserLanguageSet   = $false
+                        AppliedToSystem   = $false
+                        AppliedToNewUsers = $false
+                        Status            = 'Skipped'
+                    }
+                }
+
+                Install-Language -Language $TargetLanguage -ErrorAction Stop
+                $packAction = 'Installed'
+            } else {
+                $packAction = 'AlreadyPresent'
+            }
+
+            Set-WinUILanguageOverride -Language $TargetLanguage -ErrorAction Stop
+
+            $appliedToSystem = $false
+            $appliedToNewUsers = $false
+            if ($ToSystem -or $ToNewUsers) {
+                Copy-UserInternationalSettingsToSystem -WelcomeScreen:$ToSystem -NewUser:$ToNewUsers -ErrorAction Stop
+                $appliedToSystem = $ToSystem
+                $appliedToNewUsers = $ToNewUsers
+            }
+
+            [PSCustomObject]@{
+                PackAction        = $packAction
+                UserLanguageSet   = $true
+                AppliedToSystem   = $appliedToSystem
+                AppliedToNewUsers = $appliedToNewUsers
+                Status            = 'Success'
+            }
+        }
+    }
+
+    process {
+        foreach ($targetComputer in $ComputerName) {
+            Write-Verbose -Message "[$($MyInvocation.MyCommand)] Processing '$targetComputer'"
+
+            $actionDescription = if ($ApplyToSystem -or $ApplyToNewUsers) {
+                "Set display language to '$Language' and propagate to System/NewUsers"
+            } else {
+                "Set display language to '$Language'"
+            }
+
+            try {
+                if ($PSCmdlet.ShouldProcess($targetComputer, $actionDescription)) {
+                    $innerResult = Invoke-RemoteOrLocal -ComputerName $targetComputer -ScriptBlock $scriptBlock -ArgumentList @($Language, $NoInstall.IsPresent, $ApplyToSystem.IsPresent, $ApplyToNewUsers.IsPresent) -Credential $Credential
+
+                    [PSCustomObject]@{
+                        PSTypeName        = 'PSWinOps.DisplayLanguageResult'
+                        ComputerName      = $targetComputer
+                        Language          = $Language
+                        PackAction        = $innerResult.PackAction
+                        UserLanguageSet   = $innerResult.UserLanguageSet
+                        AppliedToSystem   = $innerResult.AppliedToSystem
+                        AppliedToNewUsers = $innerResult.AppliedToNewUsers
+                        RestartRequired   = ($innerResult.Status -eq 'Success')
+                        Status            = $innerResult.Status
+                        ErrorMessage      = $null
+                        Timestamp         = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
+                    }
+
+                    if ($innerResult.Status -eq 'Success') {
+                        Write-Warning -Message "[$($MyInvocation.MyCommand)] A session restart on '$targetComputer' is required for changes to take effect."
+                    }
+                }
+            } catch {
+                [PSCustomObject]@{
+                    PSTypeName        = 'PSWinOps.DisplayLanguageResult'
+                    ComputerName      = $targetComputer
+                    Language          = $Language
+                    PackAction        = 'None'
+                    UserLanguageSet   = $false
+                    AppliedToSystem   = $false
+                    AppliedToNewUsers = $false
+                    RestartRequired   = $false
+                    Status            = 'Failed'
+                    ErrorMessage      = $_.Exception.Message
+                    Timestamp         = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
+                }
+                Write-Error -Message "[$($MyInvocation.MyCommand)] Failed to set display language on '${targetComputer}': $_"
+                continue
+            }
+        }
+    }
+
+    end {
+        Write-Verbose -Message "[$($MyInvocation.MyCommand)] Completed"
+    }
+}

--- a/Tests/Public/system/Set-DisplayLanguage.Tests.ps1
+++ b/Tests/Public/system/Set-DisplayLanguage.Tests.ps1
@@ -201,8 +201,11 @@ Describe 'Set-DisplayLanguage' {
         It -Name 'Should write an error for the failing machine and continue to the next one' -Test {
             $script:isolationResults = 'SRV01', 'SRV02' | Set-DisplayLanguage -Language 'en-US' -Confirm:$false -ErrorVariable errVar -ErrorAction SilentlyContinue
             $errVar | Should -Not -BeNullOrEmpty
-            @($script:isolationResults).Count | Should -Be 1
-            $script:isolationResults[0].ComputerName | Should -Be 'SRV02'
+            @($script:isolationResults).Count | Should -Be 2
+            $script:isolationResults[0].ComputerName | Should -Be 'SRV01'
+            $script:isolationResults[0].Status | Should -Be 'Failed'
+            $script:isolationResults[1].ComputerName | Should -Be 'SRV02'
+            $script:isolationResults[1].Status | Should -Be 'Success'
         }
     }
 }

--- a/Tests/Public/system/Set-DisplayLanguage.Tests.ps1
+++ b/Tests/Public/system/Set-DisplayLanguage.Tests.ps1
@@ -1,0 +1,208 @@
+#Requires -Version 5.1
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+BeforeAll {
+    $script:modulePath = Split-Path -Path (Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent) -Parent
+    Import-Module -Name (Join-Path -Path $script:modulePath -ChildPath 'PSWinOps.psd1') -Force
+}
+
+Describe 'Set-DisplayLanguage' {
+
+    Context 'Local happy path' {
+
+        BeforeAll {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -MockWith {
+                return [PSCustomObject]@{
+                    PackAction        = 'Installed'
+                    UserLanguageSet   = $true
+                    AppliedToSystem   = $false
+                    AppliedToNewUsers = $false
+                    Status            = 'Success'
+                }
+            }
+            $script:result = Set-DisplayLanguage -Language 'en-US' -Confirm:$false
+        }
+
+        It -Name 'Should return PSWinOps.DisplayLanguageResult type' -Test {
+            $script:result.PSObject.TypeNames | Should -Contain 'PSWinOps.DisplayLanguageResult'
+        }
+
+        It -Name 'Should set ComputerName to the local computer' -Test {
+            $script:result.ComputerName | Should -Be $env:COMPUTERNAME
+        }
+
+        It -Name 'Should return the requested Language and pack/user status' -Test {
+            $script:result.Language | Should -Be 'en-US'
+            $script:result.PackAction | Should -Be 'Installed'
+            $script:result.UserLanguageSet | Should -Be $true
+            $script:result.Status | Should -Be 'Success'
+        }
+
+        It -Name 'Should format Timestamp as yyyy-MM-dd HH:mm:ss' -Test {
+            $script:result.Timestamp | Should -Match "^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$"
+        }
+    }
+
+    Context 'Explicit remote machine with Credential' {
+
+        BeforeAll {
+            $script:cred = [System.Management.Automation.PSCredential]::new('user', (ConvertTo-SecureString -String 'p@ss' -AsPlainText -Force))
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -MockWith {
+                return [PSCustomObject]@{
+                    PackAction        = 'AlreadyPresent'
+                    UserLanguageSet   = $true
+                    AppliedToSystem   = $false
+                    AppliedToNewUsers = $false
+                    Status            = 'Success'
+                }
+            }
+            $script:remoteResult = Set-DisplayLanguage -Language 'fr-FR' -ComputerName 'SRV01' -Credential $script:cred -Confirm:$false
+        }
+
+        It -Name 'Should forward ComputerName and Credential to Invoke-RemoteOrLocal' -Test {
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -Times 1 -Scope Context -ParameterFilter {
+                $ComputerName -eq 'SRV01' -and $Credential -eq $script:cred
+            }
+        }
+
+        It -Name 'Should set ComputerName to SRV01 on the returned object' -Test {
+            $script:remoteResult.ComputerName | Should -Be 'SRV01'
+        }
+    }
+
+    Context 'Pipeline of multiple machine names' {
+
+        BeforeAll {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -MockWith {
+                return [PSCustomObject]@{
+                    PackAction        = 'AlreadyPresent'
+                    UserLanguageSet   = $true
+                    AppliedToSystem   = $false
+                    AppliedToNewUsers = $false
+                    Status            = 'Success'
+                }
+            }
+            $script:pipelineResults = 'SRV01', 'SRV02' | Set-DisplayLanguage -Language 'en-US' -Confirm:$false
+        }
+
+        It -Name 'Should return one object per machine' -Test {
+            @($script:pipelineResults).Count | Should -Be 2
+            $script:pipelineResults[0].ComputerName | Should -Be 'SRV01'
+            $script:pipelineResults[1].ComputerName | Should -Be 'SRV02'
+        }
+    }
+
+    Context 'NoInstall skips a missing language pack' {
+
+        BeforeAll {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -MockWith {
+                return [PSCustomObject]@{
+                    PackAction        = 'Skipped'
+                    UserLanguageSet   = $false
+                    AppliedToSystem   = $false
+                    AppliedToNewUsers = $false
+                    Status            = 'Skipped'
+                }
+            }
+            $script:skipResult = Set-DisplayLanguage -Language 'en-US' -NoInstall -Confirm:$false
+        }
+
+        It -Name 'Should return Skipped status without setting the user language' -Test {
+            $script:skipResult.PackAction | Should -Be 'Skipped'
+            $script:skipResult.UserLanguageSet | Should -Be $false
+            $script:skipResult.Status | Should -Be 'Skipped'
+        }
+    }
+
+    Context 'ApplyToSystem requires administrator privileges' {
+
+        BeforeAll {
+            Mock -CommandName 'Test-IsAdministrator' -ModuleName 'PSWinOps' -MockWith { $false }
+        }
+
+        It -Name 'Should throw a terminating error when not elevated' -Test {
+            { Set-DisplayLanguage -Language 'en-US' -ApplyToSystem -Confirm:$false } | Should -Throw
+        }
+    }
+
+    Context 'ApplyToSystem propagates settings when elevated' {
+
+        BeforeAll {
+            Mock -CommandName 'Test-IsAdministrator' -ModuleName 'PSWinOps' -MockWith { $true }
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -MockWith {
+                return [PSCustomObject]@{
+                    PackAction        = 'AlreadyPresent'
+                    UserLanguageSet   = $true
+                    AppliedToSystem   = $true
+                    AppliedToNewUsers = $false
+                    Status            = 'Success'
+                }
+            }
+            $script:systemResult = Set-DisplayLanguage -Language 'en-US' -ApplyToSystem -Confirm:$false
+        }
+
+        It -Name 'Should reflect AppliedToSystem on the returned object' -Test {
+            $script:systemResult.AppliedToSystem | Should -Be $true
+        }
+    }
+
+    Context 'WhatIf writes nothing' {
+
+        BeforeAll {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -MockWith {
+                return [PSCustomObject]@{
+                    PackAction        = 'Installed'
+                    UserLanguageSet   = $true
+                    AppliedToSystem   = $false
+                    AppliedToNewUsers = $false
+                    Status            = 'Success'
+                }
+            }
+            $script:whatIfResult = Set-DisplayLanguage -Language 'en-US' -WhatIf
+        }
+
+        It -Name 'Should not invoke Invoke-RemoteOrLocal' -Test {
+            Should -Invoke -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -Times 0 -Scope Context
+        }
+
+        It -Name 'Should not return any output object' -Test {
+            $script:whatIfResult | Should -BeNullOrEmpty
+        }
+    }
+
+    Context 'Parameter validation' {
+
+        It -Name 'Should reject a language tag that does not match the BCP-47 pattern' -Test {
+            { Set-DisplayLanguage -Language 'english' -Confirm:$false } | Should -Throw
+        }
+
+        It -Name 'Should reject a null or empty ComputerName' -Test {
+            { Set-DisplayLanguage -Language 'en-US' -ComputerName '' -Confirm:$false } | Should -Throw
+        }
+    }
+
+    Context 'Per-machine failure isolation' {
+
+        BeforeAll {
+            Mock -CommandName 'Invoke-RemoteOrLocal' -ModuleName 'PSWinOps' -MockWith {
+                if ($ComputerName -eq 'SRV01') {
+                    throw "The 'LanguagePackManagement' module is not available on this computer."
+                }
+                return [PSCustomObject]@{
+                    PackAction        = 'AlreadyPresent'
+                    UserLanguageSet   = $true
+                    AppliedToSystem   = $false
+                    AppliedToNewUsers = $false
+                    Status            = 'Success'
+                }
+            }
+        }
+
+        It -Name 'Should write an error for the failing machine and continue to the next one' -Test {
+            $script:isolationResults = 'SRV01', 'SRV02' | Set-DisplayLanguage -Language 'en-US' -Confirm:$false -ErrorVariable errVar -ErrorAction SilentlyContinue
+            $errVar | Should -Not -BeNullOrEmpty
+            @($script:isolationResults).Count | Should -Be 1
+            $script:isolationResults[0].ComputerName | Should -Be 'SRV02'
+        }
+    }
+}

--- a/en-US/about_PSWinOps.help.txt
+++ b/en-US/about_PSWinOps.help.txt
@@ -193,7 +193,7 @@ FUNCTION DOMAINS
 
       Get-AuditPolicy
 
-  system (20 functions)
+  system (21 functions)
     Functions for general system information, state,
     disk cleanup, profile management, and real-time monitoring.
 
@@ -213,6 +213,7 @@ FUNCTION DOMAINS
       Get-StartupProgram
       Get-SystemSummary
       Remove-UserProfile
+      Set-DisplayLanguage
       Set-EnvironmentVariable
       Set-PageFile
       Show-SystemMonitor
@@ -341,7 +342,7 @@ REMOTE EXECUTION PATTERN
     in the pipeline continue to be processed.
 
 PSWINOPS TYPE REGISTRY
-    The following 120 PSTypeName values are defined by the
+    The following 121 PSTypeName values are defined by the
     module. Each corresponds to the output of one or more
     public functions.
 
@@ -385,6 +386,7 @@ PSWINOPS TYPE REGISTRY
       PSWinOps.DiskCleanupResult
       PSWinOps.DiskErrorEvent
       PSWinOps.DiskSpace
+      PSWinOps.DisplayLanguageResult
       PSWinOps.DnsResolution
       PSWinOps.DnsServerHealth
       PSWinOps.DriverInventory


### PR DESCRIPTION
## Summary
Adds a new public function `Set-DisplayLanguage` to change the Windows UI display language for the current user (and optionally the system account / new user profiles) via `Set-WinUILanguageOverride`, installing the language pack automatically through `LanguagePackManagement` when missing.

## Changes
- `Public/system/Set-DisplayLanguage.ps1` — full comment-based help, `SupportsShouldProcess`, remote/local support pattern (Rule 12), per-machine error isolation
- New `PSWinOps.DisplayLanguageResult` PSTypeName + Table `<View>` in `PSWinOps.Format.ps1xml`
- `Tests/Public/system/Set-DisplayLanguage.Tests.ps1` — Pester v5, covers local happy path, remote + credential, pipeline, `NoInstall`, admin-required paths (`ApplyToSystem`), `WhatIf`, parameter validation, per-machine failure isolation
- `PSWinOps.psd1` — `FunctionsToExport` updated (alphabetical), `ModuleVersion` bumped to `1.2.1` with release notes
- `CLAUDE.md` type registry and `en-US/about_PSWinOps.help.txt` updated (system domain: 20 → 21 functions)

## Notes
- Requires `LanguagePackManagement` module (built-in on Windows 11 22H2+ / Windows Server 2022+); function fails with clear guidance on older OS versions
- `-ApplyToSystem` / `-ApplyToNewUsers` require administrator privileges
- Dev environment is Linux/ARM, so this could not be executed locally; relying on CI (Pester + PSScriptAnalyzer) for verification

## Test plan
- [ ] CI: PSScriptAnalyzer lint passes
- [ ] CI: Pester suite (`Tests/Public/system/Set-DisplayLanguage.Tests.ps1`) passes on Windows runner